### PR TITLE
fix: unblock CI lint and sync test annotation KDocs

### DIFF
--- a/core/ui/test-utils/src/main/kotlin/io/github/stslex/workeeper/core/ui/test/annotations/Regression.kt
+++ b/core/ui/test-utils/src/main/kotlin/io/github/stslex/workeeper/core/ui/test/annotations/Regression.kt
@@ -3,21 +3,18 @@ package io.github.stslex.workeeper.core.ui.test.annotations
 /**
  * Marks a UI test as a regression test.
  *
- * Regression tests are comprehensive integration tests that require
- * full application deployment with real DI container, databases, APIs, and other dependencies.
+ * Regression tests are full-integration tests that exercise a real Hilt graph and database.
+ * They typically use `@HiltAndroidTest` plus `createAndroidComposeRule<MainActivity>()` and
+ * drive end-to-end user flows.
  *
- * These tests run on:
- * - Pull requests targeting master branch
- * - Pushes to master branch
- * - Manual workflow dispatch with 'regression' option
+ * Test execution: the `ui_tests.yml` workflow is `workflow_dispatch`-only with a
+ * `test_suite` selector that picks `smoke`, `regression`, or `all`. UI tests do not
+ * gate PRs — see `documentation/ci-cd.md`.
  *
  * Examples:
  * - Full application navigation flows with real dependencies
- * - End-to-end user scenarios
+ * - Multi-feature user scenarios
  * - Integration tests with real database and DI
- * - Tests annotated with @HiltAndroidTest
- *
- * Typical execution time: 30-40 minutes for all regression tests
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)

--- a/core/ui/test-utils/src/main/kotlin/io/github/stslex/workeeper/core/ui/test/annotations/Smoke.kt
+++ b/core/ui/test-utils/src/main/kotlin/io/github/stslex/workeeper/core/ui/test/annotations/Smoke.kt
@@ -3,20 +3,18 @@ package io.github.stslex.workeeper.core.ui.test.annotations
 /**
  * Marks a UI test as a smoke test.
  *
- * Smoke tests are fast, critical tests that verify basic functionality
- * without requiring full application deployment with real DI, databases, or APIs.
+ * Smoke tests are fast, mocked-data tests that verify component-level behavior without
+ * requiring a real DI container, database, or full activity. They typically use
+ * `createComposeRule()` and pass mocked state directly into a widget.
  *
- * These tests run on:
- * - All pull requests
- * - All branches
- * - Manual workflow dispatch with 'smoke' option
+ * Test execution: the `ui_tests.yml` workflow is `workflow_dispatch`-only with a
+ * `test_suite` selector that picks `smoke`, `regression`, or `all`. UI tests do not
+ * gate PRs — see `documentation/ci-cd.md`.
  *
  * Examples:
  * - Basic UI element visibility checks
- * - Simple navigation flows
  * - Component interactions with mocked data
- *
- * Typical execution time: 5-10 minutes for all smoke tests
+ * - Edge-case input handling
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)

--- a/lint-rules/lint.xml
+++ b/lint-rules/lint.xml
@@ -117,6 +117,10 @@
         <!-- Ignore intentional Kotlin downgrade for Hilt compatibility (Hilt doesn't support Kotlin 2.3.0 yet) -->
         <ignore path="**/libs.versions.toml" />
     </issue>
+    <issue id="AndroidGradlePluginVersion" severity="error">
+        <!-- AGP is intentionally pinned for Hilt compatibility; see GradleDependency above -->
+        <ignore path="**/libs.versions.toml" />
+    </issue>
 
     <!-- Kotlin specific -->
     <issue id="KotlinPropertyAccess" severity="warning" />


### PR DESCRIPTION
ci: suppress AndroidGradlePluginVersion on libs.versions.toml The Android Lint detector now flags AGP 9.1.0 as out-of-date because 9.2.0 was just published. AGP is intentionally pinned for Hilt compatibility, matching the existing GradleDependency and NewerVersionAvailable suppressions on the same file. Add a parallel exemption with a comment pointing at the same rationale.

docs: realign Smoke / Regression KDocs with ui_tests.yml Both annotation files claimed PR-driven execution ("All pull requests" for @Smoke, "Pull requests targeting master branch" for @Regression). That was true before commit e7f38b9, which moved UI tests to a workflow_dispatch-only job. Update the KDoc to match the actual workflow and drop the per-suite execution-time figures, which decay.

Verified
- ./gradlew detekt — passes.
- ./gradlew lintDebug — passes (was failing on libs.versions.toml:5 before this change).
- ./gradlew testDebugUnitTest — passes.