### PR TITLE
chore: add Claude Code skills

### DIFF
--- a/.claude/skills/add-database-migration.md
+++ b/.claude/skills/add-database-migration.md
@@ -1,0 +1,121 @@
+---
+name: add-database-migration
+description: Add a Room schema migration safely — bump `AppDatabase` version, create a `MIGRATION_X_Y` object following the `Migration12.kt` pattern, register it in `CoreDatabaseModule`, and add a `MigrationTestHelper`-based test.
+---
+
+# Add a database migration
+
+## When to use
+
+- "Add a Room migration"
+- "Bump the database schema version"
+- "Add a column / table to the database"
+- "Migrate data when the entity changes"
+
+## Prerequisites
+
+- The current schema is at `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/`.
+- The Room library convention plugin is applied (it sets `schemaDirectory` and exports schemas
+  on every build) — see `build-logic/convention/src/main/kotlin/RoomLibraryConventionPlugin.kt`.
+- `documentation/architecture.md` is available for the data-layer overview.
+
+## Step-by-step
+
+1. Decide the new schema version `Y = X + 1`. The current `X` is the `version` value on the
+   `@Database` annotation in
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt`.
+
+2. Make the entity / DAO changes. Add fields, change types, add tables, etc., under
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/`.
+
+3. Bump `version = Y` on the `@Database` annotation in `AppDatabase.kt`. Leave
+   `exportSchema = true` — Room writes the new `Y.json` schema during the next build.
+
+4. Create the migration at
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X><Y>.kt`.
+   Use the project's pattern from
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration12.kt`:
+
+   ```kotlin
+   val MIGRATION_<X>_<Y> = object : Migration(<X>, <Y>) {
+       override fun migrate(db: SupportSQLiteDatabase) {
+           // SQL statements here.
+       }
+   }
+   ```
+
+   Patterns the codebase already uses:
+
+   - **Add a table**: `db.execSQL("CREATE TABLE IF NOT EXISTS ... (...)")`.
+   - **Drop / rename a column** (SQLite has no `ALTER TABLE DROP COLUMN`): copy data into a
+     new table with the desired schema, drop the old table, rename the new one. See
+     `Migration12.kt` for the full recipe (creates `exercises_table_new`, copies rows,
+     drops `exercises_table`, renames `exercises_table_new`).
+   - **Transform values** during the copy: read the old row via `db.query(...).use { cursor }`
+     and write the converted values via parameterized `INSERT ... VALUES (?, ?, ...)`.
+   - **Use existing converters** when the new column needs a serialized form, e.g.
+     `SetsTypeConverter.toString(setsList)` or `StringConverter.listToString(...)`.
+
+5. Register the migration in
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt`:
+
+   ```kotlin
+   .addMigrations(MIGRATION_1_2, MIGRATION_<X>_<Y>)
+   ```
+
+   Append, do not replace — every prior migration must remain callable.
+
+6. Build the module so Room exports the new schema:
+
+   ```bash
+   ./gradlew :core:database:assembleDebug
+   ```
+
+   Confirm `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/<Y>.json`
+   exists, and commit it.
+
+7. Add a migration test at
+   `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X>To<Y>Test.kt`.
+   Mirror `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration1To2Test.kt`:
+
+   - Use `androidx.room.testing.MigrationTestHelper` (the project's `RoomLibraryConventionPlugin`
+     adds the `androidx-room-testing` dependency to every Room module).
+   - Open the database at version `X`, populate fixture rows that exercise the migration's
+     edge cases.
+   - Run `helper.runMigrationsAndValidate(NAME, Y, true, MIGRATION_<X>_<Y>)`.
+   - Assert that fixture rows survive (or are transformed correctly) by querying via the
+     returned `SupportSQLiteDatabase`.
+   - Cover at least: typical row, empty/edge input, multiple rows.
+
+## Verification
+
+```bash
+# Compile with the new schema
+./gradlew :core:database:assembleDebug
+
+# Run the migration test
+./gradlew :core:database:testDebugUnitTest --tests "*.Migration<X>To<Y>Test"
+
+# Static analysis on the new file
+./gradlew :core:database:detekt :core:database:lintDebug --no-configuration-cache
+```
+
+If the schema diff vs. the previous version surprises you (e.g. missing index, unintended
+NOT NULL change), inspect the JSON files in `core/database/schemas/...AppDatabase/` before
+shipping.
+
+## Common pitfalls
+
+- **Never modify a migration that has shipped.** Once `MIGRATION_X_Y` exists in a released
+  build, treat it as immutable. Forward-fix in `MIGRATION_Y_(Y+1)`.
+- **Never use `fallbackToDestructiveMigration()` in release builds.** The current
+  `CoreDatabaseModule` does not, and it should stay that way — destructive fallback wipes user
+  data.
+- **Do not skip the schema JSON commit.** Reviewers and CI need the new
+  `<Y>.json` to verify the migration matches the entity definitions.
+- **Do not skip the migration test.** It is the only thing that exercises real upgrade
+  behavior; the schema export only catches DDL drift, not data semantics.
+- **Do not write raw SQL with string concatenation of user data.** Always use bound parameters
+  (`db.execSQL(sql, arrayOf<Any?>(...))`) — the `Migration12` pattern shows this.
+- **Do not delete prior `MIGRATION_X_Y` registrations.** All previous migrations stay in the
+  `addMigrations(...)` list so users can upgrade across multiple versions.

--- a/.claude/skills/add-feature.md
+++ b/.claude/skills/add-feature.md
@@ -1,0 +1,158 @@
+---
+name: add-feature
+description: Scaffold a new `feature/<name>` Gradle module with the project's MVI + Hilt + Compose conventions, including Store contract, handlers, DI, navigation entry, and a smoke UI test stub.
+---
+
+# Add a feature module
+
+## When to use
+
+- "Add a new feature module"
+- "Create a feature for X"
+- "Scaffold a new screen with MVI"
+- "I need a new Compose feature module"
+
+## Prerequisites
+
+- The feature has a name in kebab-case (e.g. `workout-history`).
+- The corresponding `Screen` route does not yet exist in `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`.
+- `documentation/architecture.md` is available — every step below assumes its conventions and file paths.
+
+## Step-by-step
+
+1. Decide whether the feature needs a domain layer. Features with non-trivial business logic or
+   their own interactor (see `feature/exercise/.../domain/`, `feature/single-training/.../domain/`)
+   create a `domain/` package. Features that only forward to repositories
+   (`feature/all-trainings`, `feature/charts`, `feature/all-exercises`) skip it.
+
+2. Create the module directory tree under `feature/<name>/`:
+
+   ```
+   feature/<name>/
+   ├── build.gradle.kts
+   └── src/
+       ├── main/kotlin/io/github/stslex/workeeper/feature/<name_snake>/
+       │   ├── di/                 # <Name>Module, <Name>HandlerStore[+Impl], <Name>Processor, <Name>EntryPoint (if needed)
+       │   ├── domain/             # only if the feature has its own business logic
+       │   ├── mvi/
+       │   │   ├── handler/        # ClickHandler, InputHandler, NavigationHandler, optionally PagingHandler / CommonHandler, plus <Name>Component
+       │   │   ├── model/          # UI models, mappers
+       │   │   └── store/          # <Name>Store contract + <Name>StoreImpl
+       │   └── ui/
+       │       ├── components/
+       │       └── <Name>Screen.kt # or <Name>Widget.kt
+       ├── test/kotlin/...         # JUnit 5 unit tests
+       └── androidTest/kotlin/...  # @Smoke UI tests
+   ```
+
+3. Generate `feature/<name>/build.gradle.kts`. Mirror `feature/charts/build.gradle.kts`:
+
+   ```kotlin
+   plugins {
+       alias(libs.plugins.convention.composeLibrary)
+   }
+
+   dependencies {
+       implementation(project(":core:core"))
+       implementation(project(":core:dataStore"))
+       implementation(project(":core:ui:kit"))
+       implementation(project(":core:ui:mvi"))
+       implementation(project(":core:ui:navigation"))
+       implementation(project(":core:exercise"))
+       testImplementation(kotlin("test"))
+
+       androidTestImplementation(libs.bundles.android.test)
+       androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+       androidTestImplementation(project(":core:ui:test-utils"))
+       debugImplementation(libs.androidx.compose.ui.test.manifest)
+   }
+   ```
+
+   Drop dependencies the feature does not use (e.g. omit `:core:exercise` if the feature does
+   not touch exercise/training/label repositories).
+
+4. Add the module to the root settings: `include(":feature:<name>")` in `settings.gradle.kts`.
+
+5. Add the route. Edit `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`
+   and add a `@Serializable` entry. Bottom-bar destinations go under `Screen.BottomBar`; detail
+   destinations are top-level data classes that carry route arguments.
+
+6. Generate the Store contract under `mvi/store/<Name>Store.kt`. Follow the contract conventions
+   in [documentation/architecture.md#mvi-contract](../../documentation/architecture.md#mvi-contract):
+
+   - `interface <Name>Store : Store<State, Action, Event>`
+   - `data class State(val ...) : Store.State` — properties are `val`; collections are
+     `kotlinx.collections.immutable.ImmutableList` / `ImmutableSet` (never `MutableList` etc.).
+     Add a `companion object { val INITIAL = State(...) }` for tests.
+   - `sealed interface Action : Store.Action` with nested `Click`, `Input`, `Navigation`,
+     optionally `Paging` / `Common`.
+   - `sealed interface Event : Store.Event` — names follow the patterns enforced by
+     `MviEventNamingRule` (e.g. `*Success`, `*Error`, `Haptic*`, `Snackbar*`, `Navigate*`,
+     `Scroll*`).
+
+7. Generate handlers under `mvi/handler/`. Use `feature/exercise/.../mvi/handler/ClickHandler.kt`
+   as the canonical reference. Each handler:
+
+   - is `@ViewModelScoped` and uses `@Inject` constructor injection (except `NavigationHandler`,
+     which constructs from the `<Name>Component`).
+   - implements `Handler<Action.<Category>>` from `core/ui/mvi/.../handler/Handler.kt`.
+   - receives the feature's `<Name>HandlerStore` to read state, mutate state, and emit events.
+
+8. Generate `mvi/handler/<Name>Component.kt` extending `Component<Screen.<...>>` from
+   `core/ui/navigation/.../Component.kt`, plus `<Name>ComponentImpl` that the navigation graph
+   constructs. See `feature/exercise/.../mvi/handler/ExerciseComponent.kt`.
+
+9. Generate `mvi/store/<Name>StoreImpl.kt` extending `BaseStore<State, Action, Event>`,
+   annotated `@HiltViewModel(assistedFactory = <Name>StoreImpl.Factory::class)`. The
+   `handlerCreator` lambda routes each `Action` subtype to the matching handler. See
+   `feature/exercise/.../ui/mvi/store/ExerciseStoreImpl.kt`.
+
+10. Generate the Hilt module at `di/<Name>Module.kt` with
+    `@InstallIn(ViewModelComponent::class)`. Bind the `<Name>HandlerStore` (and any interactor)
+    as `@ViewModelScoped`. See `feature/exercise/.../di/ExerciseModule.kt`.
+
+11. Generate `di/<Name>HandlerStoreImpl.kt` as a `@ViewModelScoped` `@Inject` class extending
+    `BaseHandlerStore<State, Action, Event>`. See
+    `feature/exercise/.../di/ExerciseHandlerStoreImpl.kt`.
+
+12. Generate `di/<Name>Processor.kt` implementing `Feature<TProcessor, TScreen, TComponent>`
+    from `core/ui/mvi/.../Feature.kt` and a `<feature>Graph(...)` extension on `NavGraphBuilder`.
+    See `feature/charts/.../di/ChartsStoreProcessor.kt`.
+
+13. Wire the navigation graph. Edit `app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt`
+    and call your new `<feature>Graph(modifier = ..., sharedTransitionScope = this@SharedTransitionLayout)`.
+
+14. If the feature is bottom-bar visible, add an entry in
+    `app/app/src/main/java/io/github/stslex/workeeper/bottom_app_bar/BottomBarItem.kt`.
+
+15. Generate the screen. `<Name>Screen.kt` (or `<Name>Widget.kt`) is a `@Composable` ending in
+    `Screen` and must take a `*State` parameter and an action/event handler parameter — this is
+    enforced by `ComposableStateRule`.
+
+16. Add a smoke UI test stub under
+    `feature/<name>/src/androidTest/kotlin/.../<Name>ScreenTest.kt` annotated `@Smoke`. Use
+    `BaseComposeTest` with `setTransitionContent { ... }`. See
+    [documentation/testing.md](../../documentation/testing.md) and the `write-ui-test` skill.
+
+## Verification
+
+```bash
+./gradlew :feature:<name>:detekt :feature:<name>:lintDebug --no-configuration-cache
+```
+
+Both must pass. The detekt run exercises the custom MVI rules; if any fire, fix them rather
+than baselining (see the `refactor-with-mvi-rules` skill).
+
+## Common pitfalls
+
+- **Do not skip `BaseStore`.** Stores must extend `BaseStore`; this is enforced by
+  `MviStoreExtensionRule`.
+- **Do not put state mutation in `@Composable` functions.** All mutation flows through
+  `BaseStore.consume(action)` → handler → `updateState`.
+- **Do not use `MutableList` / `MutableSet` / `MutableMap` in `State`.** Use the
+  `kotlinx.collections.immutable` types. `MviStateImmutabilityRule` will reject them.
+- **Do not use `var` in `State`.** Same rule — properties must be `val`.
+- **Do not forget the `convention.composeLibrary` plugin alias** in `build.gradle.kts`. Plain
+  `kotlin("jvm")` modules will not get Hilt, Compose, or the lint convention.
+- **Do not bypass `Screen` for navigation.** Every navigable destination must be a
+  `@Serializable` entry in `core/ui/navigation/.../Screen.kt`.

--- a/.claude/skills/refactor-with-mvi-rules.md
+++ b/.claude/skills/refactor-with-mvi-rules.md
@@ -1,0 +1,114 @@
+---
+name: refactor-with-mvi-rules
+description: Resolve a custom Detekt MVI-architecture rule violation by reading the rule source under `lint-rules/.../lint_rules/`, applying the conformant fix, and verifying with `./gradlew detekt`.
+---
+
+# Refactor to satisfy MVI Detekt rules
+
+## When to use
+
+- A `./gradlew detekt` run reports an `Mvi*` rule (`MviStateImmutabilityRule`,
+  `MviActionNamingRule`, `MviEventNamingRule`, `MviHandlerNamingRule`,
+  `MviStoreExtensionRule`, `MviHandlerConstructorRule`, `MviStoreStateRule`).
+- A `HiltScopeRule` or `ComposableStateRule` violation appears.
+- The user says "fix this MVI lint violation" / "this rule is firing on X".
+
+## Prerequisites
+
+- The detekt report (`<module>/build/reports/detekt/`) or the gradle output names the rule.
+- `documentation/lint-rules.md` is available for the catalog of rules with good/bad examples.
+
+## Step-by-step
+
+1. Identify the rule. Map the reported id to its source file under
+   `lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/`:
+
+   - `MviStateImmutabilityRule.kt`
+   - `MviActionNamingRule.kt`
+   - `MviEventNamingRule.kt`
+   - `MviHandlerNamingRule.kt`
+   - `MviStoreExtensionRule.kt`
+   - `MviHandlerConstructorRule.kt`
+   - `MviStoreStateRule.kt`
+   - `HiltScopeRule.kt` (uses `ScopeClassType.kt` for the name → annotation mapping)
+   - `ComposableStateRule.kt`
+
+   Read the rule source if the message is ambiguous — it is the ground truth for what
+   triggers the report. The rule set is registered in `MviArchitectureRules.kt`.
+
+2. Apply the canonical fix. Examples and rationale live in
+   [documentation/lint-rules.md#custom-detekt-mvi-rules](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
+
+   - **`MviStateImmutabilityRule`** — convert the class to `data class` (or `sealed`),
+     change every `var` to `val`, replace `MutableList<T>` / `MutableSet<T>` /
+     `MutableMap<K, V>` with the `kotlinx.collections.immutable` types
+     (`ImmutableList`, `ImmutableSet`, `ImmutableMap`).
+   - **`MviActionNamingRule`** — make the `*Action` class `sealed` (interface or class).
+     Group nested actions under categories: `Click`, `Input`, `Navigation`, optionally
+     `Paging`, `Common`.
+   - **`MviEventNamingRule`** — make the outer `*Event` `sealed`. Each nested event must
+     either end in one of `Success`, `Error`, `Completed`, `Started`, `Failed`, `Requested`,
+     **or** contain one of `Show`, `Navigate`, `Haptic`, `Snackbar`, `Scroll`. Rename to
+     match.
+   - **`MviHandlerNamingRule`** — `*Handler` must not be a `data class`. Member functions
+     starting with `Handle` must contain `Action` (e.g. `HandleClickAction`).
+   - **`MviStoreExtensionRule`** — `*StoreImpl` must extend `BaseStore`. `*Store`
+     interfaces (excluding `*HandlerStore`) must implement `Store`.
+   - **`MviHandlerConstructorRule`** — `*Handler` classes must have a primary constructor
+     annotated `@Inject` and at least one parameter. The only exception is
+     `NavigationHandler`, which is constructed from the feature's `*Component` rather than
+     via Hilt.
+   - **`MviStoreStateRule`** — the inner `State` class of a `*Store` must be
+     `data class State(...) : Store.State`.
+   - **`HiltScopeRule`** — apply scope by class-name pattern (the mapping is in
+     `lint-rules/.../lint_rules/ScopeClassType.kt`):
+     - Names containing `Repository` / `DataStore` / `Database` / `StoreDispatchers` →
+       `@Singleton`.
+     - Names containing `Handler` / `Store` / `Interactor` / `Mapper` →
+       `@ViewModelScoped`.
+     The rule also reports if a class carries the *other* category's annotation.
+   - **`ComposableStateRule`** — `@Composable` functions whose name ends in `Screen`
+     must take a `*State` parameter and an action/event handler parameter.
+
+3. Re-run detekt for the affected module:
+
+   ```bash
+   ./gradlew :feature:<name>:detekt
+   ```
+
+   Iterate until the rule clears.
+
+4. If the rule fired on legacy code that is genuinely out of scope for the current task,
+   prefer narrowing the change to the smallest unit that satisfies the rule rather than
+   adding a baseline entry. The codebase's policy (per
+   [documentation/lint-rules.md#baselines](../../documentation/lint-rules.md#baselines)) is to
+   use baselines only when introducing a brand-new rule against established legacy code.
+
+## Verification
+
+```bash
+./gradlew detekt
+```
+
+Run at the project root to verify the violation cleared and no new ones surfaced. For changes
+to `*Store.kt` / handlers / Composables, also re-run the relevant unit tests and Compose UI
+tests (see the `write-handler-test` and `write-ui-test` skills).
+
+## Common pitfalls
+
+- **Do not add the violation to `lint-rules/detekt-baseline.xml`.** Baselines are for legacy
+  code that predates the rule, not for new violations.
+- **Do not suppress with `@Suppress("MviStateImmutabilityRule")` etc. on production code.**
+  The `core/ui/mvi` module suppresses some rules at the type-parameter level
+  (`@Suppress("MviStoreStateRule", "MviStoreExtensionRule", "MviStateImmutabilityRule")` on
+  the `Store` interface itself) because that file *defines* the contract; new feature code
+  must conform, not opt out.
+- **Do not move offending code outside `mvi/` to dodge the rule.** Several rules gate on
+  whether the file's package contains `mvi` or its path contains `/mvi/`. Hiding the file
+  silences the rule but breaks the architecture and will surprise the next contributor.
+- **Do not mix scope annotations.** `HiltScopeRule` rejects `@Singleton` on a class whose name
+  matches the `@ViewModelScoped` set (and vice-versa). Pick the scope that matches the class
+  name; if neither fits, rename the class.
+- **Do not change rule sources to make a violation go away.** If a rule's intent is wrong for
+  the codebase, that is a separate, larger conversation — open an issue rather than editing
+  `lint-rules/.../lint_rules/*.kt` mid-feature work.

--- a/.claude/skills/write-handler-test.md
+++ b/.claude/skills/write-handler-test.md
@@ -1,0 +1,112 @@
+---
+name: write-handler-test
+description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the project's mocked `HandlerStore` + `TestScope` pattern from `feature/single-training`.
+---
+
+# Write a handler / store unit test
+
+## When to use
+
+- "Add a unit test for `<...>Handler`"
+- "Test the click handler for feature X"
+- "Cover `<...>StoreImpl` with unit tests"
+- "Write tests for an MVI action"
+
+## Prerequisites
+
+- The handler or store under test exists.
+- The feature's module already pulls in `kotlin("test")` and the project's `test` bundle (most
+  feature `build.gradle.kts` files do — see `feature/charts/build.gradle.kts`).
+- `documentation/testing.md` is available for the broader strategy.
+
+## Step-by-step
+
+1. Locate a reference test in the same feature when one exists. Otherwise use:
+
+   - `feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/ui/mvi/handler/ClickHandlerTest.kt`
+   - `feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandlerTest.kt`
+   - `feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/mvi/handler/PagingHandlerTest.kt`
+
+   These set the project conventions.
+
+2. Place the new test under
+   `feature/<name>/src/test/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<sub-package>/<HandlerName>Test.kt`,
+   mirroring the production package. Use `internal class` visibility.
+
+3. Use these imports:
+
+   ```kotlin
+   import org.junit.jupiter.api.Test
+   import org.junit.jupiter.api.Assertions.assertEquals
+   import io.mockk.coEvery
+   import io.mockk.coVerify
+   import io.mockk.every
+   import io.mockk.mockk
+   import io.mockk.verify
+   import kotlinx.coroutines.flow.MutableStateFlow
+   import kotlinx.coroutines.test.TestCoroutineScheduler
+   import kotlinx.coroutines.test.TestScope
+   import kotlinx.coroutines.test.UnconfinedTestDispatcher
+   import kotlinx.coroutines.test.runTest
+   import io.github.stslex.workeeper.core.core.coroutine.scope.AppCoroutineScope
+   ```
+
+   Always use `org.junit.jupiter.api.Test` (JUnit 5), never `org.junit.Test`.
+
+4. Build the test fixture:
+
+   - Construct any collaborators (interactor, mapper, repository) with
+     `mockk<X>(relaxed = true)`.
+   - Build a `TestCoroutineScheduler`, an `UnconfinedTestDispatcher(scheduler)`, and a
+     `TestScope(dispatcher)`.
+   - Build the initial `<Store>.State` and put it inside a `MutableStateFlow`.
+   - Construct a `mockk<<Name>HandlerStore>(relaxed = true)` and stub:
+     - `every { state } returns stateFlow`
+     - `every { scope } returns AppCoroutineScope(testScope, dispatcher, dispatcher)`
+     - For handlers that call `store.launch { ... }`, stub the `launch` overload to actually
+       execute the coroutine. Copy the `every { this@mockk.launch<Any>(...) } answers { ... }`
+       block from `feature/single-training/.../ClickHandlerTest.kt` lines 67-80.
+
+5. Construct the handler under test with the mocked store and collaborators.
+
+6. Write **one `@Test` method per `Action` subclass** the handler dispatches. The naming
+   convention used in the codebase: `<actionInWords>_<expectation>()`, for example
+   `clickSave_callsInteractor()` or `clickClose_emitsHapticAndPopsBack()`.
+
+7. Inside each test:
+
+   - Call the handler: `handler.invoke(Action.Click.Save)` (or use `@Test fun foo() = runTest { ... }` if you need to await suspending behavior).
+   - Assert state mutations with `assertEquals(expected, stateFlow.value)`.
+   - Assert events with `verify { store.sendEvent(eq(Event.Haptic)) }`.
+   - Assert collaborator calls with `coVerify { interactor.save(any()) }` (use `coVerify` for
+     suspend functions; `verify` for plain ones).
+   - Capture argument shapes with `slot<T>()` when the assertion needs the actual payload.
+
+8. Use `kotlinx.collections.immutable.persistentListOf()` / `persistentSetOf()` for collection
+   literals in the fixture — `State` requires immutable collections.
+
+## Verification
+
+```bash
+./gradlew :feature:<name>:testDebugUnitTest
+```
+
+Run the full module test task. Targeting a single class also works:
+
+```bash
+./gradlew :feature:<name>:testDebugUnitTest --tests "*.<HandlerName>Test"
+```
+
+## Common pitfalls
+
+- **One action per test.** Do not pack multiple `handler.invoke(...)` calls with different
+  `Action` subtypes into one `@Test`. The reference tests have one assertion thread per case;
+  match that.
+- **Do not mock the `Store` itself.** Mock the `<Name>HandlerStore` (the handler's collaborator).
+  The store is the system under test for `*StoreImpl` tests, never a mock there.
+- **Do not import `org.junit.Test`.** This codebase is on JUnit 5. The Robolectric extension
+  plugin (`robolectric-junit5`) is wired for JVM tests that need Android stubs.
+- **Do not use real dispatchers.** Use `UnconfinedTestDispatcher` and `TestScope`. Real
+  dispatchers will cause flaky waits.
+- **Do not assert on private fields.** Drive tests through public `Action` invocations and
+  observe the public `state`/`event` surface.

--- a/.claude/skills/write-ui-test.md
+++ b/.claude/skills/write-ui-test.md
@@ -1,0 +1,144 @@
+---
+name: write-ui-test
+description: Write a `@Smoke` Compose UI test that drives a feature widget with mocked state, asserts on `testTag`s, and verifies dispatched MVI actions through `ActionCapture`.
+---
+
+# Write a UI test
+
+## When to use
+
+- "Add a UI test for `<Feature>Screen`"
+- "Cover the `<Feature>` widget with Compose tests"
+- "Write a smoke test for X"
+- "Add an accessibility / edge-case test for screen Y"
+
+## Prerequisites
+
+- The feature module's `build.gradle.kts` already has the test dependencies (mirror
+  `feature/charts/build.gradle.kts`):
+
+  ```kotlin
+  androidTestImplementation(libs.bundles.android.test)
+  androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+  androidTestImplementation(project(":core:ui:test-utils"))
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
+  ```
+
+- The screen / widget under test exposes its interactive elements via `Modifier.testTag(...)`.
+- `documentation/testing.md` is available for the broader strategy.
+
+## Step-by-step
+
+1. Default to `@Smoke`. Reach for `@Regression` only when the test must drive the real Hilt
+   graph and database via `@HiltAndroidTest` + `createAndroidComposeRule<MainActivity>()`.
+   See [documentation/testing.md](../../documentation/testing.md) for the choice criteria.
+
+2. Use these reference tests to copy the structure:
+
+   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt`
+   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenEdgeCasesTest.kt`
+   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenAccessibilityTest.kt`
+
+3. Place the new test under
+   `feature/<name>/src/androidTest/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<NameOfTest>.kt`.
+   Mirror the production package.
+
+4. Skeleton:
+
+   ```kotlin
+   @Smoke
+   @RunWith(AndroidJUnit4::class)
+   @SuppressLint("UnusedContentLambdaTargetStateParameter")
+   internal class <Feature>ScreenTest : BaseComposeTest() {
+
+       @get:Rule
+       val composeRule = createComposeRule()
+
+       @Test
+       fun <feature>_<scenario>_<expectation>() {
+           val state = <Feature>Store.State.INITIAL.copy(/* ... */)
+           val actionCapture = createActionCapture<<Feature>Store.Action>()
+
+           composeRule.mainClock.autoAdvance = false
+           composeRule.setTransitionContent { animatedContentScope, modifier ->
+               <Feature>Widget(
+                   state = state,
+                   modifier = modifier,
+                   consume = actionCapture,
+                   sharedTransitionScope = this,
+                   animatedContentScope = animatedContentScope,
+               )
+           }
+
+           composeRule.mainClock.advanceTimeBy(100)
+           composeRule.waitForIdle()
+
+           composeRule.onNodeWithTag("<Feature>Button").performClick()
+
+           actionCapture.capturedFirst<<Feature>Store.Action.Click.<...>>()
+       }
+   }
+   ```
+
+   Key methods come from `core/ui/test-utils/.../BaseComposeTest.kt`:
+
+   - `setTransitionContent { animatedContentScope, modifier -> ... }` wraps the widget in
+     `SharedTransitionScope` + `AnimatedContent`, so widgets expecting
+     `sharedTransitionScope` and `animatedContentScope` parameters work without standing up
+     `AppNavigationHost`.
+   - `createActionCapture<Action>()` returns an `ActionCapture<Action>` you can pass directly as
+     the `consume` callback. Inspection helpers: `assertCaptured<A>()`, `capturedFirst<A>()`,
+     `capturedLast<A>()`, `assertCapturedExactly(action)`, `assertCapturedCount<A>(n)`,
+     `assertCapturedOnce<A>()`, `clear()`, `getAll()`.
+
+5. Use the test-utils helpers for data and inputs:
+
+   - **Paging** state: `PagingTestUtils.createPagingFlow(items)` or
+     `PagingTestUtils.createEmptyPagingFlow()`. For error scenarios use
+     `PagingTestUtils.TestPagingSource(items, shouldFail = true, errorMessage = "...")`.
+   - **Mock data**: `MockDataFactory.createUuids(count)`,
+     `MockDataFactory.createTestNames(prefix, count)`,
+     `MockDataFactory.createDateProperty(timestamp)`.
+   - **Text input**: `composeRule.onNodeWithTag("...").performTextReplacement("new value")`
+     (clears + types in one call).
+
+6. Test-tag conventions (must match what the production widget sets):
+
+   - Screen-level: `"<Feature>Screen"`.
+   - Widget root: `"<Feature>Widget"`.
+   - Buttons: `"<Feature>Button"`, `"<Feature>SaveButton"`, `"<Feature>ActionButton"`.
+   - List: `"<Feature>List"`. List item: `"<Feature>Item_${item.uuid}"`.
+   - Dialog: `"<Feature>Dialog"`.
+
+   If the production widget is missing a needed tag, add it via `Modifier.testTag(...)` —
+   do not work around with positional finders.
+
+7. Cover the obvious cases first (basic render, primary click, primary input). Extend with edge
+   cases (empty state, very long text, special characters, large lists, rapid clicks) and
+   accessibility checks (`assertHasClickAction()`, focus / semantics) in separate test classes
+   when there are enough of them, mirroring the all-exercises split into
+   `<...>ScreenTest`, `<...>ScreenEdgeCasesTest`, `<...>ScreenAccessibilityTest`.
+
+## Verification
+
+```bash
+# Run smoke tests for the module on a connected device or emulator
+./gradlew :feature:<name>:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.annotation=io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+```
+
+Reports land at `feature/<name>/build/reports/androidTests/connected/index.html`.
+
+## Common pitfalls
+
+- **Never combine `@Smoke` with `@HiltAndroidTest`.** Smoke tests do not stand up a real DI
+  graph. Use `createComposeRule()`, not `createAndroidComposeRule<MainActivity>()`.
+- **Do not use real repositories or the database.** All collaborators are mocked or fed via
+  `State`. Real DI belongs in `@Regression` tests only.
+- **Do not skip `composeRule.mainClock.advanceTimeBy(100)` + `waitForIdle()`** after
+  `setTransitionContent`. The shared-transition wrapper schedules animations, and the assertion
+  may run before composition settles.
+- **Do not assert on positional `onChildAt(...)` finders.** Use `testTag` / `onNodeWithText`
+  finders so the test does not break when layout changes.
+- **Do not use `org.junit.jupiter.api.Test`** in instrumented tests. UI tests use AndroidX's
+  JUnit 4 runner: `org.junit.Test`, `@RunWith(AndroidJUnit4::class)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,21 @@ Project context for OpenAI Codex / Cursor agents (and any other tool that follow
 - [documentation/lint-rules.md](documentation/lint-rules.md) — Detekt MVI rules + Android Lint.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow, commit format.
 
+## Workflow recipes (`.claude/skills/`)
+
+These are Claude Code-shaped skill files. Other agents can read them as procedural recipes for
+the same tasks:
+
+- [`add-feature`](.claude/skills/add-feature.md) — scaffold a new `feature/<name>` module.
+- [`write-handler-test`](.claude/skills/write-handler-test.md) — JUnit 5 unit test for an MVI
+  handler or `*StoreImpl`.
+- [`write-ui-test`](.claude/skills/write-ui-test.md) — `@Smoke` Compose UI test with
+  `BaseComposeTest`.
+- [`add-database-migration`](.claude/skills/add-database-migration.md) — Room schema migration
+  + test.
+- [`refactor-with-mvi-rules`](.claude/skills/refactor-with-mvi-rules.md) — resolve a custom
+  Detekt rule violation.
+
 ## Current focus
 
 - `master` is the release branch; ongoing work targets `dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,24 @@ content in this file.
 - [documentation/lint-rules.md](documentation/lint-rules.md) — Detekt MVI rules + Android Lint.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow, commit format.
 
+## Available skills
+
+Project-specific skills live under [`.claude/skills/`](.claude/skills/). Invoke the matching
+skill when the user asks for one of these tasks:
+
+- [`add-feature`](.claude/skills/add-feature.md) — scaffold a new `feature/<name>` module
+  (build script, MVI contract, handlers, Hilt module, navigation entry, smoke test stub).
+- [`write-handler-test`](.claude/skills/write-handler-test.md) — write a JUnit 5 unit test for
+  an MVI handler or `*StoreImpl` using the project's mocked `HandlerStore` + `TestScope`
+  pattern.
+- [`write-ui-test`](.claude/skills/write-ui-test.md) — write a `@Smoke` Compose UI test using
+  `BaseComposeTest`, `ActionCapture`, `MockDataFactory`, and `PagingTestUtils`.
+- [`add-database-migration`](.claude/skills/add-database-migration.md) — bump the Room schema
+  version, add a `MIGRATION_X_Y` object, register it in `CoreDatabaseModule`, and add a
+  `MigrationTestHelper`-based test.
+- [`refactor-with-mvi-rules`](.claude/skills/refactor-with-mvi-rules.md) — resolve a custom
+  Detekt MVI / Hilt scope / Composable rule violation by applying the conformant fix.
+
 ## Current focus
 
 - `master` is the release branch; ongoing work targets `dev`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -33,6 +33,20 @@ content here.
 - [documentation/lint-rules.md](documentation/lint-rules.md) — Detekt MVI rules + Android Lint.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow, commit format.
 
+## Workflow recipes (`.claude/skills/`)
+
+These are Claude Code-shaped skill files. Read them as procedural recipes for common tasks:
+
+- [`add-feature`](.claude/skills/add-feature.md) — scaffold a new `feature/<name>` module.
+- [`write-handler-test`](.claude/skills/write-handler-test.md) — JUnit 5 unit test for an MVI
+  handler or `*StoreImpl`.
+- [`write-ui-test`](.claude/skills/write-ui-test.md) — `@Smoke` Compose UI test with
+  `BaseComposeTest`.
+- [`add-database-migration`](.claude/skills/add-database-migration.md) — Room schema migration
+  + test.
+- [`refactor-with-mvi-rules`](.claude/skills/refactor-with-mvi-rules.md) — resolve a custom
+  Detekt rule violation.
+
 ## Current focus
 
 - `master` is the release branch; ongoing work targets `dev`.


### PR DESCRIPTION
Add five workflow skill files under `.claude/skills/`. Each is a Claude Code-shaped Markdown file with frontmatter (name + description) plus `When to use`, `Prerequisites`, `Step-by-step`, `Verification`, and `Common pitfalls` sections. They reference `documentation/*.md` rather than duplicating its content.

Skills
- add-feature.md — scaffold a new `feature/<name>` Gradle module with the project's MVI + Hilt + Compose conventions, including Store contract, handlers, DI, navigation entry, and a smoke UI test stub. Cites `feature/charts/build.gradle.kts`, `feature/exercise/.../di/*`, `feature/exercise/.../ui/mvi/store/ExerciseStoreImpl.kt`.
- write-handler-test.md — JUnit 5 unit test for an MVI handler or `*StoreImpl` using the project's mocked `HandlerStore` + `TestScope` pattern. Cites `feature/single-training/.../ClickHandlerTest.kt`.
- write-ui-test.md — `@Smoke` Compose UI test using `BaseComposeTest`, `ActionCapture`, `MockDataFactory`, and `PagingTestUtils`. Cites `feature/all-exercises/.../AllExercisesScreenTest.kt`.
- add-database-migration.md — bump the Room schema version, add a `MIGRATION_X_Y` object, register it in `CoreDatabaseModule`, and add a `MigrationTestHelper`-based test. Cites `Migration12.kt` and `Migration1To2Test.kt`.
- refactor-with-mvi-rules.md — resolve a custom Detekt MVI / Hilt scope / Composable rule violation. Cites every rule file under `lint-rules/src/main/kotlin/.../lint_rules/`.

Pointer files
- CLAUDE.md gets an "Available skills" section that lets Claude Code invoke each skill by name.
- AGENTS.md and GEMINI.md get a "Workflow recipes" section so Codex / Cursor / Gemini agents can read the same files as procedural guides for the same tasks.

Verified
- `./gradlew detekt` — passes (Markdown only, no Kotlin changed).
- All `.claude/skills/*` links from CLAUDE.md / AGENTS.md / GEMINI.md resolve.
- All `../../documentation/*` cross-links from skills resolve.
- Each skill is under 200 lines (158 / 121 / 144 / 112 / 114).