### PR TITLE
feat(settings): implement Settings + Archive (Stage 5.1)

### DIFF
--- a/.claude/skills/add-database-migration.md
+++ b/.claude/skills/add-database-migration.md
@@ -1,6 +1,6 @@
 ---
 name: add-database-migration
-description: Add a Room schema migration safely — bump `AppDatabase` version, create a `MIGRATION_X_Y` object following the `Migration12.kt` pattern, register it in `CoreDatabaseModule`, and add a `MigrationTestHelper`-based test.
+description: Bump the Room schema version on `AppDatabase`, register it in `CoreDatabaseModule` via `fallbackToDestructiveMigrationFrom(...)`, and refresh DAO tests. Until v1 ships to the Play Store with real users, schema changes use destructive migration — no `Migration` class, no preserved data.
 ---
 
 # Add a database migration
@@ -12,58 +12,74 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
 - "Add a column / table to the database"
 - "Migrate data when the entity changes"
 
+## Current policy: destructive migration
+
+For the v1 development cycle the project has **no production users**, so the data layer
+treats every schema bump as a fresh install. The current pattern is documented in
+[documentation/db-redesign.md](../../documentation/db-redesign.md#migration-strategy):
+
+- `@Database(version = ...)` is bumped on
+  `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt`.
+- `CoreDatabaseModule` (`core/database/.../di/CoreDatabaseModule.kt`) wires
+  `.fallbackToDestructiveMigrationFrom(dropAllTables = true, <oldVersions...>)` on the
+  `Room.databaseBuilder`. Each prior version that ever shipped to a developer device is
+  added to the destructive list; current call site at the time of writing is
+  `fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3)` (line 36).
+- There is **no `migrations/` directory** under
+  `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/` — no
+  `Migration<X><Y>` classes are written, no `addMigrations(...)` chain. The earlier
+  `Migration12.kt` and its enclosing folder were deleted when the destructive policy
+  landed; recreate the folder only when the [non-destructive playbook](#when-to-switch-back-to-non-destructive-migrations)
+  becomes active.
+- `core/database/converters/` keeps only `UuidConverter.kt`. The earlier `StringConverter`
+  and `SetsTypeConverter` were dropped along with the legacy entity blobs they served.
+
+This stays the rule **until the first Play Store release with real users**. After that, every
+new version requires a real `Migration` class and an instrumented migration test. The
+"non-destructive playbook" section at the bottom captures what that looks like.
+
 ## Prerequisites
 
-- The current schema is at `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/`.
-- The Room library convention plugin is applied (it sets `schemaDirectory` and exports schemas
-  on every build) — see `build-logic/convention/src/main/kotlin/RoomLibraryConventionPlugin.kt`.
-- `documentation/architecture.md` is available for the data-layer overview.
+- The current schema lives at
+  `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/`. Released
+  versions to date: `1.json`, `2.json`, `3.json`, `4.json`. The on-disk JSON for the new
+  version is exported automatically the next time the module assembles.
+- The Room library convention plugin is applied (`build-logic/convention/src/main/kotlin/RoomLibraryConventionPlugin.kt`)
+  — it sets `schemaDirectory("$projectDir/schemas")`, exports schemas on every build, and
+  pulls in `androidx-room-testing` so DAO + migration tests have `MigrationTestHelper` available
+  if/when a real migration is needed later.
+- [documentation/architecture.md](../../documentation/architecture.md#data-layer) and
+  [documentation/db-redesign.md](../../documentation/db-redesign.md) describe the entity
+  catalog (9 entities as of v4) and the cascade rules.
 
-## Step-by-step
+## Step-by-step (destructive bump — current default)
 
-1. Decide the new schema version `Y = X + 1`. The current `X` is the `version` value on the
-   `@Database` annotation in
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt`.
+1. Decide the new schema version `Y = X + 1`. The current `X` is the `version = ...` value on
+   the `@Database` annotation in `AppDatabase.kt` (4 at the time of writing).
 
 2. Make the entity / DAO changes. Add fields, change types, add tables, etc., under
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/`.
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/`. New entities
+   ship in version `Y` only — there is no migration logic to write.
 
 3. Bump `version = Y` on the `@Database` annotation in `AppDatabase.kt`. Leave
    `exportSchema = true` — Room writes the new `Y.json` schema during the next build.
 
-4. Create the migration at
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X><Y>.kt`.
-   Use the project's pattern from
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration12.kt`:
+4. If you added new entities, register their DAOs as `abstract val ...` on `AppDatabase`
+   and add matching `@Provides @Singleton fun provide<Name>Dao(db: AppDatabase): <Name>Dao`
+   bindings in
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt`.
+
+5. Extend the destructive list in the `Room.databaseBuilder` chain in `CoreDatabaseModule`:
 
    ```kotlin
-   val MIGRATION_<X>_<Y> = object : Migration(<X>, <Y>) {
-       override fun migrate(db: SupportSQLiteDatabase) {
-           // SQL statements here.
-       }
-   }
+   Room.databaseBuilder(context, AppDatabase::class.java, AppDatabase.Companion.NAME)
+       .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3, X)
+       .build()
    ```
 
-   Patterns the codebase already uses:
-
-   - **Add a table**: `db.execSQL("CREATE TABLE IF NOT EXISTS ... (...)")`.
-   - **Drop / rename a column** (SQLite has no `ALTER TABLE DROP COLUMN`): copy data into a
-     new table with the desired schema, drop the old table, rename the new one. See
-     `Migration12.kt` for the full recipe (creates `exercises_table_new`, copies rows,
-     drops `exercises_table`, renames `exercises_table_new`).
-   - **Transform values** during the copy: read the old row via `db.query(...).use { cursor }`
-     and write the converted values via parameterized `INSERT ... VALUES (?, ?, ...)`.
-   - **Use existing converters** when the new column needs a serialized form, e.g.
-     `SetsTypeConverter.toString(setsList)` or `StringConverter.listToString(...)`.
-
-5. Register the migration in
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt`:
-
-   ```kotlin
-   .addMigrations(MIGRATION_1_2, MIGRATION_<X>_<Y>)
-   ```
-
-   Append, do not replace — every prior migration must remain callable.
+   Append the prior version number (the `X` you just bumped from). Keep the existing
+   entries; each lets a developer device with that older `app.db` reset cleanly on first
+   launch instead of crashing at Room startup.
 
 6. Build the module so Room exports the new schema:
 
@@ -74,18 +90,18 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
    Confirm `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/<Y>.json`
    exists, and commit it.
 
-7. Add a migration test at
-   `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X>To<Y>Test.kt`.
-   Mirror `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration1To2Test.kt`:
+7. Refresh DAO unit tests. Per
+   [db-redesign.md → Tests](../../documentation/db-redesign.md#tests) destructive bumps drop
+   or rewrite the existing per-DAO tests rather than adding `MigrationTestHelper`-based ones.
+   Cover CRUD plus the indexed query paths for any new / changed DAO. There is intentionally
+   **no migration test** for a destructive bump — there is nothing to validate.
 
-   - Use `androidx.room.testing.MigrationTestHelper` (the project's `RoomLibraryConventionPlugin`
-     adds the `androidx-room-testing` dependency to every Room module).
-   - Open the database at version `X`, populate fixture rows that exercise the migration's
-     edge cases.
-   - Run `helper.runMigrationsAndValidate(NAME, Y, true, MIGRATION_<X>_<Y>)`.
-   - Assert that fixture rows survive (or are transformed correctly) by querying via the
-     returned `SupportSQLiteDatabase`.
-   - Cover at least: typical row, empty/edge input, multiple rows.
+8. Sweep for downstream breakage. Renamed entity columns, dropped converters, or new FK
+   cascades will surface in `core/exercise` repository code and feature stores. Compile the
+   whole project (`./gradlew assembleDebug`) and fix call sites; do not paper over with
+   shims unless the relevant feature is mid-rewrite (see the constraint note in the
+   Stage 5.1 prompt at
+   [documentation/feature-specs/settings-archive.md](../../documentation/feature-specs/settings-archive.md)).
 
 ## Verification
 
@@ -93,29 +109,82 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
 # Compile with the new schema
 ./gradlew :core:database:assembleDebug
 
-# Run the migration test
-./gradlew :core:database:testDebugUnitTest --tests "*.Migration<X>To<Y>Test"
+# DAO unit tests
+./gradlew :core:database:testDebugUnitTest
 
-# Static analysis on the new file
+# Whole-project compile (catches feature-side breakage)
+./gradlew assembleDebug
+
+# Static analysis on the touched files
 ./gradlew :core:database:detekt :core:database:lintDebug --no-configuration-cache
 ```
 
-If the schema diff vs. the previous version surprises you (e.g. missing index, unintended
-NOT NULL change), inspect the JSON files in `core/database/schemas/...AppDatabase/` before
-shipping.
+Inspect the schema diff between `<X>.json` and `<Y>.json` before shipping — unexpected
+index, NOT NULL, or default-value differences are easier to catch by reading the JSON than
+by re-deriving them from the entity classes.
 
 ## Common pitfalls
 
-- **Never modify a migration that has shipped.** Once `MIGRATION_X_Y` exists in a released
-  build, treat it as immutable. Forward-fix in `MIGRATION_Y_(Y+1)`.
-- **Never use `fallbackToDestructiveMigration()` in release builds.** The current
-  `CoreDatabaseModule` does not, and it should stay that way — destructive fallback wipes user
-  data.
-- **Do not skip the schema JSON commit.** Reviewers and CI need the new
-  `<Y>.json` to verify the migration matches the entity definitions.
-- **Do not skip the migration test.** It is the only thing that exercises real upgrade
-  behavior; the schema export only catches DDL drift, not data semantics.
-- **Do not write raw SQL with string concatenation of user data.** Always use bound parameters
-  (`db.execSQL(sql, arrayOf<Any?>(...))`) — the `Migration12` pattern shows this.
-- **Do not delete prior `MIGRATION_X_Y` registrations.** All previous migrations stay in the
-  `addMigrations(...)` list so users can upgrade across multiple versions.
+- **Do not write a `Migration<X><Y>` class while destructive policy is in force.** The
+  `migrations/` package does not exist on disk. Adding one would be dead code and would
+  mislead the next contributor about whether real migration logic ran on upgrade.
+- **Do not drop the `dropAllTables = true` flag.** Without it, Room's destructive fallback
+  leaves orphaned tables that older entity definitions referenced — the next app launch can
+  fail in confusing ways.
+- **Do not drop prior versions from the destructive list.** Each entry covers a developer
+  device that may still hold that older `app.db`. Removing entries means those devices
+  crash at Room startup instead of resetting cleanly.
+- **Do not skip the schema JSON commit.** Reviewers and CI need the new `<Y>.json` to verify
+  the entity definitions exported what you expect.
+- **Do not modify a schema JSON by hand.** It is generated. If the diff looks wrong, fix
+  the entity / index / converter and re-export.
+
+## When to switch back to non-destructive migrations
+
+Once the app has shipped to the Play Store and any user has installed it, every new schema
+bump must preserve their data. The transition looks like:
+
+1. Stop adding to `fallbackToDestructiveMigrationFrom(...)`. Leave the existing list in
+   place so legacy developer devices still reset cleanly, but the new version is added via
+   `addMigrations(MIGRATION_X_Y)` instead.
+
+2. Recreate the `migrations/` package and add `MIGRATION_<X>_<Y>` at
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X><Y>.kt`:
+
+   ```kotlin
+   val MIGRATION_X_Y = object : Migration(X, Y) {
+       override fun migrate(db: SupportSQLiteDatabase) {
+           // SQL: ALTER, CREATE, copy-and-rename for column drops, etc.
+       }
+   }
+   ```
+
+   SQLite has no `ALTER TABLE DROP COLUMN`, so column drops are done by creating
+   `<table>_new`, copying rows, dropping the old table, renaming. Use parameterized
+   `db.execSQL(sql, arrayOf(...))` for any value substitution.
+
+3. Register it in `CoreDatabaseModule`:
+
+   ```kotlin
+   .addMigrations(MIGRATION_X_Y)
+   .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3, ...)
+   .build()
+   ```
+
+   Both calls coexist — `addMigrations` handles real upgrade paths from versions Room knows
+   about; the destructive list still catches developer-only legacy versions.
+
+4. Add an instrumented migration test under
+   `core/database/src/test/kotlin/.../migrations/Migration<X>To<Y>Test.kt` using
+   `androidx.room.testing.MigrationTestHelper`:
+
+   - Open the database at version `X`, populate fixture rows that exercise edge cases.
+   - Call `helper.runMigrationsAndValidate(NAME, Y, true, MIGRATION_X_Y)`.
+   - Assert that fixture rows survive (or are transformed correctly).
+   - Cover at least: typical row, empty/edge input, multiple rows.
+
+5. Once shipped, never edit `MIGRATION_X_Y` again. Forward-fix in `MIGRATION_Y_(Y+1)`.
+
+This non-destructive playbook is dormant until the first Play Store release lands. Treat
+this section as the future plan, not the current one — and update this skill when the
+policy actually flips.

--- a/.claude/skills/add-feature.md
+++ b/.claude/skills/add-feature.md
@@ -1,6 +1,6 @@
 ---
 name: add-feature
-description: Scaffold a new `feature/<name>` Gradle module with the project's MVI + Hilt + Compose conventions, including Store contract, handlers, DI, navigation entry, and a smoke UI test stub.
+description: Scaffold a new `feature/<name>` Gradle module that follows the project's MVI + Hilt + Compose conventions — including the canonical navigation pattern (Action.Navigation + NavigationHandler with injected Navigator), the design system (`core/ui/kit` components and `AppUi.*` tokens), Store contract, handlers, DI, navigation entry, and a smoke UI test stub.
 ---
 
 # Add a feature module
@@ -15,37 +15,67 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
 ## Prerequisites
 
 - The feature has a name in kebab-case (e.g. `workout-history`).
-- The corresponding `Screen` route does not yet exist in `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`.
-- `documentation/architecture.md` is available — every step below assumes its conventions and file paths.
+- The corresponding `Screen` route does not yet exist in
+  `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`.
+- These docs are the source of truth for everything below — read them before scaffolding:
+  - [documentation/architecture.md](../../documentation/architecture.md) — module map, MVI
+    contract, `Navigation flow (canonical pattern)`, DI scopes.
+  - [documentation/design-system.md](../../documentation/design-system.md) — token catalog
+    and the 21 `core/ui/kit` components.
+  - [documentation/lint-rules.md](../../documentation/lint-rules.md) — the State / Action /
+    Event / Handler / Composable rules that gate a new module.
+  - [documentation/feature-specs/settings-archive.md](../../documentation/feature-specs/settings-archive.md)
+    — canonical worked example of a v1 feature, including handler split and graph composable.
+
+## Reference implementation
+
+The fullest current example is `feature/settings/` (Stage 5.1). The most literal
+"canonical navigation" reference is `feature/all-trainings/`:
+
+- Graph composable: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/ui/AllTrainingsGraph.kt`
+- NavigationHandler: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/NavigationHandler.kt`
+- Component: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/AllTrainingsComponent.kt`
+- StoreImpl: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/store/TrainingStoreImpl.kt`
+- Feature wiring: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/di/TrainingsFeature.kt`
+
+Older features (`feature/exercise`, `feature/single-training`, `feature/charts`) keep the
+MVI under `ui/mvi/` and use the older `*StoreProcessor.kt` naming. When extending those
+modules, mirror what already exists there. When creating a **new** module, follow the
+post-Stage-5.1 layout below.
 
 ## Step-by-step
 
-1. Decide whether the feature needs a domain layer. Features with non-trivial business logic or
-   their own interactor (see `feature/exercise/.../domain/`, `feature/single-training/.../domain/`)
-   create a `domain/` package. Features that only forward to repositories
-   (`feature/all-trainings`, `feature/charts`, `feature/all-exercises`) skip it.
+1. Decide whether the feature needs a domain layer. Features with non-trivial business logic
+   or their own interactor (`feature/settings/.../domain/`,
+   `feature/exercise/.../domain/`, `feature/single-training/.../domain/`) create a `domain/`
+   package. Features that only forward to repositories (`feature/all-trainings`,
+   `feature/charts`, `feature/all-exercises`) skip it.
 
-2. Create the module directory tree under `feature/<name>/`:
+2. Create the module directory tree under `feature/<name>/`. Post-Stage-5.1 layout
+   (mirrors `feature/settings/`):
 
    ```
    feature/<name>/
    ├── build.gradle.kts
    └── src/
+       ├── main/AndroidManifest.xml
        ├── main/kotlin/io/github/stslex/workeeper/feature/<name_snake>/
-       │   ├── di/                 # <Name>Module, <Name>HandlerStore[+Impl], <Name>Processor, <Name>EntryPoint (if needed)
+       │   ├── di/                 # <Name>Module, <Name>HandlerStore[+Impl], <Name>Feature
        │   ├── domain/             # only if the feature has its own business logic
        │   ├── mvi/
-       │   │   ├── handler/        # ClickHandler, InputHandler, NavigationHandler, optionally PagingHandler / CommonHandler, plus <Name>Component
+       │   │   ├── handler/        # ClickHandler, InputHandler, NavigationHandler,
+       │   │   │                   # optional PagingHandler / CommonHandler, plus <Name>Component
        │   │   ├── model/          # UI models, mappers
        │   │   └── store/          # <Name>Store contract + <Name>StoreImpl
        │   └── ui/
        │       ├── components/
-       │       └── <Name>Screen.kt # or <Name>Widget.kt
-       ├── test/kotlin/...         # JUnit 5 unit tests
-       └── androidTest/kotlin/...  # @Smoke UI tests
+       │       ├── <Name>Screen.kt
+       │       └── <Name>Graph.kt   # NavGraphBuilder.<feature>Graph extension
+       ├── test/kotlin/...         # JUnit 5 unit tests (handlers, interactor)
+       └── androidTest/kotlin/...  # @Smoke UI tests (often stubs — see write-ui-test)
    ```
 
-3. Generate `feature/<name>/build.gradle.kts`. Mirror `feature/charts/build.gradle.kts`:
+3. Generate `feature/<name>/build.gradle.kts`. Mirror `feature/settings/build.gradle.kts`:
 
    ```kotlin
    plugins {
@@ -54,12 +84,15 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
 
    dependencies {
        implementation(project(":core:core"))
+
        implementation(project(":core:dataStore"))
        implementation(project(":core:ui:kit"))
        implementation(project(":core:ui:mvi"))
        implementation(project(":core:ui:navigation"))
        implementation(project(":core:exercise"))
+
        testImplementation(kotlin("test"))
+       testImplementation(libs.androidx.paging.testing) // only if the feature uses PagingHandler
 
        androidTestImplementation(libs.bundles.android.test)
        androidTestImplementation(libs.androidx.compose.ui.test.junit4)
@@ -69,79 +102,272 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
    ```
 
    Drop dependencies the feature does not use (e.g. omit `:core:exercise` if the feature does
-   not touch exercise/training/label repositories).
+   not touch exercise / training / tag repositories).
 
 4. Add the module to the root settings: `include(":feature:<name>")` in `settings.gradle.kts`.
 
-5. Add the route. Edit `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`
-   and add a `@Serializable` entry. Bottom-bar destinations go under `Screen.BottomBar`; detail
-   destinations are top-level data classes that carry route arguments.
+5. Add the route. Edit
+   `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`
+   and add a `@Serializable` entry. Bottom-bar destinations go under `Screen.BottomBar`;
+   detail destinations are top-level `data class` types that carry route arguments;
+   single-instance destinations are `data object`. Existing examples: `Screen.Settings` /
+   `Screen.Archive` (data objects), `Screen.Training(uuid)` / `Screen.Exercise(uuid, trainingUuid)`
+   (data classes).
 
-6. Generate the Store contract under `mvi/store/<Name>Store.kt`. Follow the contract conventions
-   in [documentation/architecture.md#mvi-contract](../../documentation/architecture.md#mvi-contract):
+6. Generate the Store contract under `mvi/store/<Name>Store.kt`. Conventions enforced by
+   the custom Detekt rules in
+   [documentation/lint-rules.md](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
 
-   - `interface <Name>Store : Store<State, Action, Event>`
-   - `data class State(val ...) : Store.State` — properties are `val`; collections are
-     `kotlinx.collections.immutable.ImmutableList` / `ImmutableSet` (never `MutableList` etc.).
-     Add a `companion object { val INITIAL = State(...) }` for tests.
-   - `sealed interface Action : Store.Action` with nested `Click`, `Input`, `Navigation`,
-     optionally `Paging` / `Common`.
-   - `sealed interface Event : Store.Event` — names follow the patterns enforced by
-     `MviEventNamingRule` (e.g. `*Success`, `*Error`, `Haptic*`, `Snackbar*`, `Navigate*`,
-     `Scroll*`).
+   - `internal interface <Name>Store : Store<State, Action, Event>`.
+   - `data class State(val ...) : Store.State` — properties are `val`; collections use
+     `kotlinx.collections.immutable` (`ImmutableList`, `ImmutableSet`). A
+     `companion object { fun init(...) = State(...) }` (or `INITIAL = State(...)`) keeps
+     fixture construction in tests cheap.
+   - `sealed interface Action : Store.Action` with nested categories under
+     `Click`, `Input`, `Navigation`, optionally `Paging`, `Common`. **Navigation actions
+     are always grouped under `Action.Navigation` — never modeled as `Event.Navigate*`.**
+     See the Canonical navigation pattern below.
+   - `sealed interface Event : Store.Event` for **UI side effects only**. Allowed name
+     patterns from `MviEventNamingRule` are `*Success`, `*Error`, `*Completed`, `*Started`,
+     `*Failed`, `*Requested`, plus tokens `Show`, `Haptic`, `Snackbar`, `Scroll`. Although
+     `Navigate` is technically in the rule's pattern list, the project's convention is
+     **never to use it** — emit `Action.Navigation.*` instead.
 
-7. Generate handlers under `mvi/handler/`. Use `feature/exercise/.../mvi/handler/ClickHandler.kt`
+7. Generate handlers under `mvi/handler/`. Use
+   `feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt`
    as the canonical reference. Each handler:
 
-   - is `@ViewModelScoped` and uses `@Inject` constructor injection (except `NavigationHandler`,
-     which constructs from the `<Name>Component`).
-   - implements `Handler<Action.<Category>>` from `core/ui/mvi/.../handler/Handler.kt`.
-   - receives the feature's `<Name>HandlerStore` to read state, mutate state, and emit events.
+   - Is `internal class`, `@ViewModelScoped`, with `@Inject` constructor injection (the
+     only exception is `NavigationHandler` — see Canonical navigation pattern below).
+     `MviHandlerConstructorRule` enforces `@Inject` and at least one parameter.
+   - Implements `Handler<Action.<Category>>` from
+     `core/ui/mvi/src/main/kotlin/io/github/stslex/workeeper/core/ui/mvi/handler/Handler.kt`.
+   - Receives the feature's `<Name>HandlerStore` interface (defined in `di/`) to read
+     state, mutate state via `updateState { it.copy(...) }`, dispatch other actions via
+     `consume(...)`, and emit events via `sendEvent(...)`.
 
 8. Generate `mvi/handler/<Name>Component.kt` extending `Component<Screen.<...>>` from
-   `core/ui/navigation/.../Component.kt`, plus `<Name>ComponentImpl` that the navigation graph
-   constructs. See `feature/exercise/.../mvi/handler/ExerciseComponent.kt`.
+   `core/ui/navigation/.../Component.kt`. The component carries the route data and exposes
+   a `companion object create(navigator: Navigator, ...)` factory that constructs the
+   feature's `NavigationHandler`. Reference:
+   `feature/all-trainings/.../mvi/handler/AllTrainingsComponent.kt` (no route args) or
+   `feature/exercise/.../ui/mvi/handler/ExerciseComponent.kt` (route args carried via
+   `data class Screen.Exercise`).
 
 9. Generate `mvi/store/<Name>StoreImpl.kt` extending `BaseStore<State, Action, Event>`,
    annotated `@HiltViewModel(assistedFactory = <Name>StoreImpl.Factory::class)`. The
-   `handlerCreator` lambda routes each `Action` subtype to the matching handler. See
-   `feature/exercise/.../ui/mvi/store/ExerciseStoreImpl.kt`.
+   `handlerCreator` lambda routes each `Action` subtype to the matching handler; the
+   `Action.Navigation` branch casts the assisted `<Name>Component` to the
+   `NavigationHandler`. Reference:
+   `feature/all-trainings/.../mvi/store/TrainingStoreImpl.kt` (lines 38-45) or
+   `feature/settings/.../mvi/store/SettingsStoreImpl.kt`.
 
 10. Generate the Hilt module at `di/<Name>Module.kt` with
-    `@InstallIn(ViewModelComponent::class)`. Bind the `<Name>HandlerStore` (and any interactor)
-    as `@ViewModelScoped`. See `feature/exercise/.../di/ExerciseModule.kt`.
+    `@InstallIn(ViewModelComponent::class)`. Bind the `<Name>HandlerStore`
+    (and any interactor) as `@ViewModelScoped`. Reference:
+    `feature/all-trainings/.../di/AllTrainingsModule.kt`.
 
-11. Generate `di/<Name>HandlerStoreImpl.kt` as a `@ViewModelScoped` `@Inject` class extending
-    `BaseHandlerStore<State, Action, Event>`. See
-    `feature/exercise/.../di/ExerciseHandlerStoreImpl.kt`.
+11. Generate `di/<Name>HandlerStore.kt` (the interface, e.g. `internal interface
+    SettingsHandlerStore : HandlerStore<State, Action, Event>`) and
+    `di/<Name>HandlerStoreImpl.kt` (`@ViewModelScoped`, `@Inject constructor()`,
+    extending `BaseHandlerStore<State, Action, Event>`). Reference:
+    `feature/all-trainings/.../di/TrainingHandlerStoreImpl.kt`.
 
-12. Generate `di/<Name>Processor.kt` implementing `Feature<TProcessor, TScreen, TComponent>`
-    from `core/ui/mvi/.../Feature.kt` and a `<feature>Graph(...)` extension on `NavGraphBuilder`.
-    See `feature/charts/.../di/ChartsStoreProcessor.kt`.
+12. Generate `di/<Name>Feature.kt` extending
+    `Feature<<Name>StoreProcessor, Screen.<X>, <Name>Component>` and overriding `processor`
+    to call `createProcessor<<Name>StoreImpl, <Name>StoreImpl.Factory>(screen)`. Reference:
+    `feature/all-trainings/.../di/TrainingsFeature.kt` or
+    `feature/settings/.../di/SettingsFeature.kt`. (The legacy `*StoreProcessor.kt` /
+    `*Processor.kt` naming in `feature/charts`, `feature/single-training`, and the older
+    `feature/exercise/di/ExerciseProcessor.kt` does the same job; new code uses
+    `*Feature.kt`.)
 
-13. Wire the navigation graph. Edit `app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt`
-    and call your new `<feature>Graph(modifier = ..., sharedTransitionScope = this@SharedTransitionLayout)`.
+13. Generate `ui/<Name>Graph.kt` — a `fun NavGraphBuilder.<feature>Graph(modifier: Modifier
+    = Modifier, ...)` extension. Inside, call `navComponentScreen(<Name>Feature) { processor
+    -> ... }` and consume only **UI-side** events through `processor.Handle { event -> ... }`
+    (haptics, external links, snackbar emissions, scroll commands). Pass
+    `processor.state.value` and `processor::consume` into your `<Name>Screen` /
+    `<Name>Widget`. Reference:
+    `feature/settings/.../ui/SettingsGraph.kt` and
+    `feature/all-trainings/.../ui/AllTrainingsGraph.kt`.
 
-14. If the feature is bottom-bar visible, add an entry in
+14. Wire the navigation graph into the host. Edit
+    `app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt` and call
+    your new `<feature>Graph(modifier = ..., sharedTransitionScope = this@SharedTransitionLayout)`.
+    The `sharedTransitionScope` parameter is only required for graphs that participate in
+    shared element transitions — see how `allTrainingsGraph` and `settingsGraph` differ.
+
+15. If the feature is bottom-bar visible, add an entry in
     `app/app/src/main/java/io/github/stslex/workeeper/bottom_app_bar/BottomBarItem.kt`.
 
-15. Generate the screen. `<Name>Screen.kt` (or `<Name>Widget.kt`) is a `@Composable` ending in
-    `Screen` and must take a `*State` parameter and an action/event handler parameter — this is
-    enforced by `ComposableStateRule`.
+16. Generate the screen. `<Name>Screen.kt` (or `<Name>Widget.kt`) is a `@Composable` ending
+    in `Screen` and must take both a `*State` parameter and an action/event handler
+    parameter — enforced by `ComposableStateRule`.
 
-16. Add a smoke UI test stub under
-    `feature/<name>/src/androidTest/kotlin/.../<Name>ScreenTest.kt` annotated `@Smoke`. Use
-    `BaseComposeTest` with `setTransitionContent { ... }`. See
-    [documentation/testing.md](../../documentation/testing.md) and the `write-ui-test` skill.
+17. Build the UI from `core/ui/kit` components and tokens (see Design system contract
+    below). Hardcoded `Color()`, `sp`, or `dp` outside `core/ui/kit/theme/` are not allowed.
+
+18. Add a smoke UI test stub under
+    `feature/<name>/src/androidTest/kotlin/.../<Name>ScreenTest.kt` annotated `@Smoke`. Most
+    new features start as a stub with a `TODO(feature-rewrite-tests)` marker (see the
+    `write-ui-test` skill).
+
+## Canonical navigation pattern
+
+Navigation is **always** routed through a feature's `NavigationHandler`. The graph
+composable knows nothing about routes or the `Navigator`. The full rationale lives at
+[documentation/architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+The shape:
+
+1. UI emits `Action.Navigation.<Something>` via `processor::consume(...)`.
+2. The `StoreImpl.handlerCreator` routes that action to the feature's `NavigationHandler`
+   (typically `is Action.Navigation -> component as NavigationHandler`).
+3. `NavigationHandler` receives `Navigator` (constructed by the feature's `Component.create`
+   factory at navigation time) and calls `navigator.navTo(Screen.X)` or `navigator.popBack()`.
+
+Concretely, a feature defines:
+
+```kotlin
+// In <Name>Store.kt:
+internal interface <Name>Store : Store<State, Action, Event> {
+
+    sealed interface Action : Store.Action {
+        sealed interface Navigation : Action {
+            data object Back : Navigation
+            data object OpenArchive : Navigation
+            // ... any other navigation targets
+        }
+        // ... Click, Input, Paging, Common as needed
+    }
+
+    sealed interface Event : Store.Event {
+        // ONLY UI-side effects: Haptic*, Snackbar*, Show*, Scroll*, *Success, *Error, *Completed.
+        // NEVER Navigate*. Navigation is Action.Navigation, full stop.
+    }
+}
+
+// In mvi/handler/NavigationHandler.kt:
+internal class NavigationHandler(
+    private val navigator: Navigator,
+) : <Name>Component(), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            Action.Navigation.Back -> navigator.popBack()
+            Action.Navigation.OpenArchive -> navigator.navTo(Screen.Archive)
+        }
+    }
+}
+
+// In mvi/handler/<Name>Component.kt:
+abstract class <Name>Component : Component<Screen.<X>>(Screen.<X>) {
+    companion object {
+        fun create(navigator: Navigator): <Name>Component = NavigationHandler(navigator)
+    }
+}
+```
+
+`MviHandlerConstructorRule` explicitly skips the `@Inject` requirement for classes named
+`NavigationHandler` (see `lint-rules/.../MviHandlerConstructorRule.kt:74`). Older
+NavigationHandlers in the codebase carry `@Suppress("MviHandlerConstructorRule")` — that
+suppression is unnecessary for the literal name `NavigationHandler`, only for variants like
+`SettingsNavigationHandler`. Either name compiles; prefer the bare `NavigationHandler` per
+the all-trainings reference.
+
+The graph composable (`<feature>Graph`) consumes **only** UI-side events:
+
+```kotlin
+fun NavGraphBuilder.<feature>Graph(modifier: Modifier = Modifier) {
+    navComponentScreen(<Name>Feature) { processor ->
+        val haptic = LocalHapticFeedback.current
+        val context = LocalContext.current
+
+        processor.Handle { event ->
+            when (event) {
+                is Event.Haptic -> haptic.performHapticFeedback(event.type)
+                is Event.ShowExternalLink -> context.startActivity(
+                    Intent(Intent.ACTION_VIEW, event.url.toUri())
+                        .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+                )
+                // snackbar emissions, scroll commands, ...
+            }
+        }
+
+        <Name>Screen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+        )
+    }
+}
+```
+
+The graph composable **never** reads `LocalNavigator`, **never** calls `navigator.navTo` /
+`navigator.popBack` directly, and **never** consumes a `Navigate*` event (no such event
+exists — emitting one is wrong by convention). `LocalNavigator` lives in
+`core/ui/navigation/Navigator.kt` only so the root `App.kt` can provide a single instance
+into the composition tree.
+
+## Design system contract
+
+All visible UI is built from `core/ui/kit` components and `AppUi.*` token accessors. Full
+catalog is in [documentation/design-system.md](../../documentation/design-system.md).
+Quick reference:
+
+**Tokens** — read via `AppUi.*` inside any `@Composable`:
+
+- `AppUi.colors` — `LocalAppColors.current` (semantic palette: `accent`, `textPrimary`,
+  `textSecondary`, `textTertiary`, surface tiers, semantic statuses).
+- `AppUi.typography` — `LocalAppTypography.current` (Inter family, 13-slot M3 scale).
+- `AppUi.shapes` — `LocalAppShapes.current` (`small` / `medium` / `large`).
+- `AppUi.motion` — `LocalAppMotion.current` (durations + easings).
+- `AppUi.elevation` — `LocalAppElevation.current` (color-based surface tier mapping).
+- `LocalAppDimension.current` for spacing aliases (`screenEdge`, `cardPadding`, `iconMd`,
+  `heightSm`, etc.).
+
+**Components** — every shared UI primitive lives under
+`core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/`:
+
+| Component | File |
+|---|---|
+| `AppButton` | `components/button/AppButton.kt` |
+| `AppCard` | `components/card/AppCard.kt` |
+| `AppTextField` | `components/input/AppTextField.kt` |
+| `AppNumberInput` | `components/input/AppNumberInput.kt` |
+| `AppDialog` | `components/dialog/AppDialog.kt` |
+| `AppConfirmDialog` | `components/dialog/AppConfirmDialog.kt` |
+| `AppDatePickerDialog` | `components/dialog/AppDatePickerDialog.kt` |
+| `AppEmptyState` | `components/empty/AppEmptyState.kt` |
+| `AppListItem` | `components/list/AppListItem.kt` |
+| `AppTagChip` | `components/tag/AppTagChip.kt` |
+| `AppTagPicker` | `components/tag/AppTagPicker.kt` |
+| `AppTopAppBar` | `components/topbar/AppTopAppBar.kt` |
+| `AppBottomBar` | `components/bottombar/AppBottomBar.kt` |
+| `AppBottomSheet` | `components/sheet/AppBottomSheet.kt` |
+| `AppFAB` | `components/fab/AppFAB.kt` |
+| `AppLoadingIndicator` | `components/loading/AppLoadingIndicator.kt` |
+| `AppSetTypeChip` | `components/setchip/AppSetTypeChip.kt` |
+| `AppSegmentedControl` | `components/segmented/AppSegmentedControl.kt` |
+| `AppSnackbar` | `components/snackbar/AppSnackbar.kt` |
+| `AppSwipeAction` | `components/swipe/AppSwipeAction.kt` |
+
+**Forbidden in feature code**:
+
+- Hardcoded `Color(0xFFRRGGBB)` outside `core/ui/kit/theme/AppColors.kt`.
+- Hardcoded `12.sp` / `16.dp` outside `core/ui/kit/theme/{AppTypography,AppDimension,AppShapes}.kt`.
+- Re-implementing dialogs, snackbars, list rows, or segmented controls inside a feature
+  module — extend the shared component or land the variant in `core/ui/kit/`.
 
 ## Verification
 
 ```bash
 ./gradlew :feature:<name>:detekt :feature:<name>:lintDebug --no-configuration-cache
+./gradlew :feature:<name>:assembleDebug
+./gradlew :feature:<name>:testDebugUnitTest
 ```
 
-Both must pass. The detekt run exercises the custom MVI rules; if any fire, fix them rather
-than baselining (see the `refactor-with-mvi-rules` skill).
+The detekt run exercises the custom MVI rules; if any fire, fix them rather than baselining
+(see the `refactor-with-mvi-rules` skill).
 
 ## Common pitfalls
 
@@ -152,7 +378,15 @@ than baselining (see the `refactor-with-mvi-rules` skill).
 - **Do not use `MutableList` / `MutableSet` / `MutableMap` in `State`.** Use the
   `kotlinx.collections.immutable` types. `MviStateImmutabilityRule` will reject them.
 - **Do not use `var` in `State`.** Same rule — properties must be `val`.
-- **Do not forget the `convention.composeLibrary` plugin alias** in `build.gradle.kts`. Plain
-  `kotlin("jvm")` modules will not get Hilt, Compose, or the lint convention.
+- **Do not model navigation as `Event.Navigate*`.** Every navigation target is
+  `Action.Navigation.<X>` consumed by the feature's `NavigationHandler`. See the Canonical
+  navigation pattern above and the `refactor-with-mvi-rules` skill.
+- **Do not read `LocalNavigator` from the graph composable.** The root `App.kt` provides it
+  for the composition tree; the canonical read site is `NavigationHandler` (constructed via
+  the feature's `Component.create(navigator)` factory).
+- **Do not hardcode colors / sizes / type styles in feature code.** Pull from `AppUi.*` and
+  the `core/ui/kit` components. See the Design system contract above.
+- **Do not forget the `convention.composeLibrary` plugin alias** in `build.gradle.kts`.
+  Plain `kotlin("jvm")` modules will not get Hilt, Compose, or the lint convention.
 - **Do not bypass `Screen` for navigation.** Every navigable destination must be a
   `@Serializable` entry in `core/ui/navigation/.../Screen.kt`.

--- a/.claude/skills/refactor-with-mvi-rules.md
+++ b/.claude/skills/refactor-with-mvi-rules.md
@@ -1,6 +1,6 @@
 ---
 name: refactor-with-mvi-rules
-description: Resolve a custom Detekt MVI-architecture rule violation by reading the rule source under `lint-rules/.../lint_rules/`, applying the conformant fix, and verifying with `./gradlew detekt`.
+description: Resolve a custom Detekt MVI-architecture rule violation by reading the rule source under `lint-rules/.../lint_rules/`, applying the conformant fix (including the project convention that navigation flows through `Action.Navigation`, never `Event.Navigate*`), and verifying with `./gradlew detekt`.
 ---
 
 # Refactor to satisfy MVI Detekt rules
@@ -16,7 +16,11 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 ## Prerequisites
 
 - The detekt report (`<module>/build/reports/detekt/`) or the gradle output names the rule.
-- `documentation/lint-rules.md` is available for the catalog of rules with good/bad examples.
+- [documentation/lint-rules.md](../../documentation/lint-rules.md) has the catalog of rules
+  with good/bad examples.
+- [documentation/architecture.md](../../documentation/architecture.md#mvi-contract) describes
+  the MVI contract the rules enforce, including the canonical navigation pattern
+  (`Action.Navigation` + `NavigationHandler`, never `Event.Navigate*`).
 
 ## Step-by-step
 
@@ -37,29 +41,69 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
    triggers the report. The rule set is registered in `MviArchitectureRules.kt`.
 
 2. Apply the canonical fix. Examples and rationale live in
-   [documentation/lint-rules.md#custom-detekt-mvi-rules](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
+   [documentation/lint-rules.md → Custom Detekt MVI rules](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
 
    - **`MviStateImmutabilityRule`** — convert the class to `data class` (or `sealed`),
      change every `var` to `val`, replace `MutableList<T>` / `MutableSet<T>` /
      `MutableMap<K, V>` with the `kotlinx.collections.immutable` types
      (`ImmutableList`, `ImmutableSet`, `ImmutableMap`).
+
    - **`MviActionNamingRule`** — make the `*Action` class `sealed` (interface or class).
-     Group nested actions under categories: `Click`, `Input`, `Navigation`, optionally
-     `Paging`, `Common`.
+     Group nested actions under the project's standard top-level categories: `Click`,
+     `Input`, `Navigation`, optionally `Paging`, `Common`. Verified shape across the v1
+     features (e.g. `feature/all-trainings/.../mvi/store/TrainingStore.kt`,
+     `feature/settings/.../mvi/store/SettingsStore.kt`):
+
+     ```kotlin
+     sealed interface Action : Store.Action {
+         sealed interface Click : Action { /* ... */ }
+         sealed interface Input : Action { /* ... */ }
+         sealed interface Navigation : Action { /* ... */ }
+         sealed interface Paging : Action { /* ... */ }
+         // sealed interface Common : Action { /* ... */ }   when needed
+     }
+     ```
+
    - **`MviEventNamingRule`** — make the outer `*Event` `sealed`. Each nested event must
      either end in one of `Success`, `Error`, `Completed`, `Started`, `Failed`, `Requested`,
      **or** contain one of `Show`, `Navigate`, `Haptic`, `Snackbar`, `Scroll`. Rename to
      match.
+
+     **Project convention layered on top of the rule:** Events are for UI side effects
+     only. Allowed in practice: `Haptic*` (e.g. `Event.Haptic(type)`), `Snackbar*`,
+     `Show*` (e.g. `Event.ShowExternalLink(url)`), `Scroll*`, `*Success`, `*Error`,
+     `*Completed`. **`Navigate*` is not allowed by convention even though the rule's
+     pattern would accept it.** Navigation is `Action.Navigation.<X>` consumed by the
+     feature's `NavigationHandler`. See
+     [architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+     If a `Navigate*` event slipped in, the fix is to:
+
+     1. Add an `Action.Navigation.<X>` entry on the feature's Store contract.
+     2. Move the route call into the feature's `NavigationHandler.invoke(action)` branch.
+     3. Replace `processor.Handle { Event.Navigate* -> navigator.navTo(...) }` with
+        `processor.consume(Action.Navigation.<X>)` at the call site, or drop the event
+        emission entirely if no caller needed it.
+     4. Delete the `Navigate*` event.
+
    - **`MviHandlerNamingRule`** — `*Handler` must not be a `data class`. Member functions
      starting with `Handle` must contain `Action` (e.g. `HandleClickAction`).
+
    - **`MviStoreExtensionRule`** — `*StoreImpl` must extend `BaseStore`. `*Store`
      interfaces (excluding `*HandlerStore`) must implement `Store`.
+
    - **`MviHandlerConstructorRule`** — `*Handler` classes must have a primary constructor
-     annotated `@Inject` and at least one parameter. The only exception is
-     `NavigationHandler`, which is constructed from the feature's `*Component` rather than
-     via Hilt.
+     annotated `@Inject` and at least one parameter. The rule's source explicitly skips
+     the literal class name `NavigationHandler`
+     (`lint-rules/.../MviHandlerConstructorRule.kt:74`), which is constructed from the
+     feature's `*Component.create(navigator)` factory rather than via Hilt — so
+     `internal class NavigationHandler(private val navigator: Navigator) : ...` is
+     conformant. Variants like `SettingsNavigationHandler` still trip the rule and require
+     `@Suppress("MviHandlerConstructorRule")`; prefer the bare `NavigationHandler` name
+     for new code.
+
    - **`MviStoreStateRule`** — the inner `State` class of a `*Store` must be
      `data class State(...) : Store.State`.
+
    - **`HiltScopeRule`** — apply scope by class-name pattern (the mapping is in
      `lint-rules/.../lint_rules/ScopeClassType.kt`):
      - Names containing `Repository` / `DataStore` / `Database` / `StoreDispatchers` →
@@ -67,8 +111,10 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
      - Names containing `Handler` / `Store` / `Interactor` / `Mapper` →
        `@ViewModelScoped`.
      The rule also reports if a class carries the *other* category's annotation.
+
    - **`ComposableStateRule`** — `@Composable` functions whose name ends in `Screen`
-     must take a `*State` parameter and an action/event handler parameter.
+     must take a `*State` parameter and an action/event handler parameter (typically a
+     `consume: (Action) -> Unit` lambda).
 
 3. Re-run detekt for the affected module:
 
@@ -80,9 +126,10 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 
 4. If the rule fired on legacy code that is genuinely out of scope for the current task,
    prefer narrowing the change to the smallest unit that satisfies the rule rather than
-   adding a baseline entry. The codebase's policy (per
-   [documentation/lint-rules.md#baselines](../../documentation/lint-rules.md#baselines)) is to
-   use baselines only when introducing a brand-new rule against established legacy code.
+   adding a baseline entry. The codebase's policy
+   ([documentation/lint-rules.md → Baselines](../../documentation/lint-rules.md#baselines))
+   is to use baselines only when introducing a brand-new rule against established legacy
+   code.
 
 ## Verification
 
@@ -90,14 +137,14 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 ./gradlew detekt
 ```
 
-Run at the project root to verify the violation cleared and no new ones surfaced. For changes
-to `*Store.kt` / handlers / Composables, also re-run the relevant unit tests and Compose UI
-tests (see the `write-handler-test` and `write-ui-test` skills).
+Run at the project root to verify the violation cleared and no new ones surfaced. For
+changes to `*Store.kt` / handlers / Composables, also re-run the relevant unit tests and
+Compose UI tests (see the `write-handler-test` and `write-ui-test` skills).
 
 ## Common pitfalls
 
-- **Do not add the violation to `lint-rules/detekt-baseline.xml`.** Baselines are for legacy
-  code that predates the rule, not for new violations.
+- **Do not add the violation to `lint-rules/detekt-baseline.xml`.** Baselines are for
+  legacy code that predates the rule, not for new violations.
 - **Do not suppress with `@Suppress("MviStateImmutabilityRule")` etc. on production code.**
   The `core/ui/mvi` module suppresses some rules at the type-parameter level
   (`@Suppress("MviStoreStateRule", "MviStoreExtensionRule", "MviStateImmutabilityRule")` on
@@ -106,9 +153,12 @@ tests (see the `write-handler-test` and `write-ui-test` skills).
 - **Do not move offending code outside `mvi/` to dodge the rule.** Several rules gate on
   whether the file's package contains `mvi` or its path contains `/mvi/`. Hiding the file
   silences the rule but breaks the architecture and will surprise the next contributor.
-- **Do not mix scope annotations.** `HiltScopeRule` rejects `@Singleton` on a class whose name
-  matches the `@ViewModelScoped` set (and vice-versa). Pick the scope that matches the class
-  name; if neither fits, rename the class.
-- **Do not change rule sources to make a violation go away.** If a rule's intent is wrong for
-  the codebase, that is a separate, larger conversation — open an issue rather than editing
-  `lint-rules/.../lint_rules/*.kt` mid-feature work.
+- **Do not introduce a `Navigate*` event to "fix" a navigation flow.** Add an
+  `Action.Navigation.<X>` and route through the feature's `NavigationHandler` instead.
+  See [architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+- **Do not mix scope annotations.** `HiltScopeRule` rejects `@Singleton` on a class whose
+  name matches the `@ViewModelScoped` set (and vice-versa). Pick the scope that matches
+  the class name; if neither fits, rename the class.
+- **Do not change rule sources to make a violation go away.** If a rule's intent is wrong
+  for the codebase, that is a separate, larger conversation — open an issue rather than
+  editing `lint-rules/.../lint_rules/*.kt` mid-feature work.

--- a/.claude/skills/write-handler-test.md
+++ b/.claude/skills/write-handler-test.md
@@ -1,6 +1,6 @@
 ---
 name: write-handler-test
-description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the project's mocked `HandlerStore` + `TestScope` pattern from `feature/single-training`.
+description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the project's mocked `<Name>HandlerStore` + `MutableStateFlow` pattern from `feature/settings/`. Includes a NavigationHandler template that mocks `Navigator` and asserts `navTo` / `popBack` per `Action.Navigation`.
 ---
 
 # Write a handler / store unit test
@@ -11,79 +11,173 @@ description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the
 - "Test the click handler for feature X"
 - "Cover `<...>StoreImpl` with unit tests"
 - "Write tests for an MVI action"
+- "Add a NavigationHandler test"
 
 ## Prerequisites
 
 - The handler or store under test exists.
-- The feature's module already pulls in `kotlin("test")` and the project's `test` bundle (most
-  feature `build.gradle.kts` files do — see `feature/charts/build.gradle.kts`).
-- `documentation/testing.md` is available for the broader strategy.
+- The feature's module already pulls in `kotlin("test")` and the project's `test` bundle
+  (every feature `build.gradle.kts` does — see `feature/settings/build.gradle.kts`).
+- [documentation/testing.md](../../documentation/testing.md) has the broader strategy.
+
+## Reference tests
+
+Use the **`feature/settings/`** test classes as the canonical patterns — they are the only
+real handler tests in the codebase right now. The older feature handler tests in
+`feature/all-trainings`, `feature/all-exercises`, `feature/exercise`,
+`feature/single-training`, and `feature/charts` are 10-line `placeholder() = Unit` stubs
+with `TODO(feature-rewrite)` markers; **do not copy from them** — they exist only so the
+modules still compile.
+
+Canonical references:
+
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt`
+  — straight `verify { store.sendEvent(...) }` / `verify { store.consume(...) }` with no
+  state mutation.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt`
+  — uses `MutableStateFlow` + `every { updateState(any()) } answers { ... }` to actually
+  mutate state inside the test.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt`
+  — fuller example with `coVerify`, `slot<T>()` capture, and state-conditional branches.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt`
+  — minimal `Navigator` mock + per-`Action.Navigation` assertion. See
+  [NavigationHandler test template](#navigationhandler-test-template) below.
 
 ## Step-by-step
 
-1. Locate a reference test in the same feature when one exists. Otherwise use:
-
-   - `feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/ui/mvi/handler/ClickHandlerTest.kt`
-   - `feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandlerTest.kt`
-   - `feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/mvi/handler/PagingHandlerTest.kt`
-
-   These set the project conventions.
-
-2. Place the new test under
+1. Place the new test under
    `feature/<name>/src/test/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<sub-package>/<HandlerName>Test.kt`,
    mirroring the production package. Use `internal class` visibility.
 
-3. Use these imports:
+2. Use these imports (drop the ones you do not need):
 
    ```kotlin
-   import org.junit.jupiter.api.Test
-   import org.junit.jupiter.api.Assertions.assertEquals
    import io.mockk.coEvery
    import io.mockk.coVerify
    import io.mockk.every
    import io.mockk.mockk
+   import io.mockk.slot
    import io.mockk.verify
    import kotlinx.coroutines.flow.MutableStateFlow
-   import kotlinx.coroutines.test.TestCoroutineScheduler
-   import kotlinx.coroutines.test.TestScope
-   import kotlinx.coroutines.test.UnconfinedTestDispatcher
-   import kotlinx.coroutines.test.runTest
-   import io.github.stslex.workeeper.core.core.coroutine.scope.AppCoroutineScope
+   import org.junit.jupiter.api.Assertions.assertEquals
+   import org.junit.jupiter.api.Assertions.assertTrue
+   import org.junit.jupiter.api.Test
    ```
 
    Always use `org.junit.jupiter.api.Test` (JUnit 5), never `org.junit.Test`.
 
-4. Build the test fixture:
+3. Build the test fixture. The current project pattern is intentionally minimal — no
+   `TestScope`, no `UnconfinedTestDispatcher`, no `AppCoroutineScope` plumbing. Mock the
+   `<Name>HandlerStore` directly and stub only what the handler actually reads:
 
-   - Construct any collaborators (interactor, mapper, repository) with
-     `mockk<X>(relaxed = true)`.
-   - Build a `TestCoroutineScheduler`, an `UnconfinedTestDispatcher(scheduler)`, and a
-     `TestScope(dispatcher)`.
-   - Build the initial `<Store>.State` and put it inside a `MutableStateFlow`.
-   - Construct a `mockk<<Name>HandlerStore>(relaxed = true)` and stub:
-     - `every { state } returns stateFlow`
-     - `every { scope } returns AppCoroutineScope(testScope, dispatcher, dispatcher)`
-     - For handlers that call `store.launch { ... }`, stub the `launch` overload to actually
-       execute the coroutine. Copy the `every { this@mockk.launch<Any>(...) } answers { ... }`
-       block from `feature/single-training/.../ClickHandlerTest.kt` lines 67-80.
+   ```kotlin
+   private val store = mockk<<Name>HandlerStore>(relaxed = true)
+   private val handler = <Name>ClickHandler(store)
+   ```
 
-5. Construct the handler under test with the mocked store and collaborators.
+   For a handler that mutates state via `updateState { it.copy(...) }`, wire the state
+   flow so the lambda runs:
 
-6. Write **one `@Test` method per `Action` subclass** the handler dispatches. The naming
-   convention used in the codebase: `<actionInWords>_<expectation>()`, for example
-   `clickSave_callsInteractor()` or `clickClose_emitsHapticAndPopsBack()`.
+   ```kotlin
+   private val initialState = State(/* ... */)
+   private val stateFlow = MutableStateFlow(initialState)
+   private val store = mockk<<Name>HandlerStore>(relaxed = true).apply {
+       every { state } returns stateFlow
+       every { updateState(any()) } answers {
+           val update = firstArg<(State) -> State>()
+           stateFlow.value = update(stateFlow.value)
+       }
+   }
+   ```
 
-7. Inside each test:
+   For collaborators (interactor, mapper, repository), use
+   `mockk<X>(relaxed = true)` and stub specific calls with `coEvery { ... } returns ...`
+   (suspend) or `every { ... } returns ...` (plain).
 
-   - Call the handler: `handler.invoke(Action.Click.Save)` (or use `@Test fun foo() = runTest { ... }` if you need to await suspending behavior).
-   - Assert state mutations with `assertEquals(expected, stateFlow.value)`.
-   - Assert events with `verify { store.sendEvent(eq(Event.Haptic)) }`.
-   - Assert collaborator calls with `coVerify { interactor.save(any()) }` (use `coVerify` for
-     suspend functions; `verify` for plain ones).
+4. Construct the handler under test with the mocked store and collaborators.
+
+5. Write **one `@Test` method per `Action` subclass** the handler dispatches. Naming
+   convention used in the codebase (backtick-quoted descriptions, mirroring
+   `SettingsClickHandlerTest`):
+
+   ```kotlin
+   @Test
+   fun `OnArchiveClick emits Haptic ContextClick then consumes OpenArchive`() { /* ... */ }
+   ```
+
+6. Inside each test:
+
+   - Call the handler: `handler.invoke(Action.Click.OnArchiveClick)`. If the handler is
+     suspending, wrap in `runTest { ... }`.
+   - Assert state mutations with `assertEquals(expected, stateFlow.value.<field>)`.
+   - Assert events with a `mutableListOf<Event>()` capture or `slot<Event>()`:
+     ```kotlin
+     val captured = mutableListOf<Event>()
+     verify(exactly = 1) { store.sendEvent(capture(captured)) }
+     assertHaptic(captured.single(), HapticFeedbackType.ContextClick)
+     ```
+     Or for a single emission:
+     ```kotlin
+     val captured = slot<Event>()
+     verify(exactly = 1) { store.sendEvent(capture(captured)) }
+     assertEquals(Event.ShowExternalLink(URL), captured.captured)
+     ```
+   - Assert dispatched actions with `verify { store.consume(eq(Action.Navigation.OpenArchive)) }`.
+   - Assert collaborator calls with `coVerify { interactor.save(any()) }` for suspend
+     functions, `verify` for plain ones.
    - Capture argument shapes with `slot<T>()` when the assertion needs the actual payload.
+   - Pull a small `assertHaptic(event, expected)` private helper (see
+     `SettingsClickHandlerTest.kt:56-59`) when many tests assert on `Event.Haptic` shape.
 
-8. Use `kotlinx.collections.immutable.persistentListOf()` / `persistentSetOf()` for collection
-   literals in the fixture — `State` requires immutable collections.
+7. Use `kotlinx.collections.immutable.persistentListOf()` / `persistentSetOf()` for
+   collection literals in the State fixture — `State` requires immutable collections.
+
+## NavigationHandler test template
+
+The full template, lifted directly from
+`feature/settings/.../SettingsNavigationHandlerTest.kt`:
+
+```kotlin
+package io.github.stslex.workeeper.feature.<name_snake>.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.<name_snake>.mvi.store.<Name>Store.Action
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+internal class NavigationHandlerTest {
+
+    private val navigator = mockk<Navigator>(relaxed = true)
+    private val handler = NavigationHandler(navigator)
+
+    @Test
+    fun `Back triggers popBack`() {
+        handler.invoke(Action.Navigation.Back)
+        verify(exactly = 1) { navigator.popBack() }
+    }
+
+    @Test
+    fun `OpenArchive navigates to Screen Archive`() {
+        handler.invoke(Action.Navigation.OpenArchive)
+        verify(exactly = 1) { navigator.navTo(Screen.Archive) }
+    }
+}
+```
+
+Notes:
+
+- `NavigationHandler` is constructed directly with the mocked `Navigator` — no Hilt graph,
+  no store, no `HandlerStore` mock. The class skips `@Inject` because
+  `MviHandlerConstructorRule` exempts the literal name `NavigationHandler` (see
+  `lint-rules/.../MviHandlerConstructorRule.kt:74`); test instantiation uses the same
+  plain constructor.
+- One `@Test` per `Action.Navigation.<X>` subclass. Each verifies exactly one
+  `navigator.navTo(Screen.<X>)` or `navigator.popBack()` call, with `exactly = 1`.
+- For variants like `SettingsNavigationHandler` that nest under a `*Component` for
+  feature-specific reasons, instantiate with the same plain constructor — the test does
+  not need to know about the `Component` superclass.
 
 ## Verification
 
@@ -100,13 +194,19 @@ Run the full module test task. Targeting a single class also works:
 ## Common pitfalls
 
 - **One action per test.** Do not pack multiple `handler.invoke(...)` calls with different
-  `Action` subtypes into one `@Test`. The reference tests have one assertion thread per case;
-  match that.
-- **Do not mock the `Store` itself.** Mock the `<Name>HandlerStore` (the handler's collaborator).
-  The store is the system under test for `*StoreImpl` tests, never a mock there.
-- **Do not import `org.junit.Test`.** This codebase is on JUnit 5. The Robolectric extension
-  plugin (`robolectric-junit5`) is wired for JVM tests that need Android stubs.
-- **Do not use real dispatchers.** Use `UnconfinedTestDispatcher` and `TestScope`. Real
-  dispatchers will cause flaky waits.
+  `Action` subtypes into one `@Test`. The `feature/settings/` tests have one assertion
+  thread per case; match that.
+- **Do not mock the `Store` itself.** Mock the `<Name>HandlerStore` (the handler's
+  collaborator). The store is the system under test for `*StoreImpl` tests, never a mock
+  there.
+- **Do not import `org.junit.Test`.** This codebase is on JUnit 5. The Robolectric
+  extension plugin (`robolectric-junit5`) is wired for JVM tests that need Android stubs.
+- **Do not stand up `TestScope` / `UnconfinedTestDispatcher` / `AppCoroutineScope`
+  unless the handler under test actually launches coroutines through `store.launch { ... }`.**
+  The current `feature/settings/` tests demonstrate that mocking the `HandlerStore` with
+  `relaxed = true` and stubbing only `state` + `updateState` covers most handler shapes.
+  Reach for the test scheduler stack only when a handler uses `launch { }` or `flow {}`.
 - **Do not assert on private fields.** Drive tests through public `Action` invocations and
-  observe the public `state`/`event` surface.
+  observe the public `state`/`event`/`consume` surface on the mocked HandlerStore.
+- **Do not copy the older 10-line `placeholder() = Unit` stubs.** They mark handlers
+  awaiting a real test pass; the patterns above are what to write in their place.

--- a/.claude/skills/write-ui-test.md
+++ b/.claude/skills/write-ui-test.md
@@ -1,6 +1,6 @@
 ---
 name: write-ui-test
-description: Write a `@Smoke` Compose UI test that drives a feature widget with mocked state, asserts on `testTag`s, and verifies dispatched MVI actions through `ActionCapture`.
+description: Add a `@Smoke` Compose UI test for a feature screen — either a stub with a `TODO(feature-rewrite-tests)` marker (the current default during the v1 rewrite) or a full-fidelity test that drives a widget with mocked state, asserts on `testTag`s, and verifies dispatched MVI actions through `ActionCapture`.
 ---
 
 # Write a UI test
@@ -11,11 +11,29 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
 - "Cover the `<Feature>` widget with Compose tests"
 - "Write a smoke test for X"
 - "Add an accessibility / edge-case test for screen Y"
+- "Stub a `@Smoke` test for the new feature"
+
+## Current state of UI tests in the repo
+
+Every feature module currently has a placeholder `@Smoke` UI test class with no body —
+just `BaseComposeTest` + `createComposeRule()` + a `TODO(feature-rewrite-tests)` (or
+`TODO(feature-rewrite)`) comment. The Stage 3 cleanup left these in place so the modules
+still compile and the `@Smoke` annotation surface is wired, but real assertions are
+deferred until each feature stabilizes during the v1 rewrite. Examples:
+
+- `feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt`
+- `feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt`
+- `feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt`
+- All five `feature/*/src/androidTest/.../*ScreenTest.kt` follow the same shape.
+
+Default: when scaffolding a brand-new feature, ship the **stub** form (see
+[Stub form](#stub-form-default-for-new-features) below). When the feature stabilizes and
+you want real coverage, expand the stub into the [Full form](#full-form-when-the-feature-is-stable).
 
 ## Prerequisites
 
 - The feature module's `build.gradle.kts` already has the test dependencies (mirror
-  `feature/charts/build.gradle.kts`):
+  `feature/settings/build.gradle.kts`):
 
   ```kotlin
   androidTestImplementation(libs.bundles.android.test)
@@ -24,44 +42,80 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
   debugImplementation(libs.androidx.compose.ui.test.manifest)
   ```
 
-- The screen / widget under test exposes its interactive elements via `Modifier.testTag(...)`.
-- `documentation/testing.md` is available for the broader strategy.
+- For full-form tests, the screen / widget under test exposes its interactive elements via
+  `Modifier.testTag(...)`.
+- [documentation/testing.md](../../documentation/testing.md) has the broader strategy.
 
-## Step-by-step
+## Stub form (default for new features)
 
-1. Default to `@Smoke`. Reach for `@Regression` only when the test must drive the real Hilt
-   graph and database via `@HiltAndroidTest` + `createAndroidComposeRule<MainActivity>()`.
-   See [documentation/testing.md](../../documentation/testing.md) for the choice criteria.
+Place the new test under
+`feature/<name>/src/androidTest/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<Name>ScreenTest.kt`.
+Mirror the production package. Lifted directly from
+`feature/settings/.../SettingsScreenTest.kt`:
 
-2. Use these reference tests to copy the structure:
+```kotlin
+package io.github.stslex.workeeper.feature.<name_snake>
 
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt`
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenEdgeCasesTest.kt`
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenAccessibilityTest.kt`
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
+import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Rule
+import org.junit.runner.RunWith
 
-3. Place the new test under
-   `feature/<name>/src/androidTest/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<NameOfTest>.kt`.
-   Mirror the production package.
+@Smoke
+@RunWith(AndroidJUnit4::class)
+class <Name>ScreenTest : BaseComposeTest() {
 
-4. Skeleton:
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // TODO(feature-rewrite-tests): exercise <name> after Stage <X> stabilises.
+}
+```
+
+Notes on the stub:
+
+- The class still extends `BaseComposeTest` and declares `createComposeRule()` so the test
+  surface is wired and the module compiles cleanly with the `@Smoke` annotation
+  filterable from CI.
+- The `TODO(...)` text records what to add and when. Two markers exist in the codebase —
+  `TODO(feature-rewrite-tests)` (newer, used by `feature/settings/`) and
+  `TODO(feature-rewrite)` (older, used by `feature/all-trainings/` etc.). Either is fine;
+  the new convention is `TODO(feature-rewrite-tests)`.
+- No `@Test` methods are required for the stub. The class compiles and is picked up by the
+  `@Smoke` filter as a no-op.
+
+## Full form (when the feature is stable)
+
+When the feature is no longer in active rewrite, expand the stub into a fully-asserting
+smoke test. There are no current full-form examples in the repo (all real tests are in the
+handler-test layer), so the template below is derived from `BaseComposeTest` and the
+test-utils helpers in `core/ui/test-utils/`.
+
+1. Default to `@Smoke`. Reach for `@Regression` only when the test must drive the real
+   Hilt graph and database via `@HiltAndroidTest` + `createAndroidComposeRule<MainActivity>()`.
+   See [documentation/testing.md → Choosing a category](../../documentation/testing.md#choosing-a-category).
+
+2. Use this skeleton for a screen that participates in shared element transitions:
 
    ```kotlin
    @Smoke
    @RunWith(AndroidJUnit4::class)
    @SuppressLint("UnusedContentLambdaTargetStateParameter")
-   internal class <Feature>ScreenTest : BaseComposeTest() {
+   internal class <Name>ScreenTest : BaseComposeTest() {
 
        @get:Rule
        val composeRule = createComposeRule()
 
        @Test
        fun <feature>_<scenario>_<expectation>() {
-           val state = <Feature>Store.State.INITIAL.copy(/* ... */)
-           val actionCapture = createActionCapture<<Feature>Store.Action>()
+           val state = <Name>Store.State.INITIAL.copy(/* ... */)
+           val actionCapture = createActionCapture<<Name>Store.Action>()
 
            composeRule.mainClock.autoAdvance = false
            composeRule.setTransitionContent { animatedContentScope, modifier ->
-               <Feature>Widget(
+               <Name>Widget(
                    state = state,
                    modifier = modifier,
                    consume = actionCapture,
@@ -73,28 +127,34 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
            composeRule.mainClock.advanceTimeBy(100)
            composeRule.waitForIdle()
 
-           composeRule.onNodeWithTag("<Feature>Button").performClick()
+           composeRule.onNodeWithTag("<Name>Button").performClick()
 
-           actionCapture.capturedFirst<<Feature>Store.Action.Click.<...>>()
+           actionCapture.capturedFirst<<Name>Store.Action.Click.<...>>()
        }
    }
    ```
 
-   Key methods come from `core/ui/test-utils/.../BaseComposeTest.kt`:
+   For screens without shared element transitions (e.g. Settings / Archive), drop the
+   `setTransitionContent` wrapper and call `composeRule.setContent { ... }` with the
+   screen composable directly.
+
+3. Helpers from `core/ui/test-utils/.../BaseComposeTest.kt`:
 
    - `setTransitionContent { animatedContentScope, modifier -> ... }` wraps the widget in
      `SharedTransitionScope` + `AnimatedContent`, so widgets expecting
-     `sharedTransitionScope` and `animatedContentScope` parameters work without standing up
-     `AppNavigationHost`.
-   - `createActionCapture<Action>()` returns an `ActionCapture<Action>` you can pass directly as
-     the `consume` callback. Inspection helpers: `assertCaptured<A>()`, `capturedFirst<A>()`,
-     `capturedLast<A>()`, `assertCapturedExactly(action)`, `assertCapturedCount<A>(n)`,
+     `sharedTransitionScope` and `animatedContentScope` parameters work without standing
+     up `AppNavigationHost`.
+   - `createActionCapture<Action>()` returns an `ActionCapture<Action>` you can pass
+     directly as the `consume` callback. Inspection helpers:
+     `assertCaptured<A>()`, `captured<A>()`, `capturedFirst<A>()`, `capturedLast<A>()`,
+     `assertCapturedExactly(action)`, `assertCapturedCount<A>(n)`,
      `assertCapturedOnce<A>()`, `clear()`, `getAll()`.
 
-5. Use the test-utils helpers for data and inputs:
+4. Helpers for data and inputs:
 
-   - **Paging** state: `PagingTestUtils.createPagingFlow(items)` or
-     `PagingTestUtils.createEmptyPagingFlow()`. For error scenarios use
+   - **Paging** state: `PagingTestUtils.createPagingFlow(items)` /
+     `PagingTestUtils.createEmptyPagingFlow()` /
+     `PagingTestUtils.createErrorPagingFlow()`. For richer error scenarios:
      `PagingTestUtils.TestPagingSource(items, shouldFail = true, errorMessage = "...")`.
    - **Mock data**: `MockDataFactory.createUuids(count)`,
      `MockDataFactory.createTestNames(prefix, count)`,
@@ -102,7 +162,7 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
    - **Text input**: `composeRule.onNodeWithTag("...").performTextReplacement("new value")`
      (clears + types in one call).
 
-6. Test-tag conventions (must match what the production widget sets):
+5. Test-tag conventions (must match what the production widget sets):
 
    - Screen-level: `"<Feature>Screen"`.
    - Widget root: `"<Feature>Widget"`.
@@ -110,14 +170,16 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
    - List: `"<Feature>List"`. List item: `"<Feature>Item_${item.uuid}"`.
    - Dialog: `"<Feature>Dialog"`.
 
-   If the production widget is missing a needed tag, add it via `Modifier.testTag(...)` —
-   do not work around with positional finders.
+   If the production widget is missing a needed tag, add it via `Modifier.testTag(...)`
+   — do not work around with positional finders.
 
-7. Cover the obvious cases first (basic render, primary click, primary input). Extend with edge
-   cases (empty state, very long text, special characters, large lists, rapid clicks) and
-   accessibility checks (`assertHasClickAction()`, focus / semantics) in separate test classes
-   when there are enough of them, mirroring the all-exercises split into
-   `<...>ScreenTest`, `<...>ScreenEdgeCasesTest`, `<...>ScreenAccessibilityTest`.
+6. Cover the obvious cases first (basic render, primary click, primary input). Extend with
+   edge cases (empty state, very long text, special characters, large lists, rapid clicks)
+   and accessibility checks (`assertHasClickAction()`, focus / semantics) in separate test
+   classes when there are enough of them, mirroring the all-exercises naming split into
+   `<Name>ScreenTest`, `<Name>ScreenEdgeCasesTest`, `<Name>ScreenAccessibilityTest`. Note
+   that those split files currently also exist as 18-line stubs — the naming pattern is
+   what to mirror, not the bodies.
 
 ## Verification
 
@@ -131,14 +193,16 @@ Reports land at `feature/<name>/build/reports/androidTests/connected/index.html`
 
 ## Common pitfalls
 
-- **Never combine `@Smoke` with `@HiltAndroidTest`.** Smoke tests do not stand up a real DI
-  graph. Use `createComposeRule()`, not `createAndroidComposeRule<MainActivity>()`.
-- **Do not use real repositories or the database.** All collaborators are mocked or fed via
-  `State`. Real DI belongs in `@Regression` tests only.
+- **Never combine `@Smoke` with `@HiltAndroidTest`.** Smoke tests do not stand up a real
+  DI graph. Use `createComposeRule()`, not `createAndroidComposeRule<MainActivity>()`.
+- **Do not use real repositories or the database.** All collaborators are mocked or fed
+  via `State`. Real DI belongs in `@Regression` tests only.
+- **Do not delete an existing stub when scaffolding a new feature** — the stub is the
+  intended scaffold. Replace it with the full form when the feature stabilizes.
 - **Do not skip `composeRule.mainClock.advanceTimeBy(100)` + `waitForIdle()`** after
-  `setTransitionContent`. The shared-transition wrapper schedules animations, and the assertion
-  may run before composition settles.
-- **Do not assert on positional `onChildAt(...)` finders.** Use `testTag` / `onNodeWithText`
-  finders so the test does not break when layout changes.
-- **Do not use `org.junit.jupiter.api.Test`** in instrumented tests. UI tests use AndroidX's
-  JUnit 4 runner: `org.junit.Test`, `@RunWith(AndroidJUnit4::class)`.
+  `setTransitionContent`. The shared-transition wrapper schedules animations, and the
+  assertion may run before composition settles.
+- **Do not assert on positional `onChildAt(...)` finders.** Use `testTag` /
+  `onNodeWithText` finders so the test does not break when layout changes.
+- **Do not use `org.junit.jupiter.api.Test`** in instrumented tests. UI tests use
+  AndroidX's JUnit 4 runner: `org.junit.Test`, `@RunWith(AndroidJUnit4::class)`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,674 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-   1. Definitions.
+                            Preamble
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+                       TERMS AND CONDITIONS
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  0. Definitions.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  "This License" refers to version 3 of the GNU General Public License.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  1. Source Code.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   END OF TERMS AND CONDITIONS
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-   APPENDIX: How to apply the Apache License to your work.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-   Copyright 2025 Ilya Stepanyuk
+  The Corresponding Source for a work in source code form is that
+same work.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  2. Basic Permissions.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,5 @@
 [![Android CI/CD](https://github.com/stslex/Workeeper/actions/workflows/android_build_unified.yml/badge.svg)](https://github.com/stslex/Workeeper/actions/workflows/android_build_unified.yml)
+[![License: GPLv3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 
 <div align="center">
 
@@ -92,4 +93,5 @@ in CI; see [documentation/testing.md](documentation/testing.md) and
 
 ## License
 
-This project is licensed under the terms of the [LICENSE](LICENSE) file.
+This project is licensed under the GNU General Public License v3.0. See the
+[LICENSE](LICENSE) file for the full text.

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":feature:charts"))
     implementation(project(":feature:all-exercises"))
     implementation(project(":feature:single-training"))
+    implementation(project(":feature:settings"))
 
     implementation(platform(libs.google.firebase.bom))
     implementation(libs.google.firebase.analytics)

--- a/app/app/src/main/java/io/github/stslex/workeeper/App.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/App.kt
@@ -11,6 +11,12 @@ import androidx.compose.animation.slideOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -19,19 +25,24 @@ import androidx.compose.material3.SnackbarResult.Dismissed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import io.github.stslex.workeeper.bottom_app_bar.WorkeeperBottomAppBar
 import io.github.stslex.workeeper.core.ui.kit.components.snackbar.AppSnackbar
 import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.navigation.LocalNavigator
 import io.github.stslex.workeeper.core.ui.navigation.LocalRootComponent
+import io.github.stslex.workeeper.core.ui.navigation.Screen
 import io.github.stslex.workeeper.host.AppNavigationHost
 import io.github.stslex.workeeper.host.NavHostControllerHolder.Companion.rememberNavHostControllerHolder
 import io.github.stslex.workeeper.navigation.NavigatorImpl
@@ -39,7 +50,9 @@ import io.github.stslex.workeeper.navigation.RootComponentImpl
 
 @Composable
 fun App() {
-    AppTheme {
+    val rootViewModel: AppRootViewModel = hiltViewModel()
+    val themeMode by rootViewModel.themeMode.collectAsState()
+    AppTheme(themeMode = themeMode) {
         val navigatorHolder = rememberNavHostControllerHolder()
         val navigator = remember(navigatorHolder) { NavigatorImpl(navigatorHolder) }
         val rootComponent = remember(navigator) { RootComponentImpl(navigator) }
@@ -104,6 +117,28 @@ fun App() {
                     modifier = Modifier,
                     navigator = navigator,
                 )
+
+                AnimatedVisibility(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .systemBarsPadding()
+                        .padding(end = AppDimension.screenEdge)
+                        .zIndex(1f),
+                    visible = navigatorHolder.bottomBarDestination.value != null,
+                    enter = fadeIn(tween(AppUi.motion.deliberate)),
+                    exit = fadeOut(tween(AppUi.motion.deliberate)),
+                ) {
+                    IconButton(
+                        modifier = Modifier.testTag("AppSettingsEntry"),
+                        onClick = { navigator.navTo(Screen.Settings) },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = "Settings",
+                            tint = AppUi.colors.textPrimary,
+                        )
+                    }
+                }
 
                 SnackbarHost(
                     modifier = Modifier.align(Alignment.BottomCenter),

--- a/app/app/src/main/java/io/github/stslex/workeeper/AppRootViewModel.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/AppRootViewModel.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.stslex.workeeper.core.dataStore.store.CommonDataStore
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+internal class AppRootViewModel @Inject constructor(
+    commonDataStore: CommonDataStore,
+) : ViewModel() {
+
+    val themeMode: StateFlow<ThemeMode> = commonDataStore.themePreference
+        .map { value -> runCatching { ThemeMode.valueOf(value) }.getOrDefault(ThemeMode.SYSTEM) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ThemeMode.SYSTEM,
+        )
+}

--- a/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
@@ -18,6 +18,8 @@ import io.github.stslex.workeeper.feature.all_exercises.ui.allExercisesGraph
 import io.github.stslex.workeeper.feature.all_trainings.ui.allTrainingsGraph
 import io.github.stslex.workeeper.feature.charts.ui.chartsGraph
 import io.github.stslex.workeeper.feature.exercise.ui.exerciseGraph
+import io.github.stslex.workeeper.feature.settings.ui.archiveGraph
+import io.github.stslex.workeeper.feature.settings.ui.settingsGraph
 import io.github.stslex.workeeper.feature.single_training.ui.singleTrainingsGraph
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -63,6 +65,12 @@ internal fun AppNavigationHost(
                 modifier = Modifier
                     .testTag("ExerciseGraph"),
                 sharedTransitionScope = this@SharedTransitionLayout,
+            )
+            settingsGraph(
+                modifier = Modifier.testTag("SettingsGraph"),
+            )
+            archiveGraph(
+                modifier = Modifier.testTag("ArchiveGraph"),
             )
         }
     }

--- a/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
@@ -8,6 +8,8 @@ import io.github.stslex.workeeper.feature.all_exercises.mvi.handler.AllExerciseC
 import io.github.stslex.workeeper.feature.all_trainings.mvi.handler.AllTrainingsComponent
 import io.github.stslex.workeeper.feature.charts.mvi.handler.ChartsComponent
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.handler.ExerciseComponent
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveComponent
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsComponent
 import io.github.stslex.workeeper.feature.single_training.ui.mvi.handler.SingleTrainingComponent
 
 class RootComponentImpl(
@@ -22,5 +24,7 @@ class RootComponentImpl(
         Screen.BottomBar.Charts -> ChartsComponent.create(navigator)
         is Screen.Exercise -> ExerciseComponent.create(navigator, screen)
         is Screen.Training -> SingleTrainingComponent.create(navigator, screen)
+        Screen.Settings -> SettingsComponent.create(navigator)
+        Screen.Archive -> ArchiveComponent.create(navigator)
     }
 }

--- a/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/core/BaseDataStore.kt
+++ b/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/core/BaseDataStore.kt
@@ -2,6 +2,7 @@ package io.github.stslex.workeeper.core.dataStore.core
 
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.stslex.workeeper.core.core.logger.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -20,6 +21,17 @@ open class BaseDataStore internal constructor(
         logger.i("Update key: $key with value: $value")
         storeProvider.dataStore.edit { prefs ->
             prefs[longPreferencesKey(key)] = value
+        }
+    }
+
+    fun getString(key: String, default: String): Flow<String> = storeProvider.dataStore.data.map { prefs ->
+        prefs[stringPreferencesKey(key)] ?: default
+    }
+
+    suspend fun updateString(key: String, value: String) {
+        logger.i("Update key: $key with value: $value")
+        storeProvider.dataStore.edit { prefs ->
+            prefs[stringPreferencesKey(key)] = value
         }
     }
 }

--- a/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/store/CommonDataStore.kt
+++ b/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/store/CommonDataStore.kt
@@ -8,7 +8,11 @@ interface CommonDataStore {
 
     val homeSelectedEndDate: Flow<Long?>
 
+    val themePreference: Flow<String>
+
     suspend fun setHomeSelectedStartDate(value: Long)
 
     suspend fun setHomeSelectedEndDate(value: Long)
+
+    suspend fun setThemePreference(value: String)
 }

--- a/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/store/CommonDataStoreImpl.kt
+++ b/core/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/dataStore/store/CommonDataStoreImpl.kt
@@ -17,6 +17,8 @@ class CommonDataStoreImpl @Inject internal constructor(
 
     override var homeSelectedEndDate: Flow<Long?> = getLong(KEY_HOME_SELECTED_END_DATE)
 
+    override val themePreference: Flow<String> = getString(KEY_THEME_PREFERENCE, DEFAULT_THEME)
+
     override suspend fun setHomeSelectedStartDate(value: Long) {
         updateLong(KEY_HOME_SELECTED_START_DATE, value)
     }
@@ -25,10 +27,16 @@ class CommonDataStoreImpl @Inject internal constructor(
         updateLong(KEY_HOME_SELECTED_END_DATE, value)
     }
 
+    override suspend fun setThemePreference(value: String) {
+        updateString(KEY_THEME_PREFERENCE, value)
+    }
+
     private companion object {
 
         const val KEY_HOME_SELECTED_START_DATE = "home_selected_start_date"
         const val KEY_HOME_SELECTED_END_DATE = "home_selected_end_date"
+        const val KEY_THEME_PREFERENCE = "theme_preference"
+        const val DEFAULT_THEME = "SYSTEM"
         const val NAME = "common_prefs"
     }
 }

--- a/core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/4.json
+++ b/core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/4.json
@@ -1,0 +1,645 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f33cc3bd4fa8aa878ad36e624d6274b6",
+    "entities": [
+      {
+        "tableName": "training_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `is_adhoc` INTEGER NOT NULL DEFAULT 0, `archived` INTEGER NOT NULL DEFAULT 0, `created_at` INTEGER NOT NULL, `archived_at` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdhoc",
+            "columnName": "is_adhoc",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_training_table_is_adhoc_archived_name",
+            "unique": false,
+            "columnNames": [
+              "is_adhoc",
+              "archived",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_training_table_is_adhoc_archived_name` ON `${TABLE_NAME}` (`is_adhoc`, `archived`, `name`)"
+          },
+          {
+            "name": "index_training_table_archived",
+            "unique": false,
+            "columnNames": [
+              "archived"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_training_table_archived` ON `${TABLE_NAME}` (`archived`)"
+          }
+        ]
+      },
+      {
+        "tableName": "training_exercise_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`training_uuid` TEXT NOT NULL, `exercise_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`training_uuid`, `exercise_uuid`), FOREIGN KEY(`training_uuid`) REFERENCES `training_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exercise_uuid`) REFERENCES `exercise_table`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "trainingUuid",
+            "columnName": "training_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseUuid",
+            "columnName": "exercise_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "training_uuid",
+            "exercise_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_training_exercise_table_exercise_uuid",
+            "unique": false,
+            "columnNames": [
+              "exercise_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_training_exercise_table_exercise_uuid` ON `${TABLE_NAME}` (`exercise_uuid`)"
+          },
+          {
+            "name": "index_training_exercise_table_training_uuid_position",
+            "unique": false,
+            "columnNames": [
+              "training_uuid",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_training_exercise_table_training_uuid_position` ON `${TABLE_NAME}` (`training_uuid`, `position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "training_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "training_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "exercise_table",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exercise_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "exercise_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `description` TEXT, `image_path` TEXT, `archived` INTEGER NOT NULL DEFAULT 0, `created_at` INTEGER NOT NULL, `archived_at` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archived_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exercise_table_archived_name",
+            "unique": false,
+            "columnNames": [
+              "archived",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercise_table_archived_name` ON `${TABLE_NAME}` (`archived`, `name`)"
+          },
+          {
+            "name": "index_exercise_table_archived",
+            "unique": false,
+            "columnNames": [
+              "archived"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercise_table_archived` ON `${TABLE_NAME}` (`archived`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `training_uuid` TEXT NOT NULL, `state` TEXT NOT NULL, `started_at` INTEGER NOT NULL, `finished_at` INTEGER, PRIMARY KEY(`uuid`), FOREIGN KEY(`training_uuid`) REFERENCES `training_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trainingUuid",
+            "columnName": "training_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finished_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_table_training_uuid_finished_at",
+            "unique": false,
+            "columnNames": [
+              "training_uuid",
+              "finished_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_table_training_uuid_finished_at` ON `${TABLE_NAME}` (`training_uuid`, `finished_at`)"
+          },
+          {
+            "name": "index_session_table_state",
+            "unique": false,
+            "columnNames": [
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_table_state` ON `${TABLE_NAME}` (`state`)"
+          },
+          {
+            "name": "index_session_table_finished_at",
+            "unique": false,
+            "columnNames": [
+              "finished_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_table_finished_at` ON `${TABLE_NAME}` (`finished_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "training_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "training_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "performed_exercise_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `session_uuid` TEXT NOT NULL, `exercise_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `skipped` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`uuid`), FOREIGN KEY(`session_uuid`) REFERENCES `session_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exercise_uuid`) REFERENCES `exercise_table`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionUuid",
+            "columnName": "session_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseUuid",
+            "columnName": "exercise_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipped",
+            "columnName": "skipped",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_performed_exercise_table_session_uuid_position",
+            "unique": false,
+            "columnNames": [
+              "session_uuid",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_performed_exercise_table_session_uuid_position` ON `${TABLE_NAME}` (`session_uuid`, `position`)"
+          },
+          {
+            "name": "index_performed_exercise_table_exercise_uuid",
+            "unique": false,
+            "columnNames": [
+              "exercise_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_performed_exercise_table_exercise_uuid` ON `${TABLE_NAME}` (`exercise_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "exercise_table",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exercise_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `performed_exercise_uuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `reps` INTEGER NOT NULL, `weight` REAL, `type` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`performed_exercise_uuid`) REFERENCES `performed_exercise_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "performedExerciseUuid",
+            "columnName": "performed_exercise_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_set_table_performed_exercise_uuid_position",
+            "unique": false,
+            "columnNames": [
+              "performed_exercise_uuid",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_set_table_performed_exercise_uuid_position` ON `${TABLE_NAME}` (`performed_exercise_uuid`, `position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "performed_exercise_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "performed_exercise_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tag_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL COLLATE NOCASE, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tag_table_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tag_table_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "exercise_tag_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`exercise_uuid` TEXT NOT NULL, `tag_uuid` TEXT NOT NULL, PRIMARY KEY(`exercise_uuid`, `tag_uuid`), FOREIGN KEY(`exercise_uuid`) REFERENCES `exercise_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_uuid`) REFERENCES `tag_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "exerciseUuid",
+            "columnName": "exercise_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagUuid",
+            "columnName": "tag_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "exercise_uuid",
+            "tag_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exercise_tag_table_tag_uuid_exercise_uuid",
+            "unique": false,
+            "columnNames": [
+              "tag_uuid",
+              "exercise_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercise_tag_table_tag_uuid_exercise_uuid` ON `${TABLE_NAME}` (`tag_uuid`, `exercise_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "exercise_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exercise_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "tag_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "training_tag_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`training_uuid` TEXT NOT NULL, `tag_uuid` TEXT NOT NULL, PRIMARY KEY(`training_uuid`, `tag_uuid`), FOREIGN KEY(`training_uuid`) REFERENCES `training_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tag_uuid`) REFERENCES `tag_table`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trainingUuid",
+            "columnName": "training_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagUuid",
+            "columnName": "tag_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "training_uuid",
+            "tag_uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_training_tag_table_tag_uuid_training_uuid",
+            "unique": false,
+            "columnNames": [
+              "tag_uuid",
+              "training_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_training_tag_table_tag_uuid_training_uuid` ON `${TABLE_NAME}` (`tag_uuid`, `training_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "training_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "training_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "tag_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f33cc3bd4fa8aa878ad36e624d6274b6')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt
@@ -35,7 +35,7 @@ import io.github.stslex.workeeper.core.database.training.TrainingExerciseEntity
         ExerciseTagEntity::class,
         TrainingTagEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(UuidConverter::class)

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object CoreDatabaseModule {
 
+    @Suppress("MagicNumber")
     @Provides
     @Singleton
     fun provideAppDatabase(
@@ -32,7 +33,7 @@ object CoreDatabaseModule {
         AppDatabase::class.java,
         AppDatabase.Companion.NAME,
     )
-        .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2)
+        .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3)
         .build()
 
     @Provides

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/exercise/ExerciseDao.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/exercise/ExerciseDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
 @Dao
@@ -27,6 +28,9 @@ interface ExerciseDao {
     @Query("SELECT * FROM exercise_table WHERE archived = 1 ORDER BY name COLLATE NOCASE ASC")
     fun pagedArchived(): PagingSource<Int, ExerciseEntity>
 
+    @Query("SELECT COUNT(*) FROM exercise_table WHERE archived = 1")
+    fun observeArchivedCount(): Flow<Int>
+
     @Query("SELECT * FROM exercise_table WHERE uuid = :uuid")
     suspend fun getById(uuid: Uuid): ExerciseEntity?
 
@@ -39,10 +43,10 @@ interface ExerciseDao {
     @Update
     suspend fun update(exercise: ExerciseEntity)
 
-    @Query("UPDATE exercise_table SET archived = 1 WHERE uuid = :uuid")
-    suspend fun archive(uuid: Uuid)
+    @Query("UPDATE exercise_table SET archived = 1, archived_at = :archivedAt WHERE uuid = :uuid")
+    suspend fun archive(uuid: Uuid, archivedAt: Long)
 
-    @Query("UPDATE exercise_table SET archived = 0 WHERE uuid = :uuid")
+    @Query("UPDATE exercise_table SET archived = 0, archived_at = NULL WHERE uuid = :uuid")
     suspend fun restore(uuid: Uuid)
 
     @Query("DELETE FROM exercise_table WHERE uuid = :uuid")

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/exercise/ExerciseEntity.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/exercise/ExerciseEntity.kt
@@ -29,4 +29,6 @@ data class ExerciseEntity(
     val archived: Boolean,
     @ColumnInfo(name = "created_at")
     val createdAt: Long,
+    @ColumnInfo(name = "archived_at")
+    val archivedAt: Long?,
 )

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/SessionDao.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/SessionDao.kt
@@ -48,6 +48,23 @@ interface SessionDao {
     @Query("SELECT * FROM session_table WHERE uuid = :uuid")
     suspend fun getById(uuid: Uuid): SessionEntity?
 
+    @Query(
+        """
+        SELECT COUNT(*) FROM session_table
+        WHERE training_uuid = :trainingUuid AND state = 'FINISHED'
+        """,
+    )
+    suspend fun countFinishedByTraining(trainingUuid: Uuid): Int
+
+    @Query(
+        """
+        SELECT COUNT(DISTINCT pe.session_uuid) FROM performed_exercise_table pe
+        JOIN session_table s ON s.uuid = pe.session_uuid
+        WHERE pe.exercise_uuid = :exerciseUuid AND s.state = 'FINISHED'
+        """,
+    )
+    suspend fun countFinishedContainingExercise(exerciseUuid: Uuid): Int
+
     @Insert
     suspend fun insert(session: SessionEntity)
 

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingDao.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingDao.kt
@@ -34,6 +34,9 @@ interface TrainingDao {
     @Query("SELECT * FROM training_table WHERE archived = 1 ORDER BY name COLLATE NOCASE ASC")
     fun pagedArchived(): PagingSource<Int, TrainingEntity>
 
+    @Query("SELECT COUNT(*) FROM training_table WHERE archived = 1")
+    fun observeArchivedCount(): Flow<Int>
+
     @Query("SELECT * FROM training_table WHERE uuid = :uuid")
     suspend fun getById(uuid: Uuid): TrainingEntity?
 
@@ -46,10 +49,10 @@ interface TrainingDao {
     @Update
     suspend fun update(training: TrainingEntity)
 
-    @Query("UPDATE training_table SET archived = 1 WHERE uuid = :uuid")
-    suspend fun archive(uuid: Uuid)
+    @Query("UPDATE training_table SET archived = 1, archived_at = :archivedAt WHERE uuid = :uuid")
+    suspend fun archive(uuid: Uuid, archivedAt: Long)
 
-    @Query("UPDATE training_table SET archived = 0 WHERE uuid = :uuid")
+    @Query("UPDATE training_table SET archived = 0, archived_at = NULL WHERE uuid = :uuid")
     suspend fun restore(uuid: Uuid)
 
     @Query("DELETE FROM training_table WHERE uuid = :uuid")

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingEntity.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingEntity.kt
@@ -27,4 +27,6 @@ data class TrainingEntity(
     val archived: Boolean,
     @ColumnInfo(name = "created_at")
     val createdAt: Long,
+    @ColumnInfo(name = "archived_at")
+    val archivedAt: Long?,
 )

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepository.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepository.kt
@@ -6,6 +6,7 @@ import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseDataModel
 import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
+@Suppress("TooManyFunctions")
 interface ExerciseRepository {
 
     val exercises: Flow<PagingData<ExerciseDataModel>>
@@ -35,4 +36,10 @@ interface ExerciseRepository {
     suspend fun permanentDelete(uuid: String)
 
     suspend fun canArchive(uuid: String): Boolean
+
+    fun pagedArchived(): Flow<PagingData<ExerciseDataModel>>
+
+    fun observeArchivedCount(): Flow<Int>
+
+    suspend fun countSessionsUsing(exerciseUuid: String): Int
 }

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepositoryImpl.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.database.exercise.ExerciseDao
+import io.github.stslex.workeeper.core.database.session.SessionDao
 import io.github.stslex.workeeper.core.database.tag.ExerciseTagDao
 import io.github.stslex.workeeper.core.database.tag.ExerciseTagEntity
 import io.github.stslex.workeeper.core.database.tag.TagDao
@@ -30,6 +31,7 @@ internal class ExerciseRepositoryImpl @Inject constructor(
     private val tagDao: TagDao,
     private val exerciseTagDao: ExerciseTagDao,
     private val trainingExerciseDao: TrainingExerciseDao,
+    private val sessionDao: SessionDao,
     @IODispatcher private val bgDispatcher: CoroutineDispatcher,
 ) : ExerciseRepository {
 
@@ -105,7 +107,7 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun archive(uuid: String) {
         withContext(bgDispatcher) {
-            dao.archive(Uuid.parse(uuid))
+            dao.archive(Uuid.parse(uuid), System.currentTimeMillis())
         }
     }
 
@@ -123,6 +125,24 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun canArchive(uuid: String): Boolean = withContext(bgDispatcher) {
         trainingExerciseDao.countActiveTemplatesUsing(Uuid.parse(uuid)) == 0
+    }
+
+    override fun pagedArchived(): Flow<PagingData<ExerciseDataModel>> = Pager(
+        config = pagingConfig,
+        pagingSourceFactory = dao::pagedArchived,
+    ).flow
+        .map { pagingData ->
+            pagingData.map { entity -> entity.toData(labels = loadLabels(entity.uuid)) }
+        }
+        .flowOn(bgDispatcher)
+
+    override fun observeArchivedCount(): Flow<Int> = dao.observeArchivedCount()
+        .flowOn(bgDispatcher)
+
+    override suspend fun countSessionsUsing(
+        exerciseUuid: String,
+    ): Int = withContext(bgDispatcher) {
+        sessionDao.countFinishedContainingExercise(Uuid.parse(exerciseUuid))
     }
 
     private suspend fun loadLabels(exerciseUuid: Uuid): List<String> =

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/model/ExerciseChangeDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/model/ExerciseChangeDataModel.kt
@@ -26,4 +26,5 @@ internal fun ExerciseChangeDataModel.toEntity(): ExerciseEntity = ExerciseEntity
     imagePath = imagePath,
     archived = archived,
     createdAt = timestamp,
+    archivedAt = null,
 )

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/model/ExerciseDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/model/ExerciseDataModel.kt
@@ -11,6 +11,7 @@ data class ExerciseDataModel(
     val description: String? = null,
     val imagePath: String? = null,
     val archived: Boolean = false,
+    val archivedAt: Long? = null,
     val timestamp: Long,
     // legacy v2 fields, retained for feature compatibility during v3 transition.
     // `trainingUuid` is not modelled in v3 (exercises are library items, not training-bound).
@@ -30,6 +31,7 @@ internal fun ExerciseEntity.toData(
     description = description,
     imagePath = imagePath,
     archived = archived,
+    archivedAt = archivedAt,
     timestamp = createdAt,
     labels = labels,
 )
@@ -42,4 +44,5 @@ internal fun ExerciseDataModel.toEntity(): ExerciseEntity = ExerciseEntity(
     imagePath = imagePath,
     archived = archived,
     createdAt = timestamp,
+    archivedAt = archivedAt,
 )

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingChangeDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingChangeDataModel.kt
@@ -22,4 +22,5 @@ internal fun TrainingChangeDataModel.toEntity(): TrainingEntity = TrainingEntity
     isAdhoc = isAdhoc,
     archived = archived,
     createdAt = timestamp,
+    archivedAt = null,
 )

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingDataModel.kt
@@ -9,6 +9,7 @@ data class TrainingDataModel(
     val description: String? = null,
     val isAdhoc: Boolean = false,
     val archived: Boolean = false,
+    val archivedAt: Long? = null,
     val timestamp: Long,
     val labels: List<String> = emptyList(),
     val exerciseUuids: List<String> = emptyList(),
@@ -23,6 +24,7 @@ internal fun TrainingEntity.toData(
     description = description,
     isAdhoc = isAdhoc,
     archived = archived,
+    archivedAt = archivedAt,
     timestamp = createdAt,
     labels = labels,
     exerciseUuids = exerciseUuids,
@@ -35,6 +37,7 @@ internal fun TrainingDataModel.toEntity(): TrainingEntity = TrainingEntity(
     isAdhoc = isAdhoc,
     archived = archived,
     createdAt = timestamp,
+    archivedAt = archivedAt,
 )
 
 fun TrainingDataModel.toChangeModel(): TrainingChangeDataModel = TrainingChangeDataModel(

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepository.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepository.kt
@@ -3,6 +3,7 @@ package io.github.stslex.workeeper.core.exercise.training
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 interface TrainingRepository {
 
     fun getTrainings(query: String): Flow<PagingData<TrainingDataModel>>
@@ -28,4 +29,10 @@ interface TrainingRepository {
     suspend fun restore(uuid: String)
 
     suspend fun permanentDelete(uuid: String)
+
+    fun pagedArchived(): Flow<PagingData<TrainingDataModel>>
+
+    fun observeArchivedCount(): Flow<Int>
+
+    suspend fun countSessionsUsing(trainingUuid: String): Int
 }

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepositoryImpl.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.database.session.SessionDao
 import io.github.stslex.workeeper.core.database.tag.TagDao
 import io.github.stslex.workeeper.core.database.tag.TagEntity
 import io.github.stslex.workeeper.core.database.tag.TrainingTagDao
@@ -27,6 +28,7 @@ class TrainingRepositoryImpl @Inject constructor(
     private val trainingExerciseDao: TrainingExerciseDao,
     private val tagDao: TagDao,
     private val trainingTagDao: TrainingTagDao,
+    private val sessionDao: SessionDao,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : TrainingRepository {
 
@@ -106,7 +108,7 @@ class TrainingRepositoryImpl @Inject constructor(
 
     override suspend fun archive(uuid: String) {
         withContext(ioDispatcher) {
-            dao.archive(Uuid.parse(uuid))
+            dao.archive(Uuid.parse(uuid), System.currentTimeMillis())
         }
     }
 
@@ -120,6 +122,29 @@ class TrainingRepositoryImpl @Inject constructor(
         withContext(ioDispatcher) {
             dao.permanentDelete(Uuid.parse(uuid))
         }
+    }
+
+    override fun pagedArchived(): Flow<PagingData<TrainingDataModel>> = Pager(
+        config = pagingConfig,
+        pagingSourceFactory = dao::pagedArchived,
+    ).flow
+        .map { pagingData ->
+            pagingData.map { entity ->
+                entity.toData(
+                    labels = trainingTagDao.getTagNames(entity.uuid),
+                    exerciseUuids = trainingExerciseDao.getByTraining(entity.uuid).map { it.exerciseUuid.toString() },
+                )
+            }
+        }
+        .flowOn(ioDispatcher)
+
+    override fun observeArchivedCount(): Flow<Int> = dao.observeArchivedCount()
+        .flowOn(ioDispatcher)
+
+    override suspend fun countSessionsUsing(
+        trainingUuid: String,
+    ): Int = withContext(ioDispatcher) {
+        sessionDao.countFinishedByTraining(Uuid.parse(trainingUuid))
     }
 
     private suspend fun syncLabels(trainingUuid: Uuid, labels: List<String>) {

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppConfirmDialog.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppConfirmDialog.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
+import io.github.stslex.workeeper.core.ui.kit.R
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
@@ -28,8 +30,10 @@ fun AppConfirmDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    dismissLabel: String? = null,
 ) {
     val dialogBg = if (AppUi.colors.isDark) AppUi.colors.surfaceTier1 else AppUi.colors.surfaceTier2
+    val resolvedDismissLabel = dismissLabel ?: stringResource(R.string.core_ui_kit_action_cancel)
     Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = modifier
@@ -66,7 +70,7 @@ fun AppConfirmDialog(
                 ),
             ) {
                 AppButton.Primary(
-                    text = "Cancel",
+                    text = resolvedDismissLabel,
                     onClick = onDismiss,
                     size = AppButtonSize.MEDIUM,
                 )

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppDialog.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppDialog.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
+import io.github.stslex.workeeper.core.ui.kit.R
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
@@ -31,6 +33,7 @@ fun AppDialog(
     destructive: Boolean = false,
 ) {
     val dialogBg = if (AppUi.colors.isDark) AppUi.colors.surfaceTier1 else AppUi.colors.surfaceTier2
+    val resolvedDismissLabel = dismissLabel ?: stringResource(R.string.core_ui_kit_action_cancel)
     Dialog(onDismissRequest = { onDismiss?.invoke() }) {
         Column(
             modifier = modifier
@@ -56,9 +59,9 @@ fun AppDialog(
                     alignment = Alignment.End,
                 ),
             ) {
-                if (dismissLabel != null && onDismiss != null) {
+                if (onDismiss != null) {
                     AppButton.Tertiary(
-                        text = dismissLabel,
+                        text = resolvedDismissLabel,
                         onClick = onDismiss,
                         size = AppButtonSize.MEDIUM,
                     )

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppTheme.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppTheme.kt
@@ -15,10 +15,16 @@ import androidx.core.view.WindowCompat
 
 @Composable
 fun AppTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit,
 ) {
     val localActivity = LocalActivity.current
+
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
 
     val colors = remember(darkTheme) {
         if (darkTheme) provideDarkAppColors() else provideLightAppColors()

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppTheme.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppTheme.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.core.view.WindowCompat
@@ -37,7 +37,7 @@ fun AppTheme(
     val m3Typography = remember(typography) { typography.toM3Typography() }
     val m3Shapes = remember(shapes) { shapes.toM3Shapes() }
 
-    LaunchedEffect(darkTheme) {
+    SideEffect {
         localActivity?.window?.let { window ->
             WindowCompat.getInsetsController(window, window.decorView)
                 .isAppearanceLightStatusBars = !darkTheme

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/ThemeMode.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/ThemeMode.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.ui.kit.theme
+
+enum class ThemeMode {
+    SYSTEM,
+    LIGHT,
+    DARK,
+}

--- a/core/ui/kit/src/main/res/values-ru/strings.xml
+++ b/core/ui/kit/src/main/res/values-ru/strings.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="core_ui_kit_action_cancel">Отмена</string>
+    <string name="core_ui_kit_action_save">Сохранить</string>
+    <string name="core_ui_kit_action_back">Назад</string>
 </resources>

--- a/core/ui/kit/src/main/res/values/strings.xml
+++ b/core/ui/kit/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="core_ui_kit_action_cancel">Cancel</string>
+    <string name="core_ui_kit_action_save">Save</string>
+    <string name="core_ui_kit_action_back">Back</string>
 </resources>

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
@@ -44,6 +44,12 @@ sealed interface Screen {
         val trainingUuid: String?,
     ) : Screen
 
+    @Serializable
+    data object Settings : Screen
+
+    @Serializable
+    data object Archive : Screen
+
     companion object {
 
         @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -164,8 +164,11 @@ Briefly:
 - `Action` is a sealed interface or sealed class implementing `Store.Action`. Top-level
   categories are typically `Click`, `Input`, `Navigation`, `Paging`, `Common`.
 - `Event` is a sealed interface or sealed class implementing `Store.Event`. Names describe what
-  happened (`*Success`, `*Error`, `*Completed`, `Navigate*`, `Show*`, `Haptic*`, `Snackbar*`,
-  `Scroll*`).
+  happened (`*Success`, `*Error`, `*Completed`, `Show*`, `Haptic*`, `Snackbar*`, `Scroll*`).
+  **Events are for UI-side effects only** — haptic feedback, snackbar display, external Intent
+  dispatch, scroll commands. **Navigation is never an Event.** Navigation flows through
+  `Action.Navigation` consumed by the feature's `NavigationHandler` (see [Navigation
+  flow](#navigation-flow) below).
 
 ## Per-feature MVI layout
 
@@ -332,6 +335,58 @@ domain models:
   serialized route (`data: Screen.Training`, etc.). `RootComponentImpl`
   (`app/app/.../navigation/RootComponentImpl.kt`) creates the right `Component` for a screen and
   is provided through `LocalRootComponent`.
+
+### Navigation flow (canonical pattern)
+
+Navigation is **always** routed through a feature's `NavigationHandler`, never through the
+graph composable directly. This keeps UI dumb (it knows nothing about routes or `Navigator`)
+and lets navigation be tested in isolation. The pattern:
+
+1. UI emits an `Action.Navigation.<Something>` via `processor.consume(...)`.
+2. The store's `handlerCreator` lambda routes that action to the feature's `NavigationHandler`.
+3. `NavigationHandler` has `Navigator` injected via Hilt DI and calls `navigator.navTo(...)` or
+   `navigator.popBack()`.
+
+Concretely, a feature defines:
+
+```kotlin
+// In the Store contract:
+sealed interface Action : Store.Action {
+    sealed interface Navigation : Action {
+        data object Back : Navigation
+        data object OpenArchive : Navigation
+        // ... any other navigation targets
+    }
+}
+
+// As a separate handler class in mvi/handler/:
+internal class NavigationHandler @Inject constructor(
+    private val navigator: Navigator,
+) : <Feature>Component(), Handler<Action.Navigation> {
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            is Action.Navigation.Back -> navigator.popBack()
+            is Action.Navigation.OpenArchive -> navigator.navTo(Screen.Archive)
+        }
+    }
+}
+```
+
+The graph composable consumes only **UI-side events** through `processor.Handle { event -> ... }`:
+
+- `Event.Haptic` — translated to `LocalHapticFeedback.current.performHapticFeedback(...)`.
+- `Event.ShowExternalLink(url)` — translated to an `Intent.ACTION_VIEW` against `LocalContext`.
+- `Event.Snackbar*` — emitted to the host snackbar manager.
+- `Event.Scroll*` — translated to a `LazyListState` scroll command in scope.
+
+The graph composable **never** reads `LocalNavigator` and **never** consumes an
+`Event.Navigate*` (such an event must not exist — it would be misnamed). `LocalNavigator`
+exists in `core/ui/navigation/Navigator.kt` so the root `App.kt` can provide a single
+`Navigator` instance into the composition tree, but the canonical read site is
+`NavigationHandler` via Hilt — not graph composables.
+
+Reference implementation: `feature/all-trainings/ui/AllTrainingsGraph.kt` (graph) and
+`feature/all-trainings/mvi/handler/NavigationHandler.kt` (handler).
 
 ### Navigation host and shared element transitions
 

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -443,6 +443,108 @@ calling `LocalHapticFeedback.current.performHapticFeedback(...)` — see
 - `StoreDispatchers` (`core/ui/mvi/.../di/StoreDispatchers.kt`) injects `@DefaultDispatcher`
   and `@MainImmediateDispatcher` from `core/core/.../di/CoreModule.kt`.
 
+### Localization
+
+Workeeper supports two locales out of the box: **English** (default) and **Russian**.
+English is the default for international audience and contributors on GitHub; Russian is
+overlaid via Android's resource qualifier system for users with `system locale = ru`.
+
+Resource layout per module:
+
+```
+<module>/src/main/res/values/strings.xml        — English (default fallback)
+<module>/src/main/res/values-ru/strings.xml     — Russian overlay
+```
+
+Every user-facing string is extracted to `strings.xml` from the start. Compose code reads
+strings via `stringResource(R.string.xxx)`, never as Kotlin literals. This applies to:
+
+- Screen titles, button labels, list headers, empty state copy.
+- Error messages and snackbar text.
+- Field labels and placeholders.
+- Date/time format strings (use `androidx.compose.ui.text.intl.Locale.current` if format
+  varies by language).
+
+It does **not** apply to:
+
+- Internal log messages and analytics event names — these stay English-only.
+- Domain identifiers (entity types, set types, action names in MVI) — these stay English
+  in code, translated on display.
+
+#### Naming convention
+
+```
+feature_<feature>_<context>_<purpose>
+```
+
+Examples:
+
+```xml
+<string name="feature_settings_title">Settings</string>
+<string name="feature_settings_section_about">About</string>
+<string name="feature_settings_section_appearance">Appearance</string>
+<string name="feature_archive_segment_exercises">Exercises</string>
+<string name="feature_archive_action_restore">Restore</string>
+<string name="feature_archive_action_permanent_delete">Delete permanently</string>
+<string name="feature_archive_dialog_permanent_delete_title">Delete '%1$s' permanently?</string>
+<string name="feature_archive_dialog_permanent_delete_body_with_history">
+    This will permanently delete the %1$s along with %2$d sessions of history. This cannot be undone.
+</string>
+```
+
+Strings shared across features (e.g. "Cancel", "Save", "Back") live in the relevant `core/`
+module — typically `core/ui/kit` for UI verbs:
+
+```xml
+<string name="core_ui_kit_action_cancel">Cancel</string>
+<string name="core_ui_kit_action_save">Save</string>
+<string name="core_ui_kit_action_back">Back</string>
+```
+
+#### Pluralization
+
+Use `<plurals>` resources for any number-driven text ("1 session" vs "5 sessions" vs Russian
+forms "1 сессия" / "2 сессии" / "5 сессий"). Read with `pluralStringResource(R.plurals.xxx, count, count)`.
+
+Example:
+
+```xml
+<plurals name="feature_archive_session_count">
+    <item quantity="one">%d session</item>
+    <item quantity="other">%d sessions</item>
+</plurals>
+```
+
+Russian needs the `few` quantity for 2-4:
+
+```xml
+<plurals name="feature_archive_session_count">
+    <item quantity="one">%d сессия</item>
+    <item quantity="few">%d сессии</item>
+    <item quantity="many">%d сессий</item>
+    <item quantity="other">%d сессии</item>
+</plurals>
+```
+
+#### Forbidden patterns
+
+- Hardcoded user-facing string literals in Composables.
+- Concatenation of localized fragments — always use full sentences as resources, with
+  format placeholders for variable parts. (`"$name was archived"` is forbidden;
+  `getString(R.string.archived_format, name)` is correct.)
+- Manual locale switching in code — let Android resolve from system locale.
+
+#### Adding a new feature
+
+When creating a new feature module:
+
+1. Create `src/main/res/values/strings.xml` with all English strings.
+2. Create `src/main/res/values-ru/strings.xml` with the Russian translations.
+3. Both files must contain the same set of keys — adding a key to one without the other
+   means the missing locale falls back to English (which is acceptable but visible).
+4. Reference all strings via `stringResource(R.string.xxx)` from Composables and
+   `context.getString(R.string.xxx)` from non-Compose code.
+
 ## Build conventions
 
 Convention plugins live in `build-logic/convention/src/main/kotlin/`:

--- a/documentation/design-system.md
+++ b/documentation/design-system.md
@@ -2,7 +2,7 @@
 
 This document specifies the v1 design system for Workeeper: tokens
 (color, typography, spacing, shape, motion, elevation), component
-inventory (19 shared components), and the implementation plan for
+inventory (21 shared components), and the implementation plan for
 `core/ui/kit`.
 
 It is the input to the Claude Code prompt at the bottom of this
@@ -27,6 +27,56 @@ Material 3 + custom values + custom semantic layer.
   `LocalAppColors`, `LocalAppTypography`, etc. (CompositionLocal),
   carrying fitness-specific roles (set type colors, PR highlights,
   etc.) that M3 does not cover.
+
+### Theme switch reactivity contract
+
+When the user changes the theme preference (System / Light / Dark in
+Settings), three things must update **simultaneously and in a single
+recomposition**:
+
+1. M3 `MaterialTheme` color scheme — automatic via `AppTheme`
+   recomposition.
+2. `LocalAppColors` and other AppUi locals — automatic via
+   `AppTheme` recomposition.
+3. **Activity window chrome** — status bar tint, navigation bar
+   tint, and surface insets controller. This is **not** automatic;
+   it requires an explicit side effect inside `AppTheme`.
+
+The window chrome side effect must use `SideEffect` (not
+`LaunchedEffect`):
+
+```kotlin
+@Composable
+fun AppTheme(
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
+    content: @Composable () -> Unit,
+) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
+
+    val activity = LocalActivity.current
+    SideEffect {
+        activity?.window?.let { window ->
+            val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+            insetsController.isAppearanceLightStatusBars = !darkTheme
+            insetsController.isAppearanceLightNavigationBars = !darkTheme
+        }
+    }
+
+    // ... rest of AppTheme: build ColorScheme, provide locals, MaterialTheme { content }
+}
+```
+
+`SideEffect` runs on every successful recomposition. `LaunchedEffect`
+does not — it relaunches only when its keys change, which can miss
+the recomposition triggered by a `darkTheme` boolean flip.
+
+This contract is the source of the "TopAppBar recolors out of phase
+with screen content" bug. Any future contributor wiring window
+chrome behavior must use `SideEffect`.
 
 ### Color palette
 
@@ -288,9 +338,68 @@ The current hard-coded `defaultAnimationDuration = 600` in
 `core/ui/kit` is replaced by `AppMotion.deliberate`. All other
 animations use `normal` (300ms) or `fast` (200ms) as the default.
 
+### Haptic feedback
+
+Haptics are part of the design system contract, not optional. Every
+user-initiated action that produces an MVI side effect emits a
+`Haptic` event from the store. The application's Haptic event
+handler (existing in `core/ui/kit/utils/`) maps the event to the
+device's haptic feedback API.
+
+Workeeper recognizes two haptic intensities:
+
+- **light** — default for any normal click (button tap, row tap,
+  toggle, segment switch, FAB press, navigation). 90% of haptic
+  emissions.
+- **medium** — destructive intents and important confirmations
+  (delete confirm, archive permanent delete, finish session).
+
+Stores expose this through the `Event` sealed hierarchy. The
+existing pattern (used by all v1 features):
+
+```kotlin
+sealed interface Event : Store.Event {
+    data object HapticLight : Event
+    data object HapticMedium : Event
+    // ... feature-specific events
+}
+```
+
+#### When to emit haptics
+
+Every Click action that produces a state change OR triggers
+navigation OR opens a dialog must emit a haptic. Counter-examples
+(do NOT emit haptic):
+
+- Cancel/dismiss in dialogs — the haptic was already produced when
+  the dialog opened; cancelling is a "negation", not a positive
+  action.
+- Repeated rapid actions (e.g. holding a button for continuous
+  scroll) — haptics fire once on press, not on every frame.
+- Pure observational actions (text input typing, scroll, swipe in
+  progress before threshold).
+
+#### Convention
+
+Each feature spec under `documentation/feature-specs/` lists
+explicit haptic mappings per Click action. The base rule of thumb:
+
+| Action category | Intensity |
+|---|---|
+| Tap a row, button, FAB, toggle, chip, tab, segment | light |
+| Open a screen / dialog / bottom sheet | light (on the trigger) |
+| Confirm a destructive action | medium |
+| Confirm an important non-destructive action (finish session) | medium |
+| Cancel / dismiss any dialog | none |
+| Undo from snackbar | light |
+
+Haptic emission is the trigger's responsibility, not the receiver's.
+Tapping a row that opens a dialog: the haptic emits at row tap. The
+dialog opens silently (no separate haptic).
+
 ## Component inventory
 
-19 shared components in `core/ui/kit`. Each has a fixed package and a
+21 shared components in `core/ui/kit`. Each has a fixed package and a
 clear purpose. No two screens should reimplement these — if a screen
 needs a variation, it goes back into the kit.
 
@@ -650,8 +759,59 @@ swipe-from-end. Action panel uses actionTint as background (typically
 error or warning).
 ```
 
-(Counts as 19 + 1 added during scope review per the chat session;
-final count = 20 components.)
+### 21. AppSettingsRow
+
+A full-width row designed for Settings-style preference pickers and
+list-style menu entries. The default layout for everything that
+appears under Settings, Archive headers, future Manage tags, etc.
+
+```
+package: io.github.stslex.workeeper.core.ui.kit.components.settings
+
+variants:
+  AppSettingsRow.Navigation — title + optional subtitle + trailing chevron;
+                              tap navigates somewhere
+  AppSettingsRow.Choice     — title + optional subtitle + leading RadioButton;
+                              tap selects (use inside selectableGroup())
+  AppSettingsRow.Toggle     — title + optional subtitle + trailing Switch
+  AppSettingsRow.Action     — title + optional subtitle + trailing icon;
+                              tap fires an action (e.g. external link)
+
+API: composables taking title, subtitle (optional), enabled (default true),
+     onClick (or onCheckedChange for Toggle, selected for Choice).
+
+Visual:
+  width:            full screen width (modifier.fillMaxWidth())
+  height:           AppDimension.heightSm minimum, taller if subtitle wraps
+  horizontal padding: AppDimension.screenEdge (16.dp)
+  vertical padding:   12.dp
+  background:       transparent (the row sits on parent surface)
+  ripple:           full row width on tap
+  title:            AppUi.typography.bodyMedium, AppUi.colors.textPrimary
+  subtitle:         AppUi.typography.bodySmall, AppUi.colors.textTertiary
+  spacing between title and subtitle: 2.dp
+  trailing chevron / icon: AppDimension.iconSm (18.dp)
+
+Modifier behavior:
+  - Use Modifier.clickable for Navigation / Action variants.
+  - Use Modifier.selectable(role = Role.RadioButton) for Choice variant.
+  - Wrap a group of Choice rows in a Column with Modifier.selectableGroup().
+  - Choice variant: tapping anywhere on the row selects the option, ripple
+    covers the full row width. The RadioButton is purely visual indicator;
+    do not handle its onClick separately.
+```
+
+#### Why a dedicated component
+
+Settings UIs frequently fall into the trap of using bare
+`RadioButton + Text` or `Text + Switch` without a unifying row
+container. The result is small floating hit targets and ripples that
+do not match the visual extent of the option. AppSettingsRow
+enforces full-width tap targets and consistent typography across all
+settings surfaces.
+
+(Counts as 19 + 1 added during scope review per the chat session
++ 1 added in Stage 5.1 (AppSettingsRow); final count = 21 components.)
 
 ## Module structure
 

--- a/documentation/feature-specs/settings-archive.md
+++ b/documentation/feature-specs/settings-archive.md
@@ -243,18 +243,22 @@ interface SettingsStore : Store<SettingsState, Action, Event> {
             data class OnThemeChange(val mode: ThemeMode) : Input
         }
         sealed interface Navigation : Action {
-            data object OnBackClick : Navigation
+            data object Back : Navigation
+            data object OpenArchive : Navigation
         }
     }
 
     @Stable
     sealed interface Event : Store.Event {
-        data object NavigateToArchive : Event
-        data class OpenExternalLink(val url: String) : Event
-        data object NavigateBack : Event
+        data class HapticClick(val type: HapticFeedbackType) : Event
+        data class ShowExternalLink(val url: String) : Event
     }
 }
 ```
+
+Note: navigation is `Action.Navigation` consumed by `SettingsNavigationHandler`, not an
+`Event`. UI only consumes `Event.HapticClick` and `Event.ShowExternalLink`. See
+[architecture.md → Navigation flow](../architecture.md#navigation-flow-canonical-pattern).
 
 ### ArchiveStore
 
@@ -285,33 +289,59 @@ interface ArchiveStore : Store<ArchiveState, Action, Event> {
             data class OnUndoRestore(val item: ArchivedItem) : Click
         }
         sealed interface Navigation : Action {
-            data object OnBackClick : Navigation
+            data object Back : Navigation
         }
     }
 
     @Stable
     sealed interface Event : Store.Event {
+        data class HapticClick(val type: HapticFeedbackType) : Event
         data class ShowRestoredSnackbar(val item: ArchivedItem) : Event
         data object ShowPermanentlyDeletedSnackbar : Event
-        data object NavigateBack : Event
-        data object Haptic : Event
     }
 }
 ```
 
+Note: navigation is `Action.Navigation.Back` consumed by `ArchiveNavigationHandler`, not an
+`Event`. UI only consumes `Event.HapticClick` and the two snackbar events.
+
 ### Handler responsibilities
 
-- **SettingsClickHandler** — handles About link clicks (emits
-  `OpenExternalLink`) and Archive entry click (emits
-  `NavigateToArchive`).
-- **SettingsNavigationHandler** — emits `NavigateBack`.
-- Theme change is an `Input` action, handled by the store directly
-  (no separate handler) — writes to DataStore, updates state.
-- **ArchiveClickHandler** — handles segment switch, restore (with
-  snackbar undo), permanent delete trigger and confirm/dismiss.
-- **ArchivePagingHandler** — paged source for the active segment.
-  Switches between exercise paging and training paging based on
-  state.selectedSegment.
+Each feature has its own set of handlers. Settings has 3, Archive has 3.
+
+**Settings handlers:**
+
+- `SettingsClickHandler` — handles About link clicks (emits `Event.ShowExternalLink` for
+  external Intent dispatch) and Archive entry click (emits
+  `Action.Navigation.OpenArchive` via `consume`). Also handles theme change (it's an
+  `Input` action, but routed through this handler for simplicity — writes DataStore,
+  updates state).
+- `SettingsNavigationHandler` — `internal class @Inject constructor(private val navigator: Navigator)`.
+  Implements `Handler<Action.Navigation>`. Consumes `Action.Navigation.Back` →
+  `navigator.popBack()` and `Action.Navigation.OpenArchive` → `navigator.navTo(Screen.Archive)`.
+  Reference: `feature/all-trainings/.../mvi/handler/NavigationHandler.kt`.
+- (Optional) `SettingsCommonHandler` — only if the store has `Action.Common` items; not
+  required for v1.
+
+**Archive handlers:**
+
+- `ArchiveClickHandler` — handles segment switch, restore (with snackbar undo emitted as
+  Event), permanent delete trigger and confirm/dismiss.
+- `ArchivePagingHandler` — paged source for the active segment. Switches between exercise
+  paging and training paging based on `state.selectedSegment`.
+- `ArchiveNavigationHandler` — same shape as `SettingsNavigationHandler`. Consumes
+  `Action.Navigation.Back` → `navigator.popBack()`.
+
+**Graph composables (settingsGraph and archiveGraph):**
+
+Each consumes only UI-side events through `processor.Handle { event -> ... }`:
+
+- `Event.HapticClick` → `LocalHapticFeedback.current.performHapticFeedback(event.type)`
+- `Event.ShowExternalLink(url)` → `Intent.ACTION_VIEW` against `LocalContext`
+- `Event.ShowRestoredSnackbar` / `Event.ShowPermanentlyDeletedSnackbar` → snackbar host
+
+Graph composables **do NOT** read `LocalNavigator` and **do NOT** call `navigator.navTo`
+or `navigator.popBack` directly. All navigation goes through the relevant `NavigationHandler`.
 
 ## Domain layer
 
@@ -592,6 +622,24 @@ PROCESS
     conventions (BaseStore extension, @HiltViewModel store,
     @ViewModelScoped handlers). Custom Detekt MVI rules must pass
     without baseline additions.
+
+    CANONICAL NAVIGATION PATTERN (mandatory):
+    - Navigation is `Action.Navigation`, NOT `Event.Navigate*`.
+    - Each feature has a separate `NavigationHandler` class with
+      `Navigator` injected via Hilt @Inject constructor.
+      `NavigationHandler` implements `Handler<Action.Navigation>`
+      and consumes navigation actions by calling `navigator.navTo`
+      / `navigator.popBack`.
+    - The graph composable (`settingsGraph`, `archiveGraph`)
+      consumes ONLY UI-side events via `processor.Handle { event -> ... }`:
+      Haptic, ShowExternalLink, snackbar events.
+    - The graph composable MUST NOT read `LocalNavigator` and MUST
+      NOT call `navigator.navTo` / `navigator.popBack` directly.
+    - Reference implementation:
+      `feature/all-trainings/ui/AllTrainingsGraph.kt` (graph) and
+      `feature/all-trainings/mvi/handler/NavigationHandler.kt` (handler).
+    - Read `documentation/architecture.md` section "Navigation flow
+      (canonical pattern)" before writing graph composables.
 
 11. Implement domain layer: SettingsInteractor + impl. Hilt module
     in `feature/settings/.../di/`.

--- a/documentation/feature-specs/settings-archive.md
+++ b/documentation/feature-specs/settings-archive.md
@@ -1,0 +1,645 @@
+# Feature spec — Settings + Archive
+
+This is the Stage 5.1 feature spec, the first v1 feature
+implementation. It builds on the foundation set by
+[product.md](../product.md), [ux-architecture.md](../ux-architecture.md),
+[data-needs.md](../data-needs.md), and
+[design-system.md](../design-system.md).
+
+Settings + Archive is intentionally first because it is the most
+isolated feature: it depends on nothing in the rest of the v1
+surface, and other features will eventually depend on its archive
+mechanics being in place.
+
+## Scope
+
+Two screens:
+
+- **Settings** — entry from Home TopAppBar settings icon. Sections:
+  About, Theme, Archive (entry).
+- **Archive** — sub-screen of Settings. Lists archived training
+  templates and exercise templates with restore and permanent-delete
+  actions.
+
+This spec implements the v1 portion only:
+
+- Settings: About + Theme + Archive entry.
+- Archive: list + restore + permanent delete + impact dialog.
+
+Out of scope (v2): Crash reporting toggle, Manage tags screen.
+
+## Module structure
+
+Create a new feature module:
+
+```
+feature/settings/
+  build.gradle.kts                        — apply convention plugins (see feature/charts)
+  src/main/AndroidManifest.xml
+  src/main/kotlin/io/github/stslex/workeeper/feature/settings/
+    di/CoreSettingsModule.kt              — Hilt module
+    domain/
+      SettingsInteractor.kt               — interface
+      SettingsInteractorImpl.kt           — impl
+      model/
+        ArchivedItem.kt                   — sealed for trainings vs exercises in unified list
+    ui/
+      SettingsScreen.kt                   — Composable entry, Hilt navigation
+      ArchiveScreen.kt                    — Composable entry, Hilt navigation
+      components/
+        SettingsSection.kt                — section container with eyebrow header
+        SettingsRow.kt                    — list row variant for Settings entries
+        ThemeSelector.kt                  — 3 inline radio buttons
+        AboutBlock.kt                     — version, license, links
+        ArchivedItemRow.kt                — row inside Archive screen
+        PermanentDeleteDialog.kt          — wraps AppConfirmDialog with impact summary
+      mvi/
+        store/
+          SettingsStore.kt                — interface
+          SettingsStoreImpl.kt            — impl
+          ArchiveStore.kt                 — interface
+          ArchiveStoreImpl.kt             — impl
+        handler/
+          SettingsClickHandler.kt
+          SettingsNavigationHandler.kt
+          ArchiveClickHandler.kt
+          ArchivePagingHandler.kt
+        model/
+          SettingsState.kt
+          ArchiveState.kt
+```
+
+Add `include(":feature:settings")` to `settings.gradle.kts`.
+Wire navigation in `app/`.
+
+## Screens
+
+### Settings
+
+A single-screen vertical scroll. Sections in order:
+
+1. **About** (top section)
+2. **Appearance** — theme selector
+3. **Data** — Archive entry
+
+Each section uses `SettingsSection` with a labelSmall eyebrow header
+in `AppUi.colors.textTertiary`. Sections separated by 24.dp
+(`AppDimension.sectionSpacing`).
+
+#### About section content
+
+```
+Workeeper                       — titleMedium
+Version 1.0.0 (15)              — bodySmall, textTertiary  (read from BuildConfig)
+GPLv3 license                   — bodySmall, accent (clickable, opens LICENSE URL)
+View on GitHub                  — bodyMedium, accent (clickable, opens repo URL)
+Privacy Policy                  — bodyMedium, accent (clickable, opens Play Console URL)
+```
+
+Constants live in `feature/settings/src/main/kotlin/.../about/AboutLinks.kt`:
+
+```kotlin
+internal object AboutLinks {
+    const val GITHUB_URL = "https://github.com/stslex/Workeeper"
+    const val LICENSE_URL = "https://github.com/stslex/Workeeper/blob/master/LICENSE"
+    const val PRIVACY_POLICY_URL = "https://stslex.github.io/Workeeper/"
+}
+```
+
+External link clicks use `Intent.ACTION_VIEW` via
+`androidx.core.net.toUri()`. No in-app webview.
+
+#### Appearance section
+
+Three inline `RadioButton`s in a column with labels:
+
+```
+Appearance
+  ⊙ System default     ← selected by default if user hasn't picked
+  ○ Light
+  ○ Dark
+```
+
+Persisted via `core/dataStore`. New key:
+
+```kotlin
+val themePreferenceKey = stringPreferencesKey("theme_preference")
+```
+
+Values: `"SYSTEM"` / `"LIGHT"` / `"DARK"`. Default: `"SYSTEM"`.
+
+`AppTheme` composable in `core/ui/kit` accepts a
+`themeMode: ThemeMode` parameter (currently it takes only
+`darkTheme: Boolean`). Update its signature:
+
+```kotlin
+enum class ThemeMode { SYSTEM, LIGHT, DARK }
+
+@Composable
+fun AppTheme(
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
+    content: @Composable () -> Unit,
+) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
+    // ... rest as before
+}
+```
+
+The app entry composable reads the preference via DataStore Flow,
+maps to `ThemeMode`, passes to `AppTheme`. Theme switch is reactive
+— picking a radio button immediately recomposes the whole app.
+
+#### Data section
+
+Single row:
+
+```
+Archive                        →
+```
+
+Trailing chevron icon (`Icons.AutoMirrored.Filled.KeyboardArrowRight`).
+Tap navigates to Archive screen.
+
+### Archive
+
+Sub-screen with TopAppBar back button, title "Archive", and a tab-like
+segmented control with two segments showing counts:
+
+```
+[ Exercises (12) ]  [ Trainings (3) ]
+```
+
+Uses `AppSegmentedControl`. Default segment: Exercises.
+
+Below the segment selector, a paged list of archived items in the
+selected category. Each row uses `ArchivedItemRow`:
+
+```
+[ name (bodyMedium) ]                              [ Restore ] [ ⋯ ]
+[ tags chips (labelSmall) ]
+[ "Archived 2 days ago" (bodySmall, textTertiary) ]
+```
+
+The `Restore` button is `AppButton.Tertiary` size small. The trailing
+`⋯` icon button opens an overflow with a single action: "Delete
+permanently".
+
+Tap **Restore** → calls repository → `Snackbar` "X restored. Undo".
+Undo re-archives.
+
+Tap **Delete permanently** → opens `PermanentDeleteDialog`
+(wraps `AppConfirmDialog`):
+
+```
+Title:  Delete '<name>' permanently?
+Body:   This will permanently delete the <training/exercise> along
+        with N sessions of history. This cannot be undone.
+ImpactSummary: "<N> sessions of history"
+ConfirmLabel: Delete
+DismissLabel: Cancel
+```
+
+Impact count is fetched on demand: number of finished sessions
+referencing this training (for trainings) or this exercise (for
+exercises). For exercises with zero sessions, the body text drops
+the impact clause:
+
+```
+Body:   This will permanently delete the exercise. This cannot be
+        undone.
+```
+
+Empty state for each segment when nothing is archived: centered
+`AppEmptyState` with `Icons.Filled.Inventory2` icon, headline
+"Nothing archived" and supporting text "Archived <exercises/trainings>
+appear here for restore or permanent delete."
+
+## MVI surface
+
+### SettingsStore
+
+```kotlin
+interface SettingsStore : Store<SettingsState, Action, Event> {
+
+    @Stable
+    data class State(
+        val themeMode: ThemeMode,
+        val appVersion: String,
+    ) : Store.State
+
+    @Stable
+    sealed interface Action : Store.Action {
+        sealed interface Click : Action {
+            data object OnArchiveClick : Click
+            data object OnGitHubClick : Click
+            data object OnLicenseClick : Click
+            data object OnPrivacyPolicyClick : Click
+        }
+        sealed interface Input : Action {
+            data class OnThemeChange(val mode: ThemeMode) : Input
+        }
+        sealed interface Navigation : Action {
+            data object OnBackClick : Navigation
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+        data object NavigateToArchive : Event
+        data class OpenExternalLink(val url: String) : Event
+        data object NavigateBack : Event
+    }
+}
+```
+
+### ArchiveStore
+
+```kotlin
+interface ArchiveStore : Store<ArchiveState, Action, Event> {
+
+    @Stable
+    data class State(
+        val selectedSegment: Segment,
+        val exerciseCount: Int,
+        val trainingCount: Int,
+        val archivedExercises: PagingData<ArchivedItem.Exercise>,
+        val archivedTrainings: PagingData<ArchivedItem.Training>,
+        val pendingDeleteImpact: Int?,
+        val pendingDeleteTarget: ArchivedItem?,
+    ) : Store.State
+
+    enum class Segment { EXERCISES, TRAININGS }
+
+    @Stable
+    sealed interface Action : Store.Action {
+        sealed interface Click : Action {
+            data class OnSegmentChange(val segment: Segment) : Click
+            data class OnRestoreClick(val item: ArchivedItem) : Click
+            data class OnPermanentDeleteClick(val item: ArchivedItem) : Click
+            data object OnDeleteConfirm : Click
+            data object OnDeleteDismiss : Click
+            data class OnUndoRestore(val item: ArchivedItem) : Click
+        }
+        sealed interface Navigation : Action {
+            data object OnBackClick : Navigation
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+        data class ShowRestoredSnackbar(val item: ArchivedItem) : Event
+        data object ShowPermanentlyDeletedSnackbar : Event
+        data object NavigateBack : Event
+        data object Haptic : Event
+    }
+}
+```
+
+### Handler responsibilities
+
+- **SettingsClickHandler** — handles About link clicks (emits
+  `OpenExternalLink`) and Archive entry click (emits
+  `NavigateToArchive`).
+- **SettingsNavigationHandler** — emits `NavigateBack`.
+- Theme change is an `Input` action, handled by the store directly
+  (no separate handler) — writes to DataStore, updates state.
+- **ArchiveClickHandler** — handles segment switch, restore (with
+  snackbar undo), permanent delete trigger and confirm/dismiss.
+- **ArchivePagingHandler** — paged source for the active segment.
+  Switches between exercise paging and training paging based on
+  state.selectedSegment.
+
+## Domain layer
+
+Add to `core/exercise`:
+
+### ExerciseRepository (extend)
+
+Add (was deferred from db redesign PR):
+
+```kotlin
+fun pagedArchived(): PagingSource<Int, ExerciseDataModel>
+suspend fun countSessionsUsing(exerciseUuid: String): Int
+```
+
+`countSessionsUsing` queries `performed_exercise` joined to `session`
+where state = FINISHED.
+
+### TrainingRepository (extend)
+
+Add:
+
+```kotlin
+fun pagedArchived(): PagingSource<Int, TrainingDataModel>
+suspend fun countSessionsUsing(trainingUuid: String): Int
+```
+
+`countSessionsUsing` queries `session` where `training_uuid = ?` and
+`state = FINISHED`.
+
+### SettingsInteractor
+
+```kotlin
+interface SettingsInteractor {
+    fun observeThemeMode(): Flow<ThemeMode>
+    suspend fun setThemeMode(mode: ThemeMode)
+
+    fun observeArchivedExerciseCount(): Flow<Int>
+    fun observeArchivedTrainingCount(): Flow<Int>
+
+    fun pagedArchivedExercises(): Flow<PagingData<ArchivedItem.Exercise>>
+    fun pagedArchivedTrainings(): Flow<PagingData<ArchivedItem.Training>>
+
+    suspend fun restoreExercise(uuid: String)
+    suspend fun restoreTraining(uuid: String)
+
+    suspend fun countExerciseSessions(uuid: String): Int
+    suspend fun countTrainingSessions(uuid: String): Int
+
+    suspend fun permanentlyDeleteExercise(uuid: String)
+    suspend fun permanentlyDeleteTraining(uuid: String)
+}
+```
+
+`ThemeMode` lives in `core/ui/kit/theme/ThemeMode.kt` since it is
+used by `AppTheme`.
+
+`ArchivedItem` is a sealed interface defined in
+`feature/settings/.../domain/model/ArchivedItem.kt`:
+
+```kotlin
+sealed interface ArchivedItem {
+    val uuid: String
+    val name: String
+    val tags: List<String>
+    val archivedAt: Long
+
+    data class Exercise(
+        override val uuid: String,
+        override val name: String,
+        override val tags: List<String>,
+        override val archivedAt: Long,
+        val type: ExerciseType,
+    ) : ArchivedItem
+
+    data class Training(
+        override val uuid: String,
+        override val name: String,
+        override val tags: List<String>,
+        override val archivedAt: Long,
+        val exerciseCount: Int,
+    ) : ArchivedItem
+}
+```
+
+## Data layer additions
+
+`ExerciseDao` — already has `pagedArchived()` from db redesign;
+verify it's there. If not, add.
+
+`SessionDao` — add:
+
+```kotlin
+@Query("""
+    SELECT COUNT(*) FROM session_table
+    WHERE training_uuid = :trainingUuid AND state = 'FINISHED'
+""")
+suspend fun countFinishedByTraining(trainingUuid: Uuid): Int
+
+@Query("""
+    SELECT COUNT(DISTINCT session_uuid) FROM performed_exercise_table pe
+    JOIN session_table s ON s.uuid = pe.session_uuid
+    WHERE pe.exercise_uuid = :exerciseUuid AND s.state = 'FINISHED'
+""")
+suspend fun countFinishedContainingExercise(exerciseUuid: Uuid): Int
+```
+
+`TrainingDao` — `archivedAt` is not in the schema today, only
+`createdAt`. Two options:
+
+- (A) Add `archived_at: Long?` column — migration v3 → v4. Required
+  if "Archived 2 days ago" should be accurate.
+- (B) Reuse `createdAt` for the "archived" timestamp display. Wrong
+  semantics but no migration.
+
+Default: **(A)**. Add column on both `training_table` and
+`exercise_table`. Migration is destructive again (no users), trivial.
+Bump to v4.
+
+## Navigation
+
+Add Settings + Archive as nav destinations in `app/`:
+
+```kotlin
+@Serializable
+object SettingsRoute
+
+@Serializable
+object ArchiveRoute
+```
+
+Settings reachable from Home TopAppBar settings icon. Archive
+reachable only from Settings — no deep link, no bottom-bar entry.
+Back stack: Home → Settings → Archive.
+
+## Edge cases and decisions
+
+- **Theme switch** during a live session — the active session
+  composable is part of the app graph; theme change recomposes
+  through the root and is fine. No special handling.
+- **Restore an exercise** that has the same name as a non-archived
+  exercise — allowed (no uniqueness constraint on names). User can
+  rename one of them later.
+- **Permanent delete during paged scroll** — when a row is removed,
+  the PagingSource invalidates and the list rebuilds. Acceptable
+  flicker.
+- **Empty Archive screen** — the segment selector still shows with
+  counts (0). Empty state below.
+- **No Manage tags entry** in Settings v1. The Settings → Data
+  section currently has only Archive. When v2 adds Manage tags, it
+  joins the Data section.
+
+## Testing
+
+Unit tests:
+
+- `SettingsInteractorImplTest` — DataStore read/write, count flow
+  composition.
+- `SettingsClickHandlerTest`, `SettingsNavigationHandlerTest` —
+  state and event assertions per Action.
+- `ArchiveClickHandlerTest` — segment switch, restore, delete
+  trigger, confirm/dismiss.
+- `ArchivePagingHandlerTest` — segment-driven source switching.
+
+UI tests (deferred, follow Stage 3 cleanup pattern — write @Smoke
+stubs only with `TODO(feature-rewrite)` markers, real tests added
+later).
+
+## Open questions
+
+- **Undo restore TTL.** Snackbar default is 4s. Long enough? Default
+  yes — leave at default 4s.
+- **Permanent-delete confirmation for exercise with 0 sessions.** Do
+  we still show the dialog? Default yes (consistency), with body
+  text adapted to drop the impact clause.
+- **Animation when restoring.** Slide out of archive list +
+  invalidate. Default M3 paging animation, no custom.
+
+## Stage 5.1 deliverables checklist
+
+- [ ] `feature/settings` module created and registered.
+- [ ] Settings screen with About, Theme, Archive entry.
+- [ ] Archive screen with segment selector, paged lists, restore,
+      permanent delete with impact dialog, empty states.
+- [ ] `ThemeMode` enum in `core/ui/kit`, `AppTheme` updated.
+- [ ] DataStore key `theme_preference` wired.
+- [ ] App entry composable reads theme preference and passes to
+      `AppTheme`.
+- [ ] `core/exercise` repositories extended with `pagedArchived` and
+      `countSessionsUsing` for both exercises and trainings.
+- [ ] `core/database` migration v3 → v4 adds `archived_at`. (Or
+      decision to skip if option B is chosen.)
+- [ ] `LICENSE` file with full GPLv3 text added at repo root.
+      `SPDX-License-Identifier: GPL-3.0-only` header on new source
+      files (decision: only on new files in this PR — bulk update
+      across existing codebase is a separate cleanup).
+- [ ] README updated with GPLv3 badge.
+- [ ] Unit tests for handlers and interactor.
+
+---
+
+## Claude Code prompt
+
+Run after this feature spec is approved.
+
+```
+Implement Stage 5.1 — Settings + Archive — per
+documentation/feature-specs/settings-archive.md.
+
+CONTEXT
+Workeeper is undergoing v1 reimplementation feature by feature. The
+foundation (db schema v3, design system tokens, 20 shared
+components) has already merged to dev. This is the first v1 feature
+implementation. Read in order before writing code:
+- documentation/product.md (release scope, decisions)
+- documentation/ux-architecture.md (Settings, Archive sections)
+- documentation/data-needs.md (queries, indexes)
+- documentation/db-redesign.md (schema)
+- documentation/design-system.md (tokens, components)
+- documentation/feature-specs/settings-archive.md (this feature)
+
+THIS PROMPT IS A SINGLE PASS — no STOP gates. Implementation,
+verification, PR opened in draft. Then await review.
+
+PROCESS
+
+1. Add `archived_at: Long?` columns on both `training_table` and
+   `exercise_table` (entities and schema). Bump db version to 4.
+   Use `fallbackToDestructiveMigrationFrom(2, 3)` (destructive — no
+   users in production). Update repositories and any in-flight code
+   that interacts with these columns. Re-export the schema JSON.
+
+2. Add a `LICENSE` file at repo root with the full GPLv3 text from
+   https://www.gnu.org/licenses/gpl-3.0.txt. Add
+   `SPDX-License-Identifier: GPL-3.0-only` header comment on every
+   new file created in this PR. Do NOT bulk-add the header to
+   existing files.
+
+3. Update README.MD: add a GPLv3 badge in the header
+   (https://img.shields.io/badge/license-GPLv3-blue.svg linking to
+   the LICENSE file).
+
+4. Move `ThemeMode` enum into `core/ui/kit/theme/ThemeMode.kt`
+   (SYSTEM, LIGHT, DARK). Update `AppTheme` composable signature to
+   accept `themeMode: ThemeMode = ThemeMode.SYSTEM` and resolve
+   darkTheme internally as in the spec.
+
+5. Add `theme_preference` to `core/dataStore` (string preference key,
+   default "SYSTEM").
+
+6. Wire app entry composable: read theme preference Flow, map to
+   ThemeMode, pass to AppTheme. Default to SYSTEM if no preference
+   set yet. Theme switch is reactive — picking a radio button
+   updates DataStore which updates Flow which recomposes AppTheme.
+
+7. Extend repositories in `core/exercise`:
+   - ExerciseRepository: add `pagedArchived()`, `countSessionsUsing()`
+   - TrainingRepository: add `pagedArchived()`, `countSessionsUsing()`
+   Wire DAOs accordingly. Add SessionDao queries
+   `countFinishedByTraining` and `countFinishedContainingExercise`
+   per the spec.
+
+8. Create `feature/settings` module with full structure per the
+   "Module structure" section. Apply existing convention plugins
+   (use feature/charts/build.gradle.kts as reference). Add
+   `include(":feature:settings")` to settings.gradle.kts. Wire
+   navigation in app/ (Settings + Archive routes).
+
+9. Implement Settings screen and Archive screen per the "Screens"
+   section. All UI uses ONLY tokens and components from
+   `core/ui/kit` (AppButton, AppCard, AppDialog, AppConfirmDialog,
+   AppEmptyState, AppListItem, AppTagChip, AppTopAppBar,
+   AppSegmentedControl, AppSnackbar, AppLoadingIndicator, etc.). No
+   raw `Color()` literals, no hardcoded sp/dp outside
+   `core/ui/kit/theme/`.
+
+10. Implement MVI surface per the spec exactly: state shapes,
+    actions, events, handlers. Follow the existing project MVI
+    conventions (BaseStore extension, @HiltViewModel store,
+    @ViewModelScoped handlers). Custom Detekt MVI rules must pass
+    without baseline additions.
+
+11. Implement domain layer: SettingsInteractor + impl. Hilt module
+    in `feature/settings/.../di/`.
+
+12. Add unit tests:
+    - SettingsInteractorImplTest
+    - SettingsClickHandlerTest, SettingsNavigationHandlerTest
+    - ArchiveClickHandlerTest, ArchivePagingHandlerTest
+    Use existing patterns from feature/charts tests (JUnit 5, MockK,
+    Turbine where useful).
+
+13. Add @Smoke UI test stubs (per documentation/testing.md and the
+    existing @Smoke pattern):
+    - SettingsScreenTest — empty stub with TODO(feature-rewrite-tests)
+    - ArchiveScreenTest — empty stub with same TODO
+
+VERIFICATION
+
+- `./gradlew :feature:settings:assembleDebug` passes.
+- `./gradlew :core:database:assembleDebug` passes (schema v4).
+- `./gradlew assembleDebug` passes (whole project, dev + store).
+- `./gradlew detekt lintDebug` passes.
+- `./gradlew testDebugUnitTest` passes.
+- core/database/schemas/.../AppDatabase/4.json exists.
+- LICENSE file present at repo root.
+- App launches, Home settings icon → Settings → Theme switching
+  works (system/light/dark) and persists across app restart.
+- App launches, Home settings icon → Settings → Archive →
+  Exercises/Trainings segments switch, restore action works,
+  permanent delete shows confirm with correct impact count.
+
+CONSTRAINTS
+
+- No data layer touches outside what's listed in step 1 and step 7.
+- No UI work outside feature/settings and the AppTheme
+  signature change in core/ui/kit.
+- Phantom shims in core/exercise (trainingUuid: Uuid?, sets, etc.)
+  remain untouched — they will be removed during their feature's
+  rewrite.
+- Old AppDimension nested objects (Padding, Radius, Icon, Button)
+  remain in place for legacy callsites; new code uses the flat
+  semantic aliases (heightSm, iconMd, screenEdge, etc.).
+- All English. No emojis in headers. No metric numbers.
+
+PR
+
+Open a draft PR titled
+`feat(settings): implement Settings + Archive (Stage 5.1)`. Body
+lists changed files grouped by module. Mark as ready for review
+after the verification gate passes.
+```

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.convention.composeLibrary)
+}
+
+dependencies {
+    implementation(project(":core:core"))
+
+    implementation(project(":core:dataStore"))
+    implementation(project(":core:ui:kit"))
+    implementation(project(":core:ui:mvi"))
+    implementation(project(":core:ui:navigation"))
+    implementation(project(":core:exercise"))
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.androidx.paging.testing)
+
+    androidTestImplementation(libs.bundles.android.test)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(project(":core:ui:test-utils"))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+}

--- a/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
+import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@Smoke
+@RunWith(AndroidJUnit4::class)
+class ArchiveScreenTest : BaseComposeTest() {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // TODO(feature-rewrite-tests): exercise segment switch + paged restore + delete dialog after Stage 5.1 stabilises.
+}

--- a/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
+import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@Smoke
+@RunWith(AndroidJUnit4::class)
+class SettingsScreenTest : BaseComposeTest() {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // TODO(feature-rewrite-tests): exercise theme selector + section rendering after Stage 5.1 stabilises.
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/about/AboutLinks.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/about/AboutLinks.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.about
+
+internal object AboutLinks {
+
+    const val GITHUB_URL = "https://github.com/stslex/Workeeper"
+    const val LICENSE_URL = "https://github.com/stslex/Workeeper/blob/master/LICENSE"
+    const val PRIVACY_POLICY_URL = "https://stslex.github.io/Workeeper/"
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveFeature.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveFeature.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import androidx.compose.runtime.Composable
+import io.github.stslex.workeeper.core.ui.mvi.Feature
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreProcessor
+import io.github.stslex.workeeper.core.ui.navigation.Screen.Archive
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveComponent
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStoreImpl
+
+internal typealias ArchiveStoreProcessor = StoreProcessor<State, Action, Event>
+
+internal object ArchiveFeature : Feature<ArchiveStoreProcessor, Archive, ArchiveComponent>() {
+
+    @Composable
+    override fun processor(
+        screen: Archive,
+    ): ArchiveStoreProcessor = createProcessor<ArchiveStoreImpl, ArchiveStoreImpl.Factory>(screen)
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveHandlerStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveHandlerStore.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.HandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+
+internal interface ArchiveHandlerStore : HandlerStore<State, Action, Event>

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveHandlerStoreImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveHandlerStoreImpl.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.BaseHandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ArchiveHandlerStoreImpl @Inject constructor() : ArchiveHandlerStore,
+    BaseHandlerStore<State, Action, Event>()

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveModule.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/ArchiveModule.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal interface ArchiveModule {
+
+    @Binds
+    @ViewModelScoped
+    fun bindHandlerStore(impl: ArchiveHandlerStoreImpl): ArchiveHandlerStore
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsFeature.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsFeature.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import androidx.compose.runtime.Composable
+import io.github.stslex.workeeper.core.ui.mvi.Feature
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreProcessor
+import io.github.stslex.workeeper.core.ui.navigation.Screen.Settings
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsComponent
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStoreImpl
+
+internal typealias SettingsStoreProcessor = StoreProcessor<State, Action, Event>
+
+internal object SettingsFeature : Feature<SettingsStoreProcessor, Settings, SettingsComponent>() {
+
+    @Composable
+    override fun processor(
+        screen: Settings,
+    ): SettingsStoreProcessor = createProcessor<SettingsStoreImpl, SettingsStoreImpl.Factory>(screen)
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsHandlerStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsHandlerStore.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.HandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+
+internal interface SettingsHandlerStore : HandlerStore<State, Action, Event>

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsHandlerStoreImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsHandlerStoreImpl.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.BaseHandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class SettingsHandlerStoreImpl @Inject constructor() : SettingsHandlerStore,
+    BaseHandlerStore<State, Action, Event>()

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/di/SettingsModule.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractorImpl
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal interface SettingsModule {
+
+    @Binds
+    @ViewModelScoped
+    fun bindInteractor(impl: SettingsInteractorImpl): SettingsInteractor
+
+    @Binds
+    @ViewModelScoped
+    fun bindHandlerStore(impl: SettingsHandlerStoreImpl): SettingsHandlerStore
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractor.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractor.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.domain
+
+import androidx.paging.PagingData
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("TooManyFunctions")
+internal interface SettingsInteractor {
+
+    fun appVersionName(): String
+
+    fun appVersionCode(): Long
+
+    fun observeThemeMode(): Flow<ThemeMode>
+
+    suspend fun setThemeMode(mode: ThemeMode)
+
+    fun observeArchivedExerciseCount(): Flow<Int>
+
+    fun observeArchivedTrainingCount(): Flow<Int>
+
+    fun pagedArchivedExercises(): Flow<PagingData<ArchivedItem.Exercise>>
+
+    fun pagedArchivedTrainings(): Flow<PagingData<ArchivedItem.Training>>
+
+    suspend fun restoreExercise(uuid: String)
+
+    suspend fun restoreTraining(uuid: String)
+
+    suspend fun reArchiveExercise(uuid: String)
+
+    suspend fun reArchiveTraining(uuid: String)
+
+    suspend fun countExerciseSessions(uuid: String): Int
+
+    suspend fun countTrainingSessions(uuid: String): Int
+
+    suspend fun permanentlyDeleteExercise(uuid: String)
+
+    suspend fun permanentlyDeleteTraining(uuid: String)
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImpl.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.domain
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.paging.PagingData
+import androidx.paging.map
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.dataStore.store.CommonDataStore
+import io.github.stslex.workeeper.core.exercise.exercise.ExerciseRepository
+import io.github.stslex.workeeper.core.exercise.training.TrainingRepository
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class SettingsInteractorImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val commonDataStore: CommonDataStore,
+    private val exerciseRepository: ExerciseRepository,
+    private val trainingRepository: TrainingRepository,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) : SettingsInteractor {
+
+    private val packageInfo: PackageInfo by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(context.packageName, 0)
+        }
+    }
+
+    override fun appVersionName(): String = packageInfo.versionName.orEmpty()
+
+    override fun appVersionCode(): Long = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        packageInfo.longVersionCode
+    } else {
+        @Suppress("DEPRECATION")
+        packageInfo.versionCode.toLong()
+    }
+
+    override fun observeThemeMode(): Flow<ThemeMode> = commonDataStore.themePreference
+        .map { value -> runCatching { ThemeMode.valueOf(value) }.getOrDefault(ThemeMode.SYSTEM) }
+        .flowOn(defaultDispatcher)
+
+    override suspend fun setThemeMode(mode: ThemeMode) {
+        commonDataStore.setThemePreference(mode.name)
+    }
+
+    override fun observeArchivedExerciseCount(): Flow<Int> = exerciseRepository
+        .observeArchivedCount()
+        .flowOn(defaultDispatcher)
+
+    override fun observeArchivedTrainingCount(): Flow<Int> = trainingRepository
+        .observeArchivedCount()
+        .flowOn(defaultDispatcher)
+
+    override fun pagedArchivedExercises(): Flow<PagingData<ArchivedItem.Exercise>> = exerciseRepository
+        .pagedArchived()
+        .map { pagingData ->
+            pagingData.map { exercise ->
+                ArchivedItem.Exercise(
+                    uuid = exercise.uuid,
+                    name = exercise.name,
+                    tags = exercise.labels,
+                    archivedAt = exercise.archivedAt ?: exercise.timestamp,
+                    type = exercise.type,
+                )
+            }
+        }
+        .flowOn(defaultDispatcher)
+
+    override fun pagedArchivedTrainings(): Flow<PagingData<ArchivedItem.Training>> = trainingRepository
+        .pagedArchived()
+        .map { pagingData ->
+            pagingData.map { training ->
+                ArchivedItem.Training(
+                    uuid = training.uuid,
+                    name = training.name,
+                    tags = training.labels,
+                    archivedAt = training.archivedAt ?: training.timestamp,
+                    exerciseCount = training.exerciseUuids.size,
+                )
+            }
+        }
+        .flowOn(defaultDispatcher)
+
+    override suspend fun restoreExercise(uuid: String) {
+        withContext(defaultDispatcher) { exerciseRepository.restore(uuid) }
+    }
+
+    override suspend fun restoreTraining(uuid: String) {
+        withContext(defaultDispatcher) { trainingRepository.restore(uuid) }
+    }
+
+    override suspend fun reArchiveExercise(uuid: String) {
+        withContext(defaultDispatcher) { exerciseRepository.archive(uuid) }
+    }
+
+    override suspend fun reArchiveTraining(uuid: String) {
+        withContext(defaultDispatcher) { trainingRepository.archive(uuid) }
+    }
+
+    override suspend fun countExerciseSessions(
+        uuid: String,
+    ): Int = withContext(defaultDispatcher) {
+        exerciseRepository.countSessionsUsing(uuid)
+    }
+
+    override suspend fun countTrainingSessions(
+        uuid: String,
+    ): Int = withContext(defaultDispatcher) {
+        trainingRepository.countSessionsUsing(uuid)
+    }
+
+    override suspend fun permanentlyDeleteExercise(uuid: String) {
+        withContext(defaultDispatcher) { exerciseRepository.permanentDelete(uuid) }
+    }
+
+    override suspend fun permanentlyDeleteTraining(uuid: String) {
+        withContext(defaultDispatcher) { trainingRepository.permanentDelete(uuid) }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/model/ArchivedItem.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/model/ArchivedItem.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.domain.model
+
+import androidx.compose.runtime.Stable
+import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel
+
+@Stable
+sealed interface ArchivedItem {
+
+    val uuid: String
+    val name: String
+    val tags: List<String>
+    val archivedAt: Long
+
+    @Stable
+    data class Exercise(
+        override val uuid: String,
+        override val name: String,
+        override val tags: List<String>,
+        override val archivedAt: Long,
+        val type: ExerciseTypeDataModel,
+    ) : ArchivedItem
+
+    @Stable
+    data class Training(
+        override val uuid: String,
+        override val name: String,
+        override val tags: List<String>,
+        override val archivedAt: Long,
+        val exerciseCount: Int,
+    ) : ArchivedItem
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
@@ -35,7 +35,7 @@ internal class ArchiveClickHandler @Inject constructor(
     }
 
     private fun processRestore(item: ArchivedItem) {
-        sendEvent(Event.Haptic(HapticFeedbackType.Confirm))
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
         launch {
             when (item) {
                 is ArchivedItem.Exercise -> interactor.restoreExercise(item.uuid)
@@ -67,7 +67,7 @@ internal class ArchiveClickHandler @Inject constructor(
 
     private fun processDeleteConfirm() {
         val target = state.value.pendingDeleteTarget ?: return
-        sendEvent(Event.Haptic(HapticFeedbackType.Confirm))
+        sendEvent(Event.Haptic(HapticFeedbackType.LongPress))
         updateState {
             it.copy(
                 pendingDeleteTarget = null,
@@ -95,6 +95,7 @@ internal class ArchiveClickHandler @Inject constructor(
     }
 
     private fun processUndoRestore(item: ArchivedItem) {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
         launch {
             when (item) {
                 is ArchivedItem.Exercise -> interactor.reArchiveExercise(item.uuid)

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.settings.di.ArchiveHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ArchiveClickHandler @Inject constructor(
+    private val interactor: SettingsInteractor,
+    store: ArchiveHandlerStore,
+) : Handler<Action.Click>, ArchiveHandlerStore by store {
+
+    override fun invoke(action: Action.Click) {
+        when (action) {
+            is Action.Click.OnSegmentChange -> processSegmentChange(action)
+            is Action.Click.OnRestoreClick -> processRestore(action.item)
+            is Action.Click.OnPermanentDeleteClick -> processDeleteRequest(action.item)
+            Action.Click.OnDeleteConfirm -> processDeleteConfirm()
+            Action.Click.OnDeleteDismiss -> processDeleteDismiss()
+            is Action.Click.OnUndoRestore -> processUndoRestore(action.item)
+        }
+    }
+
+    private fun processSegmentChange(action: Action.Click.OnSegmentChange) {
+        if (state.value.selectedSegment == action.segment) return
+        sendEvent(Event.Haptic(HapticFeedbackType.SegmentTick))
+        updateState { it.copy(selectedSegment = action.segment) }
+    }
+
+    private fun processRestore(item: ArchivedItem) {
+        sendEvent(Event.Haptic(HapticFeedbackType.Confirm))
+        launch {
+            when (item) {
+                is ArchivedItem.Exercise -> interactor.restoreExercise(item.uuid)
+                is ArchivedItem.Training -> interactor.restoreTraining(item.uuid)
+            }
+            sendEvent(Event.ShowRestoredSnackbar(item))
+        }
+    }
+
+    private fun processDeleteRequest(item: ArchivedItem) {
+        sendEvent(Event.Haptic(HapticFeedbackType.LongPress))
+        updateState {
+            it.copy(
+                pendingDeleteTarget = item,
+                pendingDeleteImpact = null,
+                deleteImpactLoading = true,
+            )
+        }
+        launch {
+            val impact = when (item) {
+                is ArchivedItem.Exercise -> interactor.countExerciseSessions(item.uuid)
+                is ArchivedItem.Training -> interactor.countTrainingSessions(item.uuid)
+            }
+            updateStateImmediate {
+                it.copy(pendingDeleteImpact = impact, deleteImpactLoading = false)
+            }
+        }
+    }
+
+    private fun processDeleteConfirm() {
+        val target = state.value.pendingDeleteTarget ?: return
+        sendEvent(Event.Haptic(HapticFeedbackType.Confirm))
+        updateState {
+            it.copy(
+                pendingDeleteTarget = null,
+                pendingDeleteImpact = null,
+                deleteImpactLoading = false,
+            )
+        }
+        launch {
+            when (target) {
+                is ArchivedItem.Exercise -> interactor.permanentlyDeleteExercise(target.uuid)
+                is ArchivedItem.Training -> interactor.permanentlyDeleteTraining(target.uuid)
+            }
+            sendEvent(Event.ShowPermanentlyDeletedSnackbar)
+        }
+    }
+
+    private fun processDeleteDismiss() {
+        updateState {
+            it.copy(
+                pendingDeleteTarget = null,
+                pendingDeleteImpact = null,
+                deleteImpactLoading = false,
+            )
+        }
+    }
+
+    private fun processUndoRestore(item: ArchivedItem) {
+        launch {
+            when (item) {
+                is ArchivedItem.Exercise -> interactor.reArchiveExercise(item.uuid)
+                is ArchivedItem.Training -> interactor.reArchiveTraining(item.uuid)
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandler.kt
@@ -80,7 +80,7 @@ internal class ArchiveClickHandler @Inject constructor(
                 is ArchivedItem.Exercise -> interactor.permanentlyDeleteExercise(target.uuid)
                 is ArchivedItem.Training -> interactor.permanentlyDeleteTraining(target.uuid)
             }
-            sendEvent(Event.ShowPermanentlyDeletedSnackbar)
+            sendEvent(Event.ShowPermanentlyDeletedSnackbar(target.name))
         }
     }
 

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveComponent.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveComponent.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Component
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen.Archive
+
+abstract class ArchiveComponent : Component<Archive>(Archive) {
+
+    companion object {
+
+        fun create(
+            navigator: Navigator,
+        ): ArchiveComponent = ArchiveNavigationHandler(
+            navigator = navigator,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveNavigationHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveNavigationHandler.kt
@@ -12,7 +12,7 @@ internal class ArchiveNavigationHandler(
 
     override fun invoke(action: Action.Navigation) {
         when (action) {
-            Action.Navigation.OnBackClick -> navigator.popBack()
+            Action.Navigation.Back -> navigator.popBack()
         }
     }
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveNavigationHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveNavigationHandler.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+
+@Suppress("MviHandlerConstructorRule")
+internal class ArchiveNavigationHandler(
+    private val navigator: Navigator,
+) : ArchiveComponent(), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            Action.Navigation.OnBackClick -> navigator.popBack()
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchivePagingHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchivePagingHandler.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import androidx.paging.PagingData
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.settings.di.ArchiveHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ArchivePagingHandler @Inject constructor(
+    private val interactor: SettingsInteractor,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    store: ArchiveHandlerStore,
+) : Handler<Action.Paging>, ArchiveHandlerStore by store {
+
+    val archivedExercisesPaging: PagingUiState<PagingData<ArchivedItem.Exercise>> = PagingUiState {
+        interactor.pagedArchivedExercises().flowOn(defaultDispatcher)
+    }
+
+    val archivedTrainingsPaging: PagingUiState<PagingData<ArchivedItem.Training>> = PagingUiState {
+        interactor.pagedArchivedTrainings().flowOn(defaultDispatcher)
+    }
+
+    override fun invoke(action: Action.Paging) {
+        when (action) {
+            Action.Paging.Init -> initObservers()
+        }
+    }
+
+    private fun initObservers() {
+        scope.launch(interactor.observeArchivedExerciseCount()) { count ->
+            updateStateImmediate { it.copy(exerciseCount = count) }
+        }
+        scope.launch(interactor.observeArchivedTrainingCount()) { count ->
+            updateStateImmediate { it.copy(trainingCount = count) }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.settings.about.AboutLinks
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class SettingsClickHandler @Inject constructor(
+    store: SettingsHandlerStore,
+) : Handler<Action.Click>, SettingsHandlerStore by store {
+
+    override fun invoke(action: Action.Click) {
+        when (action) {
+            Action.Click.OnArchiveClick -> sendEvent(Event.NavigateToArchive)
+            Action.Click.OnGitHubClick -> sendEvent(Event.ShowExternalLink(AboutLinks.GITHUB_URL))
+            Action.Click.OnLicenseClick -> sendEvent(Event.ShowExternalLink(AboutLinks.LICENSE_URL))
+            Action.Click.OnPrivacyPolicyClick -> sendEvent(
+                Event.ShowExternalLink(AboutLinks.PRIVACY_POLICY_URL),
+            )
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
@@ -18,7 +18,7 @@ internal class SettingsClickHandler @Inject constructor(
     override fun invoke(action: Action.Click) {
         sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
         when (action) {
-            Action.Click.OnArchiveClick -> sendEvent(Event.NavigateToArchive)
+            Action.Click.OnArchiveClick -> consume(Action.Navigation.OpenArchive)
             Action.Click.OnGitHubClick -> sendEvent(Event.ShowExternalLink(AboutLinks.GITHUB_URL))
             Action.Click.OnLicenseClick -> sendEvent(Event.ShowExternalLink(AboutLinks.LICENSE_URL))
             Action.Click.OnPrivacyPolicyClick -> sendEvent(

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.feature.settings.about.AboutLinks
@@ -15,6 +16,7 @@ internal class SettingsClickHandler @Inject constructor(
 ) : Handler<Action.Click>, SettingsHandlerStore by store {
 
     override fun invoke(action: Action.Click) {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
         when (action) {
             Action.Click.OnArchiveClick -> sendEvent(Event.NavigateToArchive)
             Action.Click.OnGitHubClick -> sendEvent(Event.ShowExternalLink(AboutLinks.GITHUB_URL))

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsComponent.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsComponent.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Component
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen.Settings
+
+abstract class SettingsComponent : Component<Settings>(Settings) {
+
+    companion object {
+
+        fun create(
+            navigator: Navigator,
+        ): SettingsComponent = SettingsNavigationHandler(
+            navigator = navigator,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandler.kt
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
 import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
 import javax.inject.Inject
 
 @ViewModelScoped
@@ -17,6 +19,7 @@ internal class SettingsInputHandler @Inject constructor(
     override fun invoke(action: Action.Input) {
         when (action) {
             is Action.Input.OnThemeChange -> {
+                sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
                 updateState { it.copy(themeMode = action.mode) }
                 launch { interactor.setThemeMode(action.mode) }
             }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandler.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class SettingsInputHandler @Inject constructor(
+    private val interactor: SettingsInteractor,
+    store: SettingsHandlerStore,
+) : Handler<Action.Input>, SettingsHandlerStore by store {
+
+    override fun invoke(action: Action.Input) {
+        when (action) {
+            is Action.Input.OnThemeChange -> {
+                updateState { it.copy(themeMode = action.mode) }
+                launch { interactor.setThemeMode(action.mode) }
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandler.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+
+@Suppress("MviHandlerConstructorRule")
+internal class SettingsNavigationHandler(
+    private val navigator: Navigator,
+) : SettingsComponent(), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            Action.Navigation.OnBackClick -> navigator.popBack()
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandler.kt
@@ -3,6 +3,7 @@ package io.github.stslex.workeeper.feature.settings.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
 
 @Suppress("MviHandlerConstructorRule")
@@ -12,7 +13,8 @@ internal class SettingsNavigationHandler(
 
     override fun invoke(action: Action.Navigation) {
         when (action) {
-            Action.Navigation.OnBackClick -> navigator.popBack()
+            Action.Navigation.Back -> navigator.popBack()
+            Action.Navigation.OpenArchive -> navigator.navTo(Screen.Archive)
         }
     }
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsPagingHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsPagingHandler.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class SettingsPagingHandler @Inject constructor(
+    private val interactor: SettingsInteractor,
+    store: SettingsHandlerStore,
+) : Handler<Action.Paging>, SettingsHandlerStore by store {
+
+    override fun invoke(action: Action.Paging) {
+        when (action) {
+            Action.Paging.Init -> observeTheme()
+        }
+    }
+
+    private fun observeTheme() {
+        scope.launch(interactor.observeThemeMode()) { mode ->
+            updateStateImmediate { it.copy(themeMode = mode) }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
@@ -80,7 +80,7 @@ internal interface ArchiveStore : Store<State, Action, Event> {
 
         data class ShowRestoredSnackbar(val item: ArchivedItem) : Event
 
-        data object ShowPermanentlyDeletedSnackbar : Event
+        data class ShowPermanentlyDeletedSnackbar(val name: String) : Event
 
         data class Haptic(val type: HapticFeedbackType) : Event
     }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.store
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.paging.PagingData
+import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
+import io.github.stslex.workeeper.core.ui.mvi.Store
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+
+internal interface ArchiveStore : Store<State, Action, Event> {
+
+    @Stable
+    enum class Segment { EXERCISES, TRAININGS }
+
+    @Stable
+    data class State(
+        val selectedSegment: Segment,
+        val exerciseCount: Int,
+        val trainingCount: Int,
+        val archivedExercisesPaging: PagingUiState<PagingData<ArchivedItem.Exercise>>,
+        val archivedTrainingsPaging: PagingUiState<PagingData<ArchivedItem.Training>>,
+        val pendingDeleteImpact: Int?,
+        val pendingDeleteTarget: ArchivedItem?,
+        val deleteImpactLoading: Boolean,
+    ) : Store.State {
+
+        companion object {
+
+            fun init(
+                archivedExercisesPaging: PagingUiState<PagingData<ArchivedItem.Exercise>>,
+                archivedTrainingsPaging: PagingUiState<PagingData<ArchivedItem.Training>>,
+            ): State = State(
+                selectedSegment = Segment.EXERCISES,
+                exerciseCount = 0,
+                trainingCount = 0,
+                archivedExercisesPaging = archivedExercisesPaging,
+                archivedTrainingsPaging = archivedTrainingsPaging,
+                pendingDeleteImpact = null,
+                pendingDeleteTarget = null,
+                deleteImpactLoading = false,
+            )
+        }
+    }
+
+    @Stable
+    sealed interface Action : Store.Action {
+
+        sealed interface Paging : Action {
+
+            data object Init : Paging
+        }
+
+        sealed interface Click : Action {
+
+            data class OnSegmentChange(val segment: Segment) : Click
+
+            data class OnRestoreClick(val item: ArchivedItem) : Click
+
+            data class OnPermanentDeleteClick(val item: ArchivedItem) : Click
+
+            data object OnDeleteConfirm : Click
+
+            data object OnDeleteDismiss : Click
+
+            data class OnUndoRestore(val item: ArchivedItem) : Click
+        }
+
+        sealed interface Navigation : Action {
+
+            data object OnBackClick : Navigation
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+
+        data class ShowRestoredSnackbar(val item: ArchivedItem) : Event
+
+        data object ShowPermanentlyDeletedSnackbar : Event
+
+        data class Haptic(val type: HapticFeedbackType) : Event
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStore.kt
@@ -71,7 +71,7 @@ internal interface ArchiveStore : Store<State, Action, Event> {
 
         sealed interface Navigation : Action {
 
-            data object OnBackClick : Navigation
+            data object Back : Navigation
         }
     }
 

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStoreImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/ArchiveStoreImpl.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.store
+
+import androidx.annotation.VisibleForTesting
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.stslex.workeeper.core.ui.mvi.BaseStore
+import io.github.stslex.workeeper.core.ui.mvi.di.StoreDispatchers
+import io.github.stslex.workeeper.core.ui.mvi.holders.AnalyticsHolder
+import io.github.stslex.workeeper.core.ui.mvi.holders.LoggerHolder
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
+import io.github.stslex.workeeper.feature.settings.di.ArchiveHandlerStoreImpl
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveClickHandler
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveComponent
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveNavigationHandler
+import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchivePagingHandler
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+
+@HiltViewModel(assistedFactory = ArchiveStoreImpl.Factory::class)
+internal class ArchiveStoreImpl @AssistedInject constructor(
+    @Assisted component: ArchiveComponent,
+    pagingHandler: ArchivePagingHandler,
+    clickHandler: ArchiveClickHandler,
+    storeDispatchers: StoreDispatchers,
+    storeEmitter: ArchiveHandlerStoreImpl,
+    analyticsHolder: AnalyticsHolder,
+    loggerHolder: LoggerHolder,
+) : BaseStore<State, Action, Event>(
+    name = NAME,
+    initialState = State.init(
+        archivedExercisesPaging = pagingHandler.archivedExercisesPaging,
+        archivedTrainingsPaging = pagingHandler.archivedTrainingsPaging,
+    ),
+    storeEmitter = storeEmitter,
+    storeDispatchers = storeDispatchers,
+    handlerCreator = { action ->
+        when (action) {
+            is Action.Paging -> pagingHandler
+            is Action.Navigation -> component as ArchiveNavigationHandler
+            is Action.Click -> clickHandler
+        }
+    },
+    initialActions = listOf(Action.Paging.Init),
+    analyticsHolder = analyticsHolder,
+    loggerHolder = loggerHolder,
+) {
+
+    @AssistedFactory
+    interface Factory : StoreFactory<ArchiveComponent, ArchiveStoreImpl>
+
+    companion object {
+
+        @VisibleForTesting
+        private const val NAME = "Archive"
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
@@ -54,18 +54,16 @@ internal interface SettingsStore : Store<State, Action, Event> {
 
         sealed interface Navigation : Action {
 
-            data object OnBackClick : Navigation
+            data object Back : Navigation
+
+            data object OpenArchive : Navigation
         }
     }
 
     @Stable
     sealed interface Event : Store.Event {
 
-        data object NavigateToArchive : Event
-
         data class ShowExternalLink(val url: String) : Event
-
-        data object NavigateBack : Event
 
         data class Haptic(val type: HapticFeedbackType) : Event
     }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.store
+
+import androidx.compose.runtime.Stable
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.core.ui.mvi.Store
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+
+internal interface SettingsStore : Store<State, Action, Event> {
+
+    @Stable
+    data class State(
+        val themeMode: ThemeMode,
+        val appVersion: String,
+        val appVersionCode: Int,
+    ) : Store.State {
+
+        companion object {
+
+            fun initial(
+                appVersion: String,
+                appVersionCode: Int,
+            ): State = State(
+                themeMode = ThemeMode.SYSTEM,
+                appVersion = appVersion,
+                appVersionCode = appVersionCode,
+            )
+        }
+    }
+
+    @Stable
+    sealed interface Action : Store.Action {
+
+        sealed interface Paging : Action {
+
+            data object Init : Paging
+        }
+
+        sealed interface Click : Action {
+
+            data object OnArchiveClick : Click
+            data object OnGitHubClick : Click
+            data object OnLicenseClick : Click
+            data object OnPrivacyPolicyClick : Click
+        }
+
+        sealed interface Input : Action {
+
+            data class OnThemeChange(val mode: ThemeMode) : Input
+        }
+
+        sealed interface Navigation : Action {
+
+            data object OnBackClick : Navigation
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+
+        data object NavigateToArchive : Event
+
+        data class ShowExternalLink(val url: String) : Event
+
+        data object NavigateBack : Event
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.settings.mvi.store
 
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
 import io.github.stslex.workeeper.core.ui.mvi.Store
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
@@ -65,5 +66,7 @@ internal interface SettingsStore : Store<State, Action, Event> {
         data class ShowExternalLink(val url: String) : Event
 
         data object NavigateBack : Event
+
+        data class Haptic(val type: HapticFeedbackType) : Event
     }
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStoreImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStoreImpl.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.store
+
+import androidx.annotation.VisibleForTesting
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.stslex.workeeper.core.ui.mvi.BaseStore
+import io.github.stslex.workeeper.core.ui.mvi.di.StoreDispatchers
+import io.github.stslex.workeeper.core.ui.mvi.holders.AnalyticsHolder
+import io.github.stslex.workeeper.core.ui.mvi.holders.LoggerHolder
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStoreImpl
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsClickHandler
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsComponent
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsInputHandler
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsNavigationHandler
+import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsPagingHandler
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+
+@HiltViewModel(assistedFactory = SettingsStoreImpl.Factory::class)
+internal class SettingsStoreImpl @AssistedInject constructor(
+    @Assisted component: SettingsComponent,
+    pagingHandler: SettingsPagingHandler,
+    clickHandler: SettingsClickHandler,
+    inputHandler: SettingsInputHandler,
+    interactor: SettingsInteractor,
+    storeDispatchers: StoreDispatchers,
+    storeEmitter: SettingsHandlerStoreImpl,
+    analyticsHolder: AnalyticsHolder,
+    loggerHolder: LoggerHolder,
+) : BaseStore<State, Action, Event>(
+    name = NAME,
+    initialState = State.initial(
+        appVersion = interactor.appVersionName(),
+        appVersionCode = interactor.appVersionCode().toInt(),
+    ),
+    storeEmitter = storeEmitter,
+    storeDispatchers = storeDispatchers,
+    handlerCreator = { action ->
+        when (action) {
+            is Action.Paging -> pagingHandler
+            is Action.Navigation -> component as SettingsNavigationHandler
+            is Action.Click -> clickHandler
+            is Action.Input -> inputHandler
+        }
+    },
+    initialActions = listOf(Action.Paging.Init),
+    analyticsHolder = analyticsHolder,
+    loggerHolder = loggerHolder,
+) {
+
+    @AssistedFactory
+    interface Factory : StoreFactory<SettingsComponent, SettingsStoreImpl>
+
+    companion object {
+
+        @VisibleForTesting
+        private const val NAME = "Settings"
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveGraph.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui
+
+import android.text.format.DateUtils
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavGraphBuilder
+import io.github.stslex.workeeper.core.ui.kit.snackbar.AppSnackbarModel
+import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
+import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
+import io.github.stslex.workeeper.feature.settings.R
+import io.github.stslex.workeeper.feature.settings.di.ArchiveFeature
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+
+private fun formatArchivedAt(timestamp: Long): String = if (timestamp <= 0L) {
+    "Archived"
+} else {
+    val relative = DateUtils.getRelativeTimeSpanString(
+        timestamp,
+        System.currentTimeMillis(),
+        DateUtils.MINUTE_IN_MILLIS,
+        DateUtils.FORMAT_ABBREV_RELATIVE,
+    ).toString()
+    "Archived $relative"
+}
+
+fun NavGraphBuilder.archiveGraph(
+    modifier: Modifier = Modifier,
+) {
+    navComponentScreen(ArchiveFeature) { processor ->
+        val haptic = LocalHapticFeedback.current
+        val formatter = remember<(Long) -> String> { ::formatArchivedAt }
+        val restoredTemplate = stringResource(R.string.feature_settings_snackbar_restored)
+        val undoLabel = stringResource(R.string.feature_settings_snackbar_undo)
+        val deletedMessage = stringResource(R.string.feature_settings_snackbar_deleted)
+
+        processor.Handle { event ->
+            when (event) {
+                is Event.Haptic -> haptic.performHapticFeedback(event.type)
+                is Event.ShowRestoredSnackbar -> {
+                    SnackbarManager.showSnackbar(
+                        AppSnackbarModel(
+                            message = restoredTemplate.format(event.item.name),
+                            actionLabel = undoLabel,
+                            withDismissAction = true,
+                            action = { processor.consume(Action.Click.OnUndoRestore(event.item)) },
+                        ),
+                    )
+                }
+
+                Event.ShowPermanentlyDeletedSnackbar -> {
+                    SnackbarManager.showSnackbar(message = deletedMessage)
+                }
+            }
+        }
+
+        ArchiveScreen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+            formatArchivedAt = formatter,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveGraph.kt
@@ -15,16 +15,22 @@ import io.github.stslex.workeeper.feature.settings.di.ArchiveFeature
 import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
 import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
 
-private fun formatArchivedAt(timestamp: Long): String = if (timestamp <= 0L) {
-    "Archived"
-} else {
-    val relative = DateUtils.getRelativeTimeSpanString(
-        timestamp,
-        System.currentTimeMillis(),
-        DateUtils.MINUTE_IN_MILLIS,
-        DateUtils.FORMAT_ABBREV_RELATIVE,
-    ).toString()
-    "Archived $relative"
+private class ArchivedAtFormatter(
+    private val archivedLabel: String,
+    private val archivedRelativeFormat: String,
+) : (Long) -> String {
+
+    override fun invoke(timestamp: Long): String = if (timestamp <= 0L) {
+        archivedLabel
+    } else {
+        val relative = DateUtils.getRelativeTimeSpanString(
+            timestamp,
+            System.currentTimeMillis(),
+            DateUtils.MINUTE_IN_MILLIS,
+            DateUtils.FORMAT_ABBREV_RELATIVE,
+        ).toString()
+        archivedRelativeFormat.format(relative)
+    }
 }
 
 fun NavGraphBuilder.archiveGraph(
@@ -32,10 +38,15 @@ fun NavGraphBuilder.archiveGraph(
 ) {
     navComponentScreen(ArchiveFeature) { processor ->
         val haptic = LocalHapticFeedback.current
-        val formatter = remember<(Long) -> String> { ::formatArchivedAt }
-        val restoredTemplate = stringResource(R.string.feature_settings_snackbar_restored)
-        val undoLabel = stringResource(R.string.feature_settings_snackbar_undo)
-        val deletedMessage = stringResource(R.string.feature_settings_snackbar_deleted)
+        val archivedLabel = stringResource(R.string.feature_archive_label_archived)
+        val archivedRelativeFormat = stringResource(R.string.feature_archive_label_archived_relative_format)
+        val restoredTemplate = stringResource(R.string.feature_archive_snackbar_restored_format)
+        val deletedTemplate = stringResource(R.string.feature_archive_snackbar_deleted_format)
+        val undoLabel = stringResource(R.string.feature_archive_snackbar_undo)
+
+        val formatter = remember(archivedLabel, archivedRelativeFormat) {
+            ArchivedAtFormatter(archivedLabel, archivedRelativeFormat)
+        }
 
         processor.Handle { event ->
             when (event) {
@@ -51,8 +62,8 @@ fun NavGraphBuilder.archiveGraph(
                     )
                 }
 
-                Event.ShowPermanentlyDeletedSnackbar -> {
-                    SnackbarManager.showSnackbar(message = deletedMessage)
+                is Event.ShowPermanentlyDeletedSnackbar -> {
+                    SnackbarManager.showSnackbar(message = deletedTemplate.format(event.name))
                 }
             }
         }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
@@ -43,6 +43,7 @@ import io.github.stslex.workeeper.feature.settings.ui.components.ArchivedItemRow
 import io.github.stslex.workeeper.feature.settings.ui.components.PermanentDeleteDialog
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.flowOf
+import io.github.stslex.workeeper.core.ui.kit.R as KitR
 
 @Composable
 internal fun ArchiveScreen(
@@ -66,7 +67,7 @@ internal fun ArchiveScreen(
             .testTag("ArchiveScreen"),
     ) {
         AppTopAppBar(
-            title = stringResource(R.string.feature_settings_archive_title),
+            title = stringResource(R.string.feature_archive_title),
             navigationIcon = {
                 IconButton(
                     modifier = Modifier.testTag("ArchiveBackButton"),
@@ -75,7 +76,7 @@ internal fun ArchiveScreen(
                     Icon(
                         modifier = Modifier.size(AppDimension.iconMd),
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(R.string.feature_settings_back),
+                        contentDescription = stringResource(KitR.string.core_ui_kit_action_back),
                     )
                 }
             },
@@ -86,8 +87,8 @@ internal fun ArchiveScreen(
                 .padding(horizontal = AppDimension.screenEdge, vertical = AppDimension.Space.sm)
                 .testTag("ArchiveSegments"),
             items = persistentListOf(
-                stringResource(R.string.feature_settings_archive_segment_exercises, state.exerciseCount),
-                stringResource(R.string.feature_settings_archive_segment_trainings, state.trainingCount),
+                stringResource(R.string.feature_archive_segment_exercises, state.exerciseCount),
+                stringResource(R.string.feature_archive_segment_trainings, state.trainingCount),
             ),
             selected = if (state.selectedSegment == Segment.EXERCISES) 0 else 1,
             onSelectedChange = { index ->
@@ -145,8 +146,8 @@ private fun ArchivedExerciseList(
     if (isPagingEmpty(items.loadState, items.itemCount)) {
         AppEmptyState(
             modifier = modifier.testTag("ArchiveEmptyExercises"),
-            headline = stringResource(R.string.feature_settings_archive_empty_headline),
-            supportingText = stringResource(R.string.feature_settings_archive_empty_supporting_exercises),
+            headline = stringResource(R.string.feature_archive_empty_headline),
+            supportingText = stringResource(R.string.feature_archive_empty_supporting_exercises),
             icon = Icons.Filled.Inventory2,
         )
         return
@@ -183,8 +184,8 @@ private fun ArchivedTrainingList(
     if (isPagingEmpty(items.loadState, items.itemCount)) {
         AppEmptyState(
             modifier = modifier.testTag("ArchiveEmptyTrainings"),
-            headline = stringResource(R.string.feature_settings_archive_empty_headline),
-            supportingText = stringResource(R.string.feature_settings_archive_empty_supporting_trainings),
+            headline = stringResource(R.string.feature_archive_empty_headline),
+            supportingText = stringResource(R.string.feature_archive_empty_supporting_trainings),
             icon = Icons.Filled.Inventory2,
         )
         return

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import io.github.stslex.workeeper.core.ui.kit.components.empty.AppEmptyState
+import io.github.stslex.workeeper.core.ui.kit.components.loading.AppLoadingIndicator
+import io.github.stslex.workeeper.core.ui.kit.components.segmented.AppSegmentedControl
+import io.github.stslex.workeeper.core.ui.kit.components.topbar.AppTopAppBar
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.feature.settings.R
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Segment
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+import io.github.stslex.workeeper.feature.settings.ui.components.ArchivedItemRow
+import io.github.stslex.workeeper.feature.settings.ui.components.PermanentDeleteDialog
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.flowOf
+
+@Composable
+internal fun ArchiveScreen(
+    state: State,
+    consume: (Action) -> Unit,
+    formatArchivedAt: (Long) -> String,
+    modifier: Modifier = Modifier,
+) {
+    val exerciseItems = remember(state.archivedExercisesPaging) {
+        state.archivedExercisesPaging()
+    }.collectAsLazyPagingItems()
+
+    val trainingItems = remember(state.archivedTrainingsPaging) {
+        state.archivedTrainingsPaging()
+    }.collectAsLazyPagingItems()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppUi.colors.surfaceTier0)
+            .testTag("ArchiveScreen"),
+    ) {
+        AppTopAppBar(
+            title = stringResource(R.string.feature_settings_archive_title),
+            navigationIcon = {
+                IconButton(
+                    modifier = Modifier.testTag("ArchiveBackButton"),
+                    onClick = { consume(Action.Navigation.OnBackClick) },
+                ) {
+                    Icon(
+                        modifier = Modifier.size(AppDimension.iconMd),
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.feature_settings_back),
+                    )
+                }
+            },
+        )
+
+        AppSegmentedControl(
+            modifier = Modifier
+                .padding(horizontal = AppDimension.screenEdge, vertical = AppDimension.Space.sm)
+                .testTag("ArchiveSegments"),
+            items = persistentListOf(
+                stringResource(R.string.feature_settings_archive_segment_exercises, state.exerciseCount),
+                stringResource(R.string.feature_settings_archive_segment_trainings, state.trainingCount),
+            ),
+            selected = if (state.selectedSegment == Segment.EXERCISES) 0 else 1,
+            onSelectedChange = { index ->
+                val segment = if (index == 0) Segment.EXERCISES else Segment.TRAININGS
+                consume(Action.Click.OnSegmentChange(segment))
+            },
+        )
+
+        when (state.selectedSegment) {
+            Segment.EXERCISES -> ArchivedExerciseList(
+                items = exerciseItems,
+                consume = consume,
+                formatArchivedAt = formatArchivedAt,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            Segment.TRAININGS -> ArchivedTrainingList(
+                items = trainingItems,
+                consume = consume,
+                formatArchivedAt = formatArchivedAt,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+
+    val target = state.pendingDeleteTarget
+    if (target != null) {
+        if (state.deleteImpactLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag("ArchiveDialogLoading"),
+                contentAlignment = Alignment.Center,
+            ) {
+                AppLoadingIndicator()
+            }
+        } else {
+            PermanentDeleteDialog(
+                target = target,
+                impactCount = state.pendingDeleteImpact ?: 0,
+                onConfirm = { consume(Action.Click.OnDeleteConfirm) },
+                onDismiss = { consume(Action.Click.OnDeleteDismiss) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArchivedExerciseList(
+    items: LazyPagingItems<ArchivedItem.Exercise>,
+    consume: (Action) -> Unit,
+    formatArchivedAt: (Long) -> String,
+    modifier: Modifier = Modifier,
+) {
+    if (isPagingEmpty(items.loadState, items.itemCount)) {
+        AppEmptyState(
+            modifier = modifier.testTag("ArchiveEmptyExercises"),
+            headline = stringResource(R.string.feature_settings_archive_empty_headline),
+            supportingText = stringResource(R.string.feature_settings_archive_empty_supporting_exercises),
+            icon = Icons.Filled.Inventory2,
+        )
+        return
+    }
+    LazyColumn(
+        modifier = modifier.testTag("ArchiveExerciseList"),
+        contentPadding = PaddingValues(horizontal = AppDimension.screenEdge, vertical = AppDimension.Space.sm),
+        state = rememberLazyListState(),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+    ) {
+        items(
+            count = items.itemCount,
+            key = { index -> items.peek(index)?.uuid ?: "exercise_$index" },
+        ) { index ->
+            items[index]?.let { item ->
+                ArchivedItemRow(
+                    item = item,
+                    archivedAtLabel = formatArchivedAt(item.archivedAt),
+                    onRestore = { consume(Action.Click.OnRestoreClick(item)) },
+                    onPermanentDelete = { consume(Action.Click.OnPermanentDeleteClick(item)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArchivedTrainingList(
+    items: LazyPagingItems<ArchivedItem.Training>,
+    consume: (Action) -> Unit,
+    formatArchivedAt: (Long) -> String,
+    modifier: Modifier = Modifier,
+) {
+    if (isPagingEmpty(items.loadState, items.itemCount)) {
+        AppEmptyState(
+            modifier = modifier.testTag("ArchiveEmptyTrainings"),
+            headline = stringResource(R.string.feature_settings_archive_empty_headline),
+            supportingText = stringResource(R.string.feature_settings_archive_empty_supporting_trainings),
+            icon = Icons.Filled.Inventory2,
+        )
+        return
+    }
+    LazyColumn(
+        modifier = modifier.testTag("ArchiveTrainingList"),
+        contentPadding = PaddingValues(horizontal = AppDimension.screenEdge, vertical = AppDimension.Space.sm),
+        state = rememberLazyListState(),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+    ) {
+        items(
+            count = items.itemCount,
+            key = { index -> items.peek(index)?.uuid ?: "training_$index" },
+        ) { index ->
+            items[index]?.let { item ->
+                ArchivedItemRow(
+                    item = item,
+                    archivedAtLabel = formatArchivedAt(item.archivedAt),
+                    onRestore = { consume(Action.Click.OnRestoreClick(item)) },
+                    onPermanentDelete = { consume(Action.Click.OnPermanentDeleteClick(item)) },
+                )
+            }
+        }
+    }
+}
+
+@Suppress("ComplexCondition")
+private fun isPagingEmpty(
+    loadState: androidx.paging.CombinedLoadStates,
+    itemCount: Int,
+): Boolean = loadState.refresh is LoadState.NotLoading &&
+    loadState.append is LoadState.NotLoading &&
+    loadState.prepend is LoadState.NotLoading &&
+    itemCount == 0
+
+@Preview(name = "Light", showBackground = true)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun ArchiveScreenPreview() {
+    AppTheme {
+        ArchiveScreen(
+            state = State(
+                selectedSegment = Segment.EXERCISES,
+                exerciseCount = 0,
+                trainingCount = 0,
+                archivedExercisesPaging = { flowOf(PagingData.empty()) },
+                archivedTrainingsPaging = { flowOf(PagingData.empty()) },
+                pendingDeleteImpact = null,
+                pendingDeleteTarget = null,
+                deleteImpactLoading = false,
+            ),
+            consume = {},
+            formatArchivedAt = { "Archived recently" },
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/ArchiveScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -71,7 +70,7 @@ internal fun ArchiveScreen(
             navigationIcon = {
                 IconButton(
                     modifier = Modifier.testTag("ArchiveBackButton"),
-                    onClick = { consume(Action.Navigation.OnBackClick) },
+                    onClick = { consume(Action.Navigation.Back) },
                 ) {
                     Icon(
                         modifier = Modifier.size(AppDimension.iconMd),

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui
+
+import android.content.Intent
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import androidx.navigation.NavGraphBuilder
+import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
+import io.github.stslex.workeeper.core.ui.navigation.LocalNavigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.settings.di.SettingsFeature
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+
+fun NavGraphBuilder.settingsGraph(
+    modifier: Modifier = Modifier,
+) {
+    navComponentScreen(SettingsFeature) { processor ->
+        val context = LocalContext.current
+        val navigator = LocalNavigator.current
+
+        processor.Handle { event ->
+            when (event) {
+                Event.NavigateToArchive -> navigator.navTo(Screen.Archive)
+                Event.NavigateBack -> navigator.popBack()
+                is Event.ShowExternalLink -> {
+                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri()).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    runCatching { context.startActivity(intent) }
+                }
+            }
+        }
+
+        SettingsScreen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
@@ -4,6 +4,7 @@ package io.github.stslex.workeeper.feature.settings.ui
 import android.content.Intent
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.core.net.toUri
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
@@ -18,6 +19,7 @@ fun NavGraphBuilder.settingsGraph(
     navComponentScreen(SettingsFeature) { processor ->
         val context = LocalContext.current
         val navigator = LocalNavigator.current
+        val haptic = LocalHapticFeedback.current
 
         processor.Handle { event ->
             when (event) {
@@ -29,6 +31,8 @@ fun NavGraphBuilder.settingsGraph(
                     }
                     runCatching { context.startActivity(intent) }
                 }
+
+                is Event.Haptic -> haptic.performHapticFeedback(event.type)
             }
         }
 

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.core.net.toUri
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
-import io.github.stslex.workeeper.core.ui.navigation.LocalNavigator
-import io.github.stslex.workeeper.core.ui.navigation.Screen
 import io.github.stslex.workeeper.feature.settings.di.SettingsFeature
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
 
@@ -18,13 +16,10 @@ fun NavGraphBuilder.settingsGraph(
 ) {
     navComponentScreen(SettingsFeature) { processor ->
         val context = LocalContext.current
-        val navigator = LocalNavigator.current
         val haptic = LocalHapticFeedback.current
 
         processor.Handle { event ->
             when (event) {
-                Event.NavigateToArchive -> navigator.navTo(Screen.Archive)
-                Event.NavigateBack -> navigator.popBack()
                 is Event.ShowExternalLink -> {
                     val intent = Intent(Intent.ACTION_VIEW, event.url.toUri()).apply {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
@@ -47,7 +47,7 @@ internal fun SettingsScreen(
             navigationIcon = {
                 IconButton(
                     modifier = Modifier.testTag("SettingsBackButton"),
-                    onClick = { consume(Action.Navigation.OnBackClick) },
+                    onClick = { consume(Action.Navigation.Back) },
                 ) {
                     Icon(
                         modifier = Modifier.size(AppDimension.iconMd),

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.topbar.AppTopAppBar
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.R
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+import io.github.stslex.workeeper.feature.settings.ui.components.AboutBlock
+import io.github.stslex.workeeper.feature.settings.ui.components.SettingsRow
+import io.github.stslex.workeeper.feature.settings.ui.components.SettingsSection
+import io.github.stslex.workeeper.feature.settings.ui.components.ThemeSelector
+
+@Composable
+internal fun SettingsScreen(
+    state: State,
+    consume: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppUi.colors.surfaceTier0)
+            .testTag("SettingsScreen"),
+    ) {
+        AppTopAppBar(
+            title = stringResource(R.string.feature_settings_title),
+            navigationIcon = {
+                IconButton(
+                    modifier = Modifier.testTag("SettingsBackButton"),
+                    onClick = { consume(Action.Navigation.OnBackClick) },
+                ) {
+                    Icon(
+                        modifier = Modifier.size(AppDimension.iconMd),
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.feature_settings_back),
+                    )
+                }
+            },
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.sectionSpacing),
+        ) {
+            SettingsSection(title = stringResource(R.string.feature_settings_about_section)) {
+                AboutBlock(
+                    appVersion = state.appVersion,
+                    appVersionCode = state.appVersionCode,
+                    onLicenseClick = { consume(Action.Click.OnLicenseClick) },
+                    onGitHubClick = { consume(Action.Click.OnGitHubClick) },
+                    onPrivacyClick = { consume(Action.Click.OnPrivacyPolicyClick) },
+                )
+            }
+            SettingsSection(title = stringResource(R.string.feature_settings_appearance_section)) {
+                ThemeSelector(
+                    selected = state.themeMode,
+                    onSelectedChange = { mode -> consume(Action.Input.OnThemeChange(mode)) },
+                )
+            }
+            SettingsSection(title = stringResource(R.string.feature_settings_data_section)) {
+                SettingsRow(
+                    modifier = Modifier.testTag("SettingsArchiveRow"),
+                    title = stringResource(R.string.feature_settings_archive_title),
+                    onClick = { consume(Action.Click.OnArchiveClick) },
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Light", showBackground = true)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun SettingsScreenPreview() {
+    AppTheme {
+        SettingsScreen(
+            state = State(
+                themeMode = ThemeMode.SYSTEM,
+                appVersion = "1.0.0",
+                appVersionCode = 15,
+            ),
+            consume = {},
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsScreen.kt
@@ -29,6 +29,7 @@ import io.github.stslex.workeeper.feature.settings.ui.components.AboutBlock
 import io.github.stslex.workeeper.feature.settings.ui.components.SettingsRow
 import io.github.stslex.workeeper.feature.settings.ui.components.SettingsSection
 import io.github.stslex.workeeper.feature.settings.ui.components.ThemeSelector
+import io.github.stslex.workeeper.core.ui.kit.R as KitR
 
 @Composable
 internal fun SettingsScreen(
@@ -52,7 +53,7 @@ internal fun SettingsScreen(
                     Icon(
                         modifier = Modifier.size(AppDimension.iconMd),
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(R.string.feature_settings_back),
+                        contentDescription = stringResource(KitR.string.core_ui_kit_action_back),
                     )
                 }
             },
@@ -63,7 +64,7 @@ internal fun SettingsScreen(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(AppDimension.sectionSpacing),
         ) {
-            SettingsSection(title = stringResource(R.string.feature_settings_about_section)) {
+            SettingsSection(title = stringResource(R.string.feature_settings_section_about)) {
                 AboutBlock(
                     appVersion = state.appVersion,
                     appVersionCode = state.appVersionCode,
@@ -72,16 +73,16 @@ internal fun SettingsScreen(
                     onPrivacyClick = { consume(Action.Click.OnPrivacyPolicyClick) },
                 )
             }
-            SettingsSection(title = stringResource(R.string.feature_settings_appearance_section)) {
+            SettingsSection(title = stringResource(R.string.feature_settings_section_appearance)) {
                 ThemeSelector(
                     selected = state.themeMode,
                     onSelectedChange = { mode -> consume(Action.Input.OnThemeChange(mode)) },
                 )
             }
-            SettingsSection(title = stringResource(R.string.feature_settings_data_section)) {
+            SettingsSection(title = stringResource(R.string.feature_settings_section_data)) {
                 SettingsRow(
                     modifier = Modifier.testTag("SettingsArchiveRow"),
-                    title = stringResource(R.string.feature_settings_archive_title),
+                    title = stringResource(R.string.feature_archive_title),
                     onClick = { consume(Action.Click.OnArchiveClick) },
                 )
             }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AboutBlock.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AboutBlock.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.feature.settings.R
+
+@Composable
+internal fun AboutBlock(
+    appVersion: String,
+    appVersionCode: Int,
+    onLicenseClick: () -> Unit,
+    onGitHubClick: () -> Unit,
+    onPrivacyClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = AppDimension.screenEdge),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+    ) {
+        Text(
+            text = stringResource(R.string.feature_settings_about_app_name),
+            style = AppUi.typography.titleMedium,
+            color = AppUi.colors.textPrimary,
+        )
+        Text(
+            text = stringResource(R.string.feature_settings_about_version, appVersion, appVersionCode),
+            style = AppUi.typography.bodySmall,
+            color = AppUi.colors.textTertiary,
+        )
+        Text(
+            modifier = Modifier
+                .clickable(onClick = onLicenseClick)
+                .padding(vertical = AppDimension.Space.xxs),
+            text = stringResource(R.string.feature_settings_about_license),
+            style = AppUi.typography.bodySmall,
+            color = AppUi.colors.accent,
+        )
+        Text(
+            modifier = Modifier
+                .clickable(onClick = onGitHubClick)
+                .padding(vertical = AppDimension.Space.xxs),
+            text = stringResource(R.string.feature_settings_about_github),
+            style = AppUi.typography.bodyMedium,
+            color = AppUi.colors.accent,
+        )
+        Text(
+            modifier = Modifier
+                .clickable(onClick = onPrivacyClick)
+                .padding(vertical = AppDimension.Space.xxs),
+            text = stringResource(R.string.feature_settings_about_privacy),
+            style = AppUi.typography.bodyMedium,
+            color = AppUi.colors.accent,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AboutBlock.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AboutBlock.kt
@@ -35,7 +35,7 @@ internal fun AboutBlock(
             color = AppUi.colors.textPrimary,
         )
         Text(
-            text = stringResource(R.string.feature_settings_about_version, appVersion, appVersionCode),
+            text = stringResource(R.string.feature_settings_about_version_format, appVersion, appVersionCode),
             style = AppUi.typography.bodySmall,
             color = AppUi.colors.textTertiary,
         )

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ArchivedItemRow.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ArchivedItemRow.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.components.tag.AppTagChip
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.feature.settings.R
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+
+@Composable
+internal fun ArchivedItemRow(
+    item: ArchivedItem,
+    archivedAtLabel: String,
+    onRestore: () -> Unit,
+    onPermanentDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(AppUi.shapes.medium)
+            .background(AppUi.colors.surfaceTier1)
+            .padding(AppDimension.cardPadding),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("ArchivedItemName_${item.uuid}"),
+                text = item.name,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textPrimary,
+            )
+            AppButton.Tertiary(
+                modifier = Modifier.testTag("ArchivedItemRestore_${item.uuid}"),
+                text = stringResource(R.string.feature_settings_archive_restore),
+                onClick = onRestore,
+                size = AppButtonSize.SMALL,
+            )
+            Box {
+                IconButton(
+                    modifier = Modifier
+                        .size(AppDimension.heightXs)
+                        .testTag("ArchivedItemMenu_${item.uuid}"),
+                    onClick = { menuExpanded = true },
+                ) {
+                    Icon(
+                        modifier = Modifier.size(AppDimension.iconSm),
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = stringResource(R.string.feature_settings_more),
+                        tint = AppUi.colors.textSecondary,
+                    )
+                }
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false },
+                    containerColor = AppUi.colors.surfaceTier2,
+                ) {
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(R.string.feature_settings_archive_delete_permanently),
+                                style = AppUi.typography.bodyMedium,
+                                color = AppUi.colors.setType.failureForeground,
+                            )
+                        },
+                        onClick = {
+                            menuExpanded = false
+                            onPermanentDelete()
+                        },
+                    )
+                }
+            }
+        }
+        if (item.tags.isNotEmpty()) {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+                contentPadding = PaddingValues(vertical = AppDimension.Space.xxs),
+            ) {
+                items(items = item.tags, key = { tag -> tag }) { tag ->
+                    AppTagChip.Static(label = tag)
+                }
+            }
+        }
+        Text(
+            text = archivedAtLabel,
+            style = AppUi.typography.bodySmall,
+            color = AppUi.colors.textTertiary,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ArchivedItemRow.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ArchivedItemRow.kt
@@ -69,7 +69,7 @@ internal fun ArchivedItemRow(
             )
             AppButton.Tertiary(
                 modifier = Modifier.testTag("ArchivedItemRestore_${item.uuid}"),
-                text = stringResource(R.string.feature_settings_archive_restore),
+                text = stringResource(R.string.feature_archive_action_restore),
                 onClick = onRestore,
                 size = AppButtonSize.SMALL,
             )
@@ -83,7 +83,7 @@ internal fun ArchivedItemRow(
                     Icon(
                         modifier = Modifier.size(AppDimension.iconSm),
                         imageVector = Icons.Default.MoreVert,
-                        contentDescription = stringResource(R.string.feature_settings_more),
+                        contentDescription = stringResource(R.string.feature_archive_action_more),
                         tint = AppUi.colors.textSecondary,
                     )
                 }
@@ -95,7 +95,7 @@ internal fun ArchivedItemRow(
                     DropdownMenuItem(
                         text = {
                             Text(
-                                text = stringResource(R.string.feature_settings_archive_delete_permanently),
+                                text = stringResource(R.string.feature_archive_action_permanent_delete),
                                 style = AppUi.typography.bodyMedium,
                                 color = AppUi.colors.setType.failureForeground,
                             )

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/PermanentDeleteDialog.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/PermanentDeleteDialog.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.runtime.Composable
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+
+@Composable
+internal fun PermanentDeleteDialog(
+    target: ArchivedItem,
+    impactCount: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val typeWord = when (target) {
+        is ArchivedItem.Exercise -> "exercise"
+        is ArchivedItem.Training -> "training"
+    }
+    val title = "Delete '${target.name}' permanently?"
+    val body = if (impactCount > 0) {
+        "This will permanently delete the $typeWord along with $impactCount " +
+            "${if (impactCount == 1) "session" else "sessions"} of history. " +
+            "This cannot be undone."
+    } else {
+        "This will permanently delete the $typeWord. This cannot be undone."
+    }
+    val impactSummary = if (impactCount > 0) {
+        "$impactCount ${if (impactCount == 1) "session" else "sessions"} of history"
+    } else {
+        "No session history affected"
+    }
+    AppConfirmDialog(
+        title = title,
+        body = body,
+        impactSummary = impactSummary,
+        confirmLabel = "Delete",
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/PermanentDeleteDialog.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/PermanentDeleteDialog.kt
@@ -2,7 +2,10 @@
 package io.github.stslex.workeeper.feature.settings.ui.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
+import io.github.stslex.workeeper.feature.settings.R
 import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
 
 @Composable
@@ -12,28 +15,29 @@ internal fun PermanentDeleteDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val typeWord = when (target) {
-        is ArchivedItem.Exercise -> "exercise"
-        is ArchivedItem.Training -> "training"
-    }
-    val title = "Delete '${target.name}' permanently?"
+    val title = stringResource(
+        R.string.feature_archive_dialog_permanent_delete_title,
+        target.name,
+    )
     val body = if (impactCount > 0) {
-        "This will permanently delete the $typeWord along with $impactCount " +
-            "${if (impactCount == 1) "session" else "sessions"} of history. " +
-            "This cannot be undone."
+        pluralStringResource(
+            R.plurals.feature_archive_dialog_permanent_delete_body_with_history,
+            impactCount,
+            impactCount,
+        )
     } else {
-        "This will permanently delete the $typeWord. This cannot be undone."
+        stringResource(R.string.feature_archive_dialog_permanent_delete_body_no_history)
     }
     val impactSummary = if (impactCount > 0) {
-        "$impactCount ${if (impactCount == 1) "session" else "sessions"} of history"
+        pluralStringResource(R.plurals.feature_archive_session_count, impactCount, impactCount)
     } else {
-        "No session history affected"
+        stringResource(R.string.feature_archive_dialog_impact_summary_empty)
     }
     AppConfirmDialog(
         title = title,
         body = body,
         impactSummary = impactSummary,
-        confirmLabel = "Delete",
+        confirmLabel = stringResource(R.string.feature_archive_dialog_confirm_delete),
         onConfirm = onConfirm,
         onDismiss = onDismiss,
     )

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/SettingsRow.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/SettingsRow.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListItem
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+
+@Composable
+internal fun SettingsRow(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+) {
+    AppListItem(
+        modifier = modifier.padding(horizontal = AppDimension.screenEdge),
+        headline = title,
+        supportingText = supportingText,
+        trailingContent = {
+            Icon(
+                modifier = Modifier.size(AppDimension.iconSm),
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = AppUi.colors.textTertiary,
+            )
+        },
+        onClick = onClick,
+    )
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/SettingsSection.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/SettingsSection.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+
+@Composable
+internal fun SettingsSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+    ) {
+        Text(
+            modifier = Modifier.padding(horizontal = AppDimension.screenEdge),
+            text = title,
+            style = AppUi.typography.labelSmall,
+            color = AppUi.colors.textTertiary,
+        )
+        content()
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ThemeSelector.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ThemeSelector.kt
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.ui.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
@@ -15,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
@@ -29,8 +32,7 @@ internal fun ThemeSelector(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = AppDimension.screenEdge),
-        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+            .selectableGroup(),
     ) {
         ThemeOption(
             label = stringResource(R.string.feature_settings_theme_system),
@@ -63,21 +65,27 @@ private fun ThemeOption(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = AppDimension.Space.xs),
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton,
+            )
+            .heightIn(min = AppDimension.heightSm)
+            .padding(horizontal = AppDimension.screenEdge),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
     ) {
         RadioButton(
             modifier = Modifier.testTag(tag),
             selected = selected,
-            onClick = onClick,
+            onClick = null,
             colors = RadioButtonDefaults.colors(
                 selectedColor = AppUi.colors.accent,
                 unselectedColor = AppUi.colors.borderStrong,
             ),
         )
         Text(
+            modifier = Modifier.weight(1f),
             text = label,
             style = AppUi.typography.bodyMedium,
             color = AppUi.colors.textPrimary,

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ThemeSelector.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/ThemeSelector.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.R
+
+@Composable
+internal fun ThemeSelector(
+    selected: ThemeMode,
+    onSelectedChange: (ThemeMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = AppDimension.screenEdge),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+    ) {
+        ThemeOption(
+            label = stringResource(R.string.feature_settings_theme_system),
+            selected = selected == ThemeMode.SYSTEM,
+            tag = "ThemeOption_SYSTEM",
+            onClick = { onSelectedChange(ThemeMode.SYSTEM) },
+        )
+        ThemeOption(
+            label = stringResource(R.string.feature_settings_theme_light),
+            selected = selected == ThemeMode.LIGHT,
+            tag = "ThemeOption_LIGHT",
+            onClick = { onSelectedChange(ThemeMode.LIGHT) },
+        )
+        ThemeOption(
+            label = stringResource(R.string.feature_settings_theme_dark),
+            selected = selected == ThemeMode.DARK,
+            tag = "ThemeOption_DARK",
+            onClick = { onSelectedChange(ThemeMode.DARK) },
+        )
+    }
+}
+
+@Composable
+private fun ThemeOption(
+    label: String,
+    selected: Boolean,
+    tag: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = AppDimension.Space.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+    ) {
+        RadioButton(
+            modifier = Modifier.testTag(tag),
+            selected = selected,
+            onClick = onClick,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = AppUi.colors.accent,
+                unselectedColor = AppUi.colors.borderStrong,
+            ),
+        )
+        Text(
+            text = label,
+            style = AppUi.typography.bodyMedium,
+            color = AppUi.colors.textPrimary,
+        )
+    }
+}

--- a/feature/settings/src/main/res/values-ru/strings.xml
+++ b/feature/settings/src/main/res/values-ru/strings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_settings_title">Настройки</string>
+
+    <string name="feature_settings_section_about">О приложении</string>
+    <string name="feature_settings_section_appearance">Внешний вид</string>
+    <string name="feature_settings_section_data">Данные</string>
+
+    <string name="feature_settings_theme_system">Как в системе</string>
+    <string name="feature_settings_theme_light">Светлая</string>
+    <string name="feature_settings_theme_dark">Тёмная</string>
+
+    <string name="feature_settings_about_app_name">Workeeper</string>
+    <string name="feature_settings_about_version_format">Версия %1$s (%2$d)</string>
+    <string name="feature_settings_about_license">Лицензия GPLv3</string>
+    <string name="feature_settings_about_github">Открыть на GitHub</string>
+    <string name="feature_settings_about_privacy">Политика конфиденциальности</string>
+
+    <string name="feature_archive_title">Архив</string>
+    <string name="feature_archive_action_more">Ещё</string>
+    <string name="feature_archive_segment_exercises">Упражнения (%1$d)</string>
+    <string name="feature_archive_segment_trainings">Тренировки (%1$d)</string>
+
+    <string name="feature_archive_action_restore">Восстановить</string>
+    <string name="feature_archive_action_permanent_delete">Удалить навсегда</string>
+
+    <string name="feature_archive_label_archived">В архиве</string>
+    <string name="feature_archive_label_archived_relative_format">Архивировано %1$s</string>
+
+    <string name="feature_archive_empty_headline">Архив пуст</string>
+    <string name="feature_archive_empty_supporting_exercises">Здесь будут архивированные упражнения — для восстановления или удаления навсегда.</string>
+    <string name="feature_archive_empty_supporting_trainings">Здесь будут архивированные тренировки — для восстановления или удаления навсегда.</string>
+
+    <string name="feature_archive_dialog_permanent_delete_title">Удалить «%1$s» навсегда?</string>
+    <string name="feature_archive_dialog_permanent_delete_body_no_history">Это действие нельзя отменить.</string>
+    <string name="feature_archive_dialog_impact_summary_empty">Сессии истории не затронуты</string>
+    <string name="feature_archive_dialog_confirm_delete">Удалить</string>
+
+    <string name="feature_archive_snackbar_restored_format">«%1$s» восстановлено</string>
+    <string name="feature_archive_snackbar_deleted_format">«%1$s» удалено навсегда</string>
+    <string name="feature_archive_snackbar_undo">Отменить</string>
+
+    <plurals name="feature_archive_session_count">
+        <item quantity="one">%d сессия</item>
+        <item quantity="few">%d сессии</item>
+        <item quantity="many">%d сессий</item>
+        <item quantity="other">%d сессии</item>
+    </plurals>
+
+    <plurals name="feature_archive_dialog_permanent_delete_body_with_history">
+        <item quantity="one">Также будет удалена %1$d сессия истории. Это действие нельзя отменить.</item>
+        <item quantity="few">Также будут удалены %1$d сессии истории. Это действие нельзя отменить.</item>
+        <item quantity="many">Также будет удалено %1$d сессий истории. Это действие нельзя отменить.</item>
+        <item quantity="other">Также будет удалено %1$d сессии истории. Это действие нельзя отменить.</item>
+    </plurals>
+</resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_settings_title">Settings</string>
+    <string name="feature_settings_about_section">About</string>
+    <string name="feature_settings_appearance_section">Appearance</string>
+    <string name="feature_settings_data_section">Data</string>
+    <string name="feature_settings_theme_system">System default</string>
+    <string name="feature_settings_theme_light">Light</string>
+    <string name="feature_settings_theme_dark">Dark</string>
+
+    <string name="feature_settings_archive_title">Archive</string>
+    <string name="feature_settings_archive_segment_exercises">Exercises (%1$d)</string>
+    <string name="feature_settings_archive_segment_trainings">Trainings (%1$d)</string>
+    <string name="feature_settings_archive_restore">Restore</string>
+    <string name="feature_settings_archive_delete_permanently">Delete permanently</string>
+    <string name="feature_settings_archive_empty_headline">Nothing archived</string>
+    <string name="feature_settings_archive_empty_supporting_exercises">Archived exercises appear here for restore or permanent delete.</string>
+    <string name="feature_settings_archive_empty_supporting_trainings">Archived trainings appear here for restore or permanent delete.</string>
+
+    <string name="feature_settings_about_app_name">Workeeper</string>
+    <string name="feature_settings_about_version">Version %1$s (%2$d)</string>
+    <string name="feature_settings_about_license">GPLv3 license</string>
+    <string name="feature_settings_about_github">View on GitHub</string>
+    <string name="feature_settings_about_privacy">Privacy Policy</string>
+
+    <string name="feature_settings_back">Back</string>
+    <string name="feature_settings_more">More</string>
+
+    <string name="feature_settings_snackbar_restored">%1$s restored</string>
+    <string name="feature_settings_snackbar_deleted">Permanently deleted</string>
+    <string name="feature_settings_snackbar_undo">Undo</string>
+</resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,32 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_settings_title">Settings</string>
-    <string name="feature_settings_about_section">About</string>
-    <string name="feature_settings_appearance_section">Appearance</string>
-    <string name="feature_settings_data_section">Data</string>
+
+    <string name="feature_settings_section_about">About</string>
+    <string name="feature_settings_section_appearance">Appearance</string>
+    <string name="feature_settings_section_data">Data</string>
+
     <string name="feature_settings_theme_system">System default</string>
     <string name="feature_settings_theme_light">Light</string>
     <string name="feature_settings_theme_dark">Dark</string>
 
-    <string name="feature_settings_archive_title">Archive</string>
-    <string name="feature_settings_archive_segment_exercises">Exercises (%1$d)</string>
-    <string name="feature_settings_archive_segment_trainings">Trainings (%1$d)</string>
-    <string name="feature_settings_archive_restore">Restore</string>
-    <string name="feature_settings_archive_delete_permanently">Delete permanently</string>
-    <string name="feature_settings_archive_empty_headline">Nothing archived</string>
-    <string name="feature_settings_archive_empty_supporting_exercises">Archived exercises appear here for restore or permanent delete.</string>
-    <string name="feature_settings_archive_empty_supporting_trainings">Archived trainings appear here for restore or permanent delete.</string>
-
     <string name="feature_settings_about_app_name">Workeeper</string>
-    <string name="feature_settings_about_version">Version %1$s (%2$d)</string>
+    <string name="feature_settings_about_version_format">Version %1$s (%2$d)</string>
     <string name="feature_settings_about_license">GPLv3 license</string>
     <string name="feature_settings_about_github">View on GitHub</string>
     <string name="feature_settings_about_privacy">Privacy Policy</string>
 
-    <string name="feature_settings_back">Back</string>
-    <string name="feature_settings_more">More</string>
+    <string name="feature_archive_title">Archive</string>
+    <string name="feature_archive_action_more">More</string>
+    <string name="feature_archive_segment_exercises">Exercises (%1$d)</string>
+    <string name="feature_archive_segment_trainings">Trainings (%1$d)</string>
 
-    <string name="feature_settings_snackbar_restored">%1$s restored</string>
-    <string name="feature_settings_snackbar_deleted">Permanently deleted</string>
-    <string name="feature_settings_snackbar_undo">Undo</string>
+    <string name="feature_archive_action_restore">Restore</string>
+    <string name="feature_archive_action_permanent_delete">Delete permanently</string>
+
+    <string name="feature_archive_label_archived">Archived</string>
+    <string name="feature_archive_label_archived_relative_format">Archived %1$s</string>
+
+    <string name="feature_archive_empty_headline">Nothing archived</string>
+    <string name="feature_archive_empty_supporting_exercises">Archived exercises appear here for restore or permanent delete.</string>
+    <string name="feature_archive_empty_supporting_trainings">Archived trainings appear here for restore or permanent delete.</string>
+
+    <string name="feature_archive_dialog_permanent_delete_title">Delete ‘%1$s’ permanently?</string>
+    <string name="feature_archive_dialog_permanent_delete_body_no_history">This action cannot be undone.</string>
+    <string name="feature_archive_dialog_impact_summary_empty">No session history affected</string>
+    <string name="feature_archive_dialog_confirm_delete">Delete</string>
+
+    <string name="feature_archive_snackbar_restored_format">%1$s restored</string>
+    <string name="feature_archive_snackbar_deleted_format">%1$s permanently deleted</string>
+    <string name="feature_archive_snackbar_undo">Undo</string>
+
+    <plurals name="feature_archive_session_count">
+        <item quantity="one">%d session</item>
+        <item quantity="other">%d sessions</item>
+    </plurals>
+
+    <plurals name="feature_archive_dialog_permanent_delete_body_with_history">
+        <item quantity="one">%1$d session of history will also be deleted. This action cannot be undone.</item>
+        <item quantity="other">%1$d sessions of history will also be deleted. This action cannot be undone.</item>
+    </plurals>
 </resources>

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImplTest.kt
@@ -105,5 +105,4 @@ internal class SettingsInteractorImplTest {
         coEvery { trainingRepository.countSessionsUsing("uuid-6") } returns 3
         assertEquals(3, interactor.countTrainingSessions("uuid-6"))
     }
-
 }

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/SettingsInteractorImplTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.domain
+
+import android.content.Context
+import io.github.stslex.workeeper.core.dataStore.store.CommonDataStore
+import io.github.stslex.workeeper.core.exercise.exercise.ExerciseRepository
+import io.github.stslex.workeeper.core.exercise.training.TrainingRepository
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SettingsInteractorImplTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val commonDataStore = mockk<CommonDataStore>(relaxed = true)
+    private val exerciseRepository = mockk<ExerciseRepository>(relaxed = true)
+    private val trainingRepository = mockk<TrainingRepository>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+
+    private lateinit var interactor: SettingsInteractor
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        interactor = SettingsInteractorImpl(
+            context = context,
+            commonDataStore = commonDataStore,
+            exerciseRepository = exerciseRepository,
+            trainingRepository = trainingRepository,
+            defaultDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `observeThemeMode maps stored string to ThemeMode`() = runTest(testDispatcher) {
+        every { commonDataStore.themePreference } returns flowOf("DARK")
+        assertEquals(ThemeMode.DARK, interactor.observeThemeMode().first())
+    }
+
+    @Test
+    fun `observeThemeMode returns SYSTEM for unknown stored value`() = runTest(testDispatcher) {
+        every { commonDataStore.themePreference } returns flowOf("INVALID")
+        assertEquals(ThemeMode.SYSTEM, interactor.observeThemeMode().first())
+    }
+
+    @Test
+    fun `setThemeMode forwards enum name to data store`() = runTest(testDispatcher) {
+        coEvery { commonDataStore.setThemePreference(any()) } returns Unit
+        interactor.setThemeMode(ThemeMode.LIGHT)
+        coVerify(exactly = 1) { commonDataStore.setThemePreference("LIGHT") }
+    }
+
+    @Test
+    fun `restoreExercise delegates to repository`() = runTest(testDispatcher) {
+        coEvery { exerciseRepository.restore(any()) } returns Unit
+        interactor.restoreExercise("uuid-1")
+        coVerify(exactly = 1) { exerciseRepository.restore("uuid-1") }
+    }
+
+    @Test
+    fun `restoreTraining delegates to repository`() = runTest(testDispatcher) {
+        coEvery { trainingRepository.restore(any()) } returns Unit
+        interactor.restoreTraining("uuid-2")
+        coVerify(exactly = 1) { trainingRepository.restore("uuid-2") }
+    }
+
+    @Test
+    fun `permanentlyDeleteExercise delegates to repository`() = runTest(testDispatcher) {
+        coEvery { exerciseRepository.permanentDelete(any()) } returns Unit
+        interactor.permanentlyDeleteExercise("uuid-3")
+        coVerify(exactly = 1) { exerciseRepository.permanentDelete("uuid-3") }
+    }
+
+    @Test
+    fun `permanentlyDeleteTraining delegates to repository`() = runTest(testDispatcher) {
+        coEvery { trainingRepository.permanentDelete(any()) } returns Unit
+        interactor.permanentlyDeleteTraining("uuid-4")
+        coVerify(exactly = 1) { trainingRepository.permanentDelete("uuid-4") }
+    }
+
+    @Test
+    fun `countExerciseSessions delegates to repository`() = runTest(testDispatcher) {
+        coEvery { exerciseRepository.countSessionsUsing("uuid-5") } returns 7
+        assertEquals(7, interactor.countExerciseSessions("uuid-5"))
+    }
+
+    @Test
+    fun `countTrainingSessions delegates to repository`() = runTest(testDispatcher) {
+        coEvery { trainingRepository.countSessionsUsing("uuid-6") } returns 3
+        assertEquals(3, interactor.countTrainingSessions("uuid-6"))
+    }
+
+}

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
+import io.github.stslex.workeeper.feature.settings.di.ArchiveHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.domain.model.ArchivedItem
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.Segment
+import io.github.stslex.workeeper.feature.settings.mvi.store.ArchiveStore.State
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class ArchiveClickHandlerTest {
+
+    private val interactor = mockk<SettingsInteractor>(relaxed = true)
+    private val emptyPaging: PagingUiState<androidx.paging.PagingData<ArchivedItem.Exercise>> =
+        PagingUiState { kotlinx.coroutines.flow.flowOf(androidx.paging.PagingData.empty()) }
+    private val emptyTrainingPaging: PagingUiState<androidx.paging.PagingData<ArchivedItem.Training>> =
+        PagingUiState { kotlinx.coroutines.flow.flowOf(androidx.paging.PagingData.empty()) }
+
+    private val initialState = State(
+        selectedSegment = Segment.EXERCISES,
+        exerciseCount = 0,
+        trainingCount = 0,
+        archivedExercisesPaging = emptyPaging,
+        archivedTrainingsPaging = emptyTrainingPaging,
+        pendingDeleteImpact = null,
+        pendingDeleteTarget = null,
+        deleteImpactLoading = false,
+    )
+
+    private val stateFlow = MutableStateFlow(initialState)
+
+    private val store = mockk<ArchiveHandlerStore>(relaxed = true).apply {
+        every { state } returns stateFlow
+        every { updateState(any()) } answers {
+            val update = firstArg<(State) -> State>()
+            stateFlow.value = update(stateFlow.value)
+        }
+    }
+
+    private val handler = ArchiveClickHandler(interactor, store)
+
+    @Test
+    fun `OnSegmentChange updates selectedSegment`() {
+        handler.invoke(Action.Click.OnSegmentChange(Segment.TRAININGS))
+        assertEquals(Segment.TRAININGS, stateFlow.value.selectedSegment)
+    }
+
+    @Test
+    fun `OnSegmentChange to current segment is no-op`() {
+        handler.invoke(Action.Click.OnSegmentChange(Segment.EXERCISES))
+        verify(exactly = 0) { store.sendEvent(any()) }
+    }
+
+    @Test
+    fun `OnDeleteDismiss clears pending delete state`() {
+        stateFlow.value = stateFlow.value.copy(
+            pendingDeleteTarget = exerciseItem(),
+            pendingDeleteImpact = 5,
+            deleteImpactLoading = false,
+        )
+        handler.invoke(Action.Click.OnDeleteDismiss)
+        assertEquals(null, stateFlow.value.pendingDeleteTarget)
+        assertEquals(null, stateFlow.value.pendingDeleteImpact)
+    }
+
+    @Test
+    fun `OnPermanentDeleteClick captures haptic event and target`() {
+        coEvery { interactor.countExerciseSessions(any()) } returns 0
+        val capturedEvent = slot<Event>()
+
+        val item = exerciseItem()
+        handler.invoke(Action.Click.OnPermanentDeleteClick(item))
+
+        assertEquals(item, stateFlow.value.pendingDeleteTarget)
+        verify { store.sendEvent(capture(capturedEvent)) }
+        assert(capturedEvent.captured is Event.Haptic)
+    }
+
+    @Test
+    fun `OnDeleteConfirm without target does nothing`() {
+        handler.invoke(Action.Click.OnDeleteConfirm)
+        coVerify(exactly = 0) { interactor.permanentlyDeleteExercise(any()) }
+        coVerify(exactly = 0) { interactor.permanentlyDeleteTraining(any()) }
+    }
+
+    private fun exerciseItem(): ArchivedItem.Exercise = ArchivedItem.Exercise(
+        uuid = "uuid-x",
+        name = "Bench",
+        tags = emptyList(),
+        archivedAt = 0L,
+        type = io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel.WEIGHTED,
+    )
+}

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
 import io.github.stslex.workeeper.feature.settings.di.ArchiveHandlerStore
 import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
@@ -17,6 +18,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class ArchiveClickHandlerTest {
@@ -51,14 +53,45 @@ internal class ArchiveClickHandlerTest {
     private val handler = ArchiveClickHandler(interactor, store)
 
     @Test
-    fun `OnSegmentChange updates selectedSegment`() {
+    fun `OnSegmentChange updates selectedSegment and emits SegmentTick haptic`() {
         handler.invoke(Action.Click.OnSegmentChange(Segment.TRAININGS))
         assertEquals(Segment.TRAININGS, stateFlow.value.selectedSegment)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.captured, HapticFeedbackType.SegmentTick)
     }
 
     @Test
     fun `OnSegmentChange to current segment is no-op`() {
         handler.invoke(Action.Click.OnSegmentChange(Segment.EXERCISES))
+        verify(exactly = 0) { store.sendEvent(any()) }
+    }
+
+    @Test
+    fun `OnRestoreClick emits ContextClick haptic`() {
+        coEvery { interactor.restoreExercise(any()) } returns Unit
+        handler.invoke(Action.Click.OnRestoreClick(exerciseItem()))
+        val captured = mutableListOf<Event>()
+        verify { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
+    }
+
+    @Test
+    fun `OnUndoRestore emits ContextClick haptic`() {
+        coEvery { interactor.reArchiveExercise(any()) } returns Unit
+        handler.invoke(Action.Click.OnUndoRestore(exerciseItem()))
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.captured, HapticFeedbackType.ContextClick)
+    }
+
+    @Test
+    fun `OnDeleteDismiss does not emit haptic`() {
+        stateFlow.value = stateFlow.value.copy(
+            pendingDeleteTarget = exerciseItem(),
+            pendingDeleteImpact = 0,
+        )
+        handler.invoke(Action.Click.OnDeleteDismiss)
         verify(exactly = 0) { store.sendEvent(any()) }
     }
 
@@ -75,16 +108,30 @@ internal class ArchiveClickHandlerTest {
     }
 
     @Test
-    fun `OnPermanentDeleteClick captures haptic event and target`() {
+    fun `OnPermanentDeleteClick emits LongPress haptic and stores target`() {
         coEvery { interactor.countExerciseSessions(any()) } returns 0
-        val capturedEvent = slot<Event>()
+        val captured = mutableListOf<Event>()
 
         val item = exerciseItem()
         handler.invoke(Action.Click.OnPermanentDeleteClick(item))
 
         assertEquals(item, stateFlow.value.pendingDeleteTarget)
-        verify { store.sendEvent(capture(capturedEvent)) }
-        assert(capturedEvent.captured is Event.Haptic)
+        verify { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.LongPress)
+    }
+
+    @Test
+    fun `OnDeleteConfirm emits LongPress haptic and clears target`() {
+        coEvery { interactor.permanentlyDeleteExercise(any()) } returns Unit
+        stateFlow.value = stateFlow.value.copy(
+            pendingDeleteTarget = exerciseItem(),
+            pendingDeleteImpact = 2,
+        )
+        handler.invoke(Action.Click.OnDeleteConfirm)
+        val captured = mutableListOf<Event>()
+        verify { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.LongPress)
+        assertEquals(null, stateFlow.value.pendingDeleteTarget)
     }
 
     @Test
@@ -101,4 +148,9 @@ internal class ArchiveClickHandlerTest {
         archivedAt = 0L,
         type = io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel.WEIGHTED,
     )
+
+    private fun assertHaptic(event: Event, expected: HapticFeedbackType) {
+        assertTrue(event is Event.Haptic, "expected Event.Haptic but got $event")
+        assertEquals(expected, (event as Event.Haptic).type)
+    }
 }

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchivePagingHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchivePagingHandlerTest.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import org.junit.jupiter.api.Test
+
+internal class ArchivePagingHandlerTest {
+
+    // TODO(feature-rewrite): wire AppCoroutineScope test harness for paging observers.
+    @Test
+    fun placeholder() = Unit
+}

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.feature.settings.about.AboutLinks
 import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class SettingsClickHandlerTest {
@@ -17,34 +18,43 @@ internal class SettingsClickHandlerTest {
     private val handler = SettingsClickHandler(store)
 
     @Test
-    fun `OnArchiveClick emits NavigateToArchive`() {
+    fun `OnArchiveClick emits Haptic ContextClick then NavigateToArchive`() {
         handler.invoke(Action.Click.OnArchiveClick)
-        val captured = slot<Event>()
-        verify(exactly = 1) { store.sendEvent(capture(captured)) }
-        assertEquals(Event.NavigateToArchive, captured.captured)
+        val captured = mutableListOf<Event>()
+        verify(exactly = 2) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
+        assertEquals(Event.NavigateToArchive, captured.last())
     }
 
     @Test
-    fun `OnGitHubClick emits ShowExternalLink with GitHub url`() {
+    fun `OnGitHubClick emits Haptic ContextClick then ShowExternalLink GitHub url`() {
         handler.invoke(Action.Click.OnGitHubClick)
-        val captured = slot<Event>()
-        verify(exactly = 1) { store.sendEvent(capture(captured)) }
-        assertEquals(Event.ShowExternalLink(AboutLinks.GITHUB_URL), captured.captured)
+        val captured = mutableListOf<Event>()
+        verify(exactly = 2) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
+        assertEquals(Event.ShowExternalLink(AboutLinks.GITHUB_URL), captured.last())
     }
 
     @Test
-    fun `OnLicenseClick emits ShowExternalLink with license url`() {
+    fun `OnLicenseClick emits Haptic ContextClick then ShowExternalLink license url`() {
         handler.invoke(Action.Click.OnLicenseClick)
-        val captured = slot<Event>()
-        verify(exactly = 1) { store.sendEvent(capture(captured)) }
-        assertEquals(Event.ShowExternalLink(AboutLinks.LICENSE_URL), captured.captured)
+        val captured = mutableListOf<Event>()
+        verify(exactly = 2) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
+        assertEquals(Event.ShowExternalLink(AboutLinks.LICENSE_URL), captured.last())
     }
 
     @Test
-    fun `OnPrivacyPolicyClick emits ShowExternalLink with privacy url`() {
+    fun `OnPrivacyPolicyClick emits Haptic ContextClick then ShowExternalLink privacy url`() {
         handler.invoke(Action.Click.OnPrivacyPolicyClick)
-        val captured = slot<Event>()
-        verify(exactly = 1) { store.sendEvent(capture(captured)) }
-        assertEquals(Event.ShowExternalLink(AboutLinks.PRIVACY_POLICY_URL), captured.captured)
+        val captured = mutableListOf<Event>()
+        verify(exactly = 2) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
+        assertEquals(Event.ShowExternalLink(AboutLinks.PRIVACY_POLICY_URL), captured.last())
+    }
+
+    private fun assertHaptic(event: Event, expected: HapticFeedbackType) {
+        assertTrue(event is Event.Haptic, "expected Event.Haptic but got $event")
+        assertEquals(expected, (event as Event.Haptic).type)
     }
 }

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
@@ -18,12 +18,12 @@ internal class SettingsClickHandlerTest {
     private val handler = SettingsClickHandler(store)
 
     @Test
-    fun `OnArchiveClick emits Haptic ContextClick then NavigateToArchive`() {
+    fun `OnArchiveClick emits Haptic ContextClick then consumes OpenArchive`() {
         handler.invoke(Action.Click.OnArchiveClick)
         val captured = mutableListOf<Event>()
-        verify(exactly = 2) { store.sendEvent(capture(captured)) }
-        assertHaptic(captured.first(), HapticFeedbackType.ContextClick)
-        assertEquals(Event.NavigateToArchive, captured.last())
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.single(), HapticFeedbackType.ContextClick)
+        verify(exactly = 1) { store.consume(Action.Navigation.OpenArchive) }
     }
 
     @Test

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.feature.settings.about.AboutLinks
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SettingsClickHandlerTest {
+
+    private val store = mockk<SettingsHandlerStore>(relaxed = true)
+    private val handler = SettingsClickHandler(store)
+
+    @Test
+    fun `OnArchiveClick emits NavigateToArchive`() {
+        handler.invoke(Action.Click.OnArchiveClick)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertEquals(Event.NavigateToArchive, captured.captured)
+    }
+
+    @Test
+    fun `OnGitHubClick emits ShowExternalLink with GitHub url`() {
+        handler.invoke(Action.Click.OnGitHubClick)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertEquals(Event.ShowExternalLink(AboutLinks.GITHUB_URL), captured.captured)
+    }
+
+    @Test
+    fun `OnLicenseClick emits ShowExternalLink with license url`() {
+        handler.invoke(Action.Click.OnLicenseClick)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertEquals(Event.ShowExternalLink(AboutLinks.LICENSE_URL), captured.captured)
+    }
+
+    @Test
+    fun `OnPrivacyPolicyClick emits ShowExternalLink with privacy url`() {
+        handler.invoke(Action.Click.OnPrivacyPolicyClick)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        assertEquals(Event.ShowExternalLink(AboutLinks.PRIVACY_POLICY_URL), captured.captured)
+    }
+}

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt
@@ -1,11 +1,48 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.di.SettingsHandlerStore
+import io.github.stslex.workeeper.feature.settings.domain.SettingsInteractor
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.State
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class SettingsInputHandlerTest {
 
-    // TODO(feature-rewrite): wire AppCoroutineScope test harness for input handler launch().
+    private val interactor = mockk<SettingsInteractor>(relaxed = true)
+    private val initialState = State(
+        themeMode = ThemeMode.SYSTEM,
+        appVersion = "1.0.0",
+        appVersionCode = 1,
+    )
+    private val stateFlow = MutableStateFlow(initialState)
+    private val store = mockk<SettingsHandlerStore>(relaxed = true).apply {
+        every { state } returns stateFlow
+        every { updateState(any()) } answers {
+            val update = firstArg<(State) -> State>()
+            stateFlow.value = update(stateFlow.value)
+        }
+    }
+    private val handler = SettingsInputHandler(interactor, store)
+
     @Test
-    fun placeholder() = Unit
+    fun `OnThemeChange emits ContextClick haptic and updates state`() {
+        handler.invoke(Action.Input.OnThemeChange(ThemeMode.DARK))
+        assertEquals(ThemeMode.DARK, stateFlow.value.themeMode)
+        val captured = slot<Event>()
+        verify(exactly = 1) { store.sendEvent(capture(captured)) }
+        val event = captured.captured
+        assertTrue(event is Event.Haptic, "expected Event.Haptic but got $event")
+        assertEquals(HapticFeedbackType.ContextClick, (event as Event.Haptic).type)
+    }
 }

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import org.junit.jupiter.api.Test
+
+internal class SettingsInputHandlerTest {
+
+    // TODO(feature-rewrite): wire AppCoroutineScope test harness for input handler launch().
+    @Test
+    fun placeholder() = Unit
+}

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.settings.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
 import io.mockk.mockk
 import io.mockk.verify
@@ -13,8 +14,14 @@ internal class SettingsNavigationHandlerTest {
     private val handler = SettingsNavigationHandler(navigator)
 
     @Test
-    fun `OnBackClick triggers popBack`() {
-        handler.invoke(Action.Navigation.OnBackClick)
+    fun `Back triggers popBack`() {
+        handler.invoke(Action.Navigation.Back)
         verify(exactly = 1) { navigator.popBack() }
+    }
+
+    @Test
+    fun `OpenArchive navigates to Screen Archive`() {
+        handler.invoke(Action.Navigation.OpenArchive)
+        verify(exactly = 1) { navigator.navTo(Screen.Archive) }
     }
 }

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Action
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+internal class SettingsNavigationHandlerTest {
+
+    private val navigator = mockk<Navigator>(relaxed = true)
+    private val handler = SettingsNavigationHandler(navigator)
+
+    @Test
+    fun `OnBackClick triggers popBack`() {
+        handler.invoke(Action.Navigation.OnBackClick)
+        verify(exactly = 1) { navigator.popBack() }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,5 +46,6 @@ include(":feature:all-exercises")
 include(":feature:all-trainings")
 include(":feature:charts")
 include(":feature:single-training")
+include(":feature:settings")
 
 include(":lint-rules")


### PR DESCRIPTION
## Summary

Stage 5.1 — first v1 feature implementation following the design
system that just landed. Adds a Settings screen (About, Theme,
Archive entry) and an Archive screen (segment switcher, paged
restore, permanent delete with impact dialog).

Spec: [`documentation/feature-specs/settings-archive.md`](documentation/feature-specs/settings-archive.md).

## Changes by module

### `core/database`
- `AppDatabase` v3 → v4. `archived_at: Long?` added on `training_table`
  and `exercise_table`. Schema 4 exported.
- `fallbackToDestructiveMigrationFrom(2, 3)` (no users yet, intentional).
- `ExerciseDao` / `TrainingDao` — `archive(...)` now writes a timestamp;
  `restore` clears it. New `observeArchivedCount(): Flow<Int>`.
- `SessionDao` — `countFinishedByTraining`, `countFinishedContainingExercise`.

### `core/exercise`
- `ExerciseRepository` / `TrainingRepository` extended with
  `pagedArchived()`, `observeArchivedCount()`, `countSessionsUsing()`.
- `ExerciseDataModel` / `TrainingDataModel` carry `archivedAt`.

### `core/dataStore`
- `BaseDataStore.getString` / `updateString`.
- `CommonDataStore.themePreference` (default `"SYSTEM"`).

### `core/ui/kit`
- New `ThemeMode` enum (`SYSTEM`, `LIGHT`, `DARK`).
- `AppTheme(themeMode = SYSTEM)` resolves dark internally.

### `core/ui/navigation`
- `Screen.Settings`, `Screen.Archive` data objects.

### `app/app`
- `AppRootViewModel` observes the theme preference.
- `App.kt` passes `ThemeMode` to `AppTheme`; renders an
  `AnimatedVisibility` Settings IconButton anchored top-end on bottom-bar
  destinations (no feature module touched).
- `RootComponentImpl` + `AppNavigationHost` wire `settingsGraph` and
  `archiveGraph`.

### `feature/settings` (new module)
- Domain: `SettingsInteractor` + impl, `ArchivedItem` sealed interface,
  `AboutLinks`.
- MVI: `SettingsStore` + `ArchiveStore` (Store + Impl), Click / Input /
  Paging / Navigation handlers, `SettingsComponent` / `ArchiveComponent`,
  Hilt modules, `Feature` processors.
- UI: `SettingsScreen` (sections + theme selector + Archive row),
  `ArchiveScreen` (segment selector + paged lists + impact dialog +
  empty state) using only `core/ui/kit` tokens and components.
- Tests: JUnit 5 + MockK unit tests for `SettingsInteractorImpl`,
  `SettingsClickHandler`, `SettingsNavigationHandler`,
  `ArchiveClickHandler`. Paging/Input handlers and screens are `@Smoke`
  stubs with `TODO(feature-rewrite-tests)` markers.

### Repo
- `LICENSE` rewritten as full GPLv3.
- `README.MD` GPLv3 badge + license section updated.
- `SPDX-License-Identifier: GPL-3.0-only` header on every new file in
  this PR (existing files left untouched per spec).
- `settings.gradle.kts` + `app/app/build.gradle.kts` include
  `:feature:settings`.

## Verification

- [x] `./gradlew :core:database:assembleDebug` (schema v4 exported)
- [x] `./gradlew :feature:settings:assembleDebug`
- [x] `./gradlew assembleDebug` (dev + store)
- [x] `./gradlew detekt`
- [x] `./gradlew lintDebug`
- [x] `./gradlew testDebugUnitTest` (all green)
- [x] `core/database/schemas/.../4.json` present
- [x] `LICENSE` is full GPLv3

## Test plan

- [ ] Launch dev → Home settings icon → Settings screen renders, theme
      switching (System/Light/Dark) applies immediately and survives
      app restart.
- [ ] Settings → Archive → Exercises/Trainings segments swap; counts in
      labels match data.
- [ ] Restore an archived exercise → snackbar with Undo; tapping Undo
      re-archives.
- [ ] Permanent delete → impact dialog shows correct session count;
      confirming removes the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)