### PR TITLE
chore(skills): refresh .claude/skills/ for v3 + design system + navigation pattern

### DIFF
--- a/.claude/skills/add-database-migration.md
+++ b/.claude/skills/add-database-migration.md
@@ -1,6 +1,6 @@
 ---
 name: add-database-migration
-description: Add a Room schema migration safely — bump `AppDatabase` version, create a `MIGRATION_X_Y` object following the `Migration12.kt` pattern, register it in `CoreDatabaseModule`, and add a `MigrationTestHelper`-based test.
+description: Bump the Room schema version on `AppDatabase`, register it in `CoreDatabaseModule` via `fallbackToDestructiveMigrationFrom(...)`, and refresh DAO tests. Until v1 ships to the Play Store with real users, schema changes use destructive migration — no `Migration` class, no preserved data.
 ---
 
 # Add a database migration
@@ -12,58 +12,74 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
 - "Add a column / table to the database"
 - "Migrate data when the entity changes"
 
+## Current policy: destructive migration
+
+For the v1 development cycle the project has **no production users**, so the data layer
+treats every schema bump as a fresh install. The current pattern is documented in
+[documentation/db-redesign.md](../../documentation/db-redesign.md#migration-strategy):
+
+- `@Database(version = ...)` is bumped on
+  `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt`.
+- `CoreDatabaseModule` (`core/database/.../di/CoreDatabaseModule.kt`) wires
+  `.fallbackToDestructiveMigrationFrom(dropAllTables = true, <oldVersions...>)` on the
+  `Room.databaseBuilder`. Each prior version that ever shipped to a developer device is
+  added to the destructive list; current call site at the time of writing is
+  `fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3)` (line 36).
+- There is **no `migrations/` directory** under
+  `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/` — no
+  `Migration<X><Y>` classes are written, no `addMigrations(...)` chain. The earlier
+  `Migration12.kt` and its enclosing folder were deleted when the destructive policy
+  landed; recreate the folder only when the [non-destructive playbook](#when-to-switch-back-to-non-destructive-migrations)
+  becomes active.
+- `core/database/converters/` keeps only `UuidConverter.kt`. The earlier `StringConverter`
+  and `SetsTypeConverter` were dropped along with the legacy entity blobs they served.
+
+This stays the rule **until the first Play Store release with real users**. After that, every
+new version requires a real `Migration` class and an instrumented migration test. The
+"non-destructive playbook" section at the bottom captures what that looks like.
+
 ## Prerequisites
 
-- The current schema is at `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/`.
-- The Room library convention plugin is applied (it sets `schemaDirectory` and exports schemas
-  on every build) — see `build-logic/convention/src/main/kotlin/RoomLibraryConventionPlugin.kt`.
-- `documentation/architecture.md` is available for the data-layer overview.
+- The current schema lives at
+  `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/`. Released
+  versions to date: `1.json`, `2.json`, `3.json`, `4.json`. The on-disk JSON for the new
+  version is exported automatically the next time the module assembles.
+- The Room library convention plugin is applied (`build-logic/convention/src/main/kotlin/RoomLibraryConventionPlugin.kt`)
+  — it sets `schemaDirectory("$projectDir/schemas")`, exports schemas on every build, and
+  pulls in `androidx-room-testing` so DAO + migration tests have `MigrationTestHelper` available
+  if/when a real migration is needed later.
+- [documentation/architecture.md](../../documentation/architecture.md#data-layer) and
+  [documentation/db-redesign.md](../../documentation/db-redesign.md) describe the entity
+  catalog (9 entities as of v4) and the cascade rules.
 
-## Step-by-step
+## Step-by-step (destructive bump — current default)
 
-1. Decide the new schema version `Y = X + 1`. The current `X` is the `version` value on the
-   `@Database` annotation in
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/AppDatabase.kt`.
+1. Decide the new schema version `Y = X + 1`. The current `X` is the `version = ...` value on
+   the `@Database` annotation in `AppDatabase.kt` (4 at the time of writing).
 
 2. Make the entity / DAO changes. Add fields, change types, add tables, etc., under
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/`.
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/`. New entities
+   ship in version `Y` only — there is no migration logic to write.
 
 3. Bump `version = Y` on the `@Database` annotation in `AppDatabase.kt`. Leave
    `exportSchema = true` — Room writes the new `Y.json` schema during the next build.
 
-4. Create the migration at
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X><Y>.kt`.
-   Use the project's pattern from
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration12.kt`:
+4. If you added new entities, register their DAOs as `abstract val ...` on `AppDatabase`
+   and add matching `@Provides @Singleton fun provide<Name>Dao(db: AppDatabase): <Name>Dao`
+   bindings in
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt`.
+
+5. Extend the destructive list in the `Room.databaseBuilder` chain in `CoreDatabaseModule`:
 
    ```kotlin
-   val MIGRATION_<X>_<Y> = object : Migration(<X>, <Y>) {
-       override fun migrate(db: SupportSQLiteDatabase) {
-           // SQL statements here.
-       }
-   }
+   Room.databaseBuilder(context, AppDatabase::class.java, AppDatabase.Companion.NAME)
+       .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3, X)
+       .build()
    ```
 
-   Patterns the codebase already uses:
-
-   - **Add a table**: `db.execSQL("CREATE TABLE IF NOT EXISTS ... (...)")`.
-   - **Drop / rename a column** (SQLite has no `ALTER TABLE DROP COLUMN`): copy data into a
-     new table with the desired schema, drop the old table, rename the new one. See
-     `Migration12.kt` for the full recipe (creates `exercises_table_new`, copies rows,
-     drops `exercises_table`, renames `exercises_table_new`).
-   - **Transform values** during the copy: read the old row via `db.query(...).use { cursor }`
-     and write the converted values via parameterized `INSERT ... VALUES (?, ?, ...)`.
-   - **Use existing converters** when the new column needs a serialized form, e.g.
-     `SetsTypeConverter.toString(setsList)` or `StringConverter.listToString(...)`.
-
-5. Register the migration in
-   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/di/CoreDatabaseModule.kt`:
-
-   ```kotlin
-   .addMigrations(MIGRATION_1_2, MIGRATION_<X>_<Y>)
-   ```
-
-   Append, do not replace — every prior migration must remain callable.
+   Append the prior version number (the `X` you just bumped from). Keep the existing
+   entries; each lets a developer device with that older `app.db` reset cleanly on first
+   launch instead of crashing at Room startup.
 
 6. Build the module so Room exports the new schema:
 
@@ -74,18 +90,18 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
    Confirm `core/database/schemas/io.github.stslex.workeeper.core.database.AppDatabase/<Y>.json`
    exists, and commit it.
 
-7. Add a migration test at
-   `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X>To<Y>Test.kt`.
-   Mirror `core/database/src/test/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration1To2Test.kt`:
+7. Refresh DAO unit tests. Per
+   [db-redesign.md → Tests](../../documentation/db-redesign.md#tests) destructive bumps drop
+   or rewrite the existing per-DAO tests rather than adding `MigrationTestHelper`-based ones.
+   Cover CRUD plus the indexed query paths for any new / changed DAO. There is intentionally
+   **no migration test** for a destructive bump — there is nothing to validate.
 
-   - Use `androidx.room.testing.MigrationTestHelper` (the project's `RoomLibraryConventionPlugin`
-     adds the `androidx-room-testing` dependency to every Room module).
-   - Open the database at version `X`, populate fixture rows that exercise the migration's
-     edge cases.
-   - Run `helper.runMigrationsAndValidate(NAME, Y, true, MIGRATION_<X>_<Y>)`.
-   - Assert that fixture rows survive (or are transformed correctly) by querying via the
-     returned `SupportSQLiteDatabase`.
-   - Cover at least: typical row, empty/edge input, multiple rows.
+8. Sweep for downstream breakage. Renamed entity columns, dropped converters, or new FK
+   cascades will surface in `core/exercise` repository code and feature stores. Compile the
+   whole project (`./gradlew assembleDebug`) and fix call sites; do not paper over with
+   shims unless the relevant feature is mid-rewrite (see the constraint note in the
+   Stage 5.1 prompt at
+   [documentation/feature-specs/settings-archive.md](../../documentation/feature-specs/settings-archive.md)).
 
 ## Verification
 
@@ -93,29 +109,82 @@ description: Add a Room schema migration safely — bump `AppDatabase` version, 
 # Compile with the new schema
 ./gradlew :core:database:assembleDebug
 
-# Run the migration test
-./gradlew :core:database:testDebugUnitTest --tests "*.Migration<X>To<Y>Test"
+# DAO unit tests
+./gradlew :core:database:testDebugUnitTest
 
-# Static analysis on the new file
+# Whole-project compile (catches feature-side breakage)
+./gradlew assembleDebug
+
+# Static analysis on the touched files
 ./gradlew :core:database:detekt :core:database:lintDebug --no-configuration-cache
 ```
 
-If the schema diff vs. the previous version surprises you (e.g. missing index, unintended
-NOT NULL change), inspect the JSON files in `core/database/schemas/...AppDatabase/` before
-shipping.
+Inspect the schema diff between `<X>.json` and `<Y>.json` before shipping — unexpected
+index, NOT NULL, or default-value differences are easier to catch by reading the JSON than
+by re-deriving them from the entity classes.
 
 ## Common pitfalls
 
-- **Never modify a migration that has shipped.** Once `MIGRATION_X_Y` exists in a released
-  build, treat it as immutable. Forward-fix in `MIGRATION_Y_(Y+1)`.
-- **Never use `fallbackToDestructiveMigration()` in release builds.** The current
-  `CoreDatabaseModule` does not, and it should stay that way — destructive fallback wipes user
-  data.
-- **Do not skip the schema JSON commit.** Reviewers and CI need the new
-  `<Y>.json` to verify the migration matches the entity definitions.
-- **Do not skip the migration test.** It is the only thing that exercises real upgrade
-  behavior; the schema export only catches DDL drift, not data semantics.
-- **Do not write raw SQL with string concatenation of user data.** Always use bound parameters
-  (`db.execSQL(sql, arrayOf<Any?>(...))`) — the `Migration12` pattern shows this.
-- **Do not delete prior `MIGRATION_X_Y` registrations.** All previous migrations stay in the
-  `addMigrations(...)` list so users can upgrade across multiple versions.
+- **Do not write a `Migration<X><Y>` class while destructive policy is in force.** The
+  `migrations/` package does not exist on disk. Adding one would be dead code and would
+  mislead the next contributor about whether real migration logic ran on upgrade.
+- **Do not drop the `dropAllTables = true` flag.** Without it, Room's destructive fallback
+  leaves orphaned tables that older entity definitions referenced — the next app launch can
+  fail in confusing ways.
+- **Do not drop prior versions from the destructive list.** Each entry covers a developer
+  device that may still hold that older `app.db`. Removing entries means those devices
+  crash at Room startup instead of resetting cleanly.
+- **Do not skip the schema JSON commit.** Reviewers and CI need the new `<Y>.json` to verify
+  the entity definitions exported what you expect.
+- **Do not modify a schema JSON by hand.** It is generated. If the diff looks wrong, fix
+  the entity / index / converter and re-export.
+
+## When to switch back to non-destructive migrations
+
+Once the app has shipped to the Play Store and any user has installed it, every new schema
+bump must preserve their data. The transition looks like:
+
+1. Stop adding to `fallbackToDestructiveMigrationFrom(...)`. Leave the existing list in
+   place so legacy developer devices still reset cleanly, but the new version is added via
+   `addMigrations(MIGRATION_X_Y)` instead.
+
+2. Recreate the `migrations/` package and add `MIGRATION_<X>_<Y>` at
+   `core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/migrations/Migration<X><Y>.kt`:
+
+   ```kotlin
+   val MIGRATION_X_Y = object : Migration(X, Y) {
+       override fun migrate(db: SupportSQLiteDatabase) {
+           // SQL: ALTER, CREATE, copy-and-rename for column drops, etc.
+       }
+   }
+   ```
+
+   SQLite has no `ALTER TABLE DROP COLUMN`, so column drops are done by creating
+   `<table>_new`, copying rows, dropping the old table, renaming. Use parameterized
+   `db.execSQL(sql, arrayOf(...))` for any value substitution.
+
+3. Register it in `CoreDatabaseModule`:
+
+   ```kotlin
+   .addMigrations(MIGRATION_X_Y)
+   .fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3, ...)
+   .build()
+   ```
+
+   Both calls coexist — `addMigrations` handles real upgrade paths from versions Room knows
+   about; the destructive list still catches developer-only legacy versions.
+
+4. Add an instrumented migration test under
+   `core/database/src/test/kotlin/.../migrations/Migration<X>To<Y>Test.kt` using
+   `androidx.room.testing.MigrationTestHelper`:
+
+   - Open the database at version `X`, populate fixture rows that exercise edge cases.
+   - Call `helper.runMigrationsAndValidate(NAME, Y, true, MIGRATION_X_Y)`.
+   - Assert that fixture rows survive (or are transformed correctly).
+   - Cover at least: typical row, empty/edge input, multiple rows.
+
+5. Once shipped, never edit `MIGRATION_X_Y` again. Forward-fix in `MIGRATION_Y_(Y+1)`.
+
+This non-destructive playbook is dormant until the first Play Store release lands. Treat
+this section as the future plan, not the current one — and update this skill when the
+policy actually flips.

--- a/.claude/skills/add-feature.md
+++ b/.claude/skills/add-feature.md
@@ -1,6 +1,6 @@
 ---
 name: add-feature
-description: Scaffold a new `feature/<name>` Gradle module with the project's MVI + Hilt + Compose conventions, including Store contract, handlers, DI, navigation entry, and a smoke UI test stub.
+description: Scaffold a new `feature/<name>` Gradle module that follows the project's MVI + Hilt + Compose conventions — including the canonical navigation pattern (Action.Navigation + NavigationHandler with injected Navigator), the design system (`core/ui/kit` components and `AppUi.*` tokens), Store contract, handlers, DI, navigation entry, and a smoke UI test stub.
 ---
 
 # Add a feature module
@@ -15,37 +15,67 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
 ## Prerequisites
 
 - The feature has a name in kebab-case (e.g. `workout-history`).
-- The corresponding `Screen` route does not yet exist in `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`.
-- `documentation/architecture.md` is available — every step below assumes its conventions and file paths.
+- The corresponding `Screen` route does not yet exist in
+  `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`.
+- These docs are the source of truth for everything below — read them before scaffolding:
+  - [documentation/architecture.md](../../documentation/architecture.md) — module map, MVI
+    contract, `Navigation flow (canonical pattern)`, DI scopes.
+  - [documentation/design-system.md](../../documentation/design-system.md) — token catalog
+    and the 21 `core/ui/kit` components.
+  - [documentation/lint-rules.md](../../documentation/lint-rules.md) — the State / Action /
+    Event / Handler / Composable rules that gate a new module.
+  - [documentation/feature-specs/settings-archive.md](../../documentation/feature-specs/settings-archive.md)
+    — canonical worked example of a v1 feature, including handler split and graph composable.
+
+## Reference implementation
+
+The fullest current example is `feature/settings/` (Stage 5.1). The most literal
+"canonical navigation" reference is `feature/all-trainings/`:
+
+- Graph composable: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/ui/AllTrainingsGraph.kt`
+- NavigationHandler: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/NavigationHandler.kt`
+- Component: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/AllTrainingsComponent.kt`
+- StoreImpl: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/store/TrainingStoreImpl.kt`
+- Feature wiring: `feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/di/TrainingsFeature.kt`
+
+Older features (`feature/exercise`, `feature/single-training`, `feature/charts`) keep the
+MVI under `ui/mvi/` and use the older `*StoreProcessor.kt` naming. When extending those
+modules, mirror what already exists there. When creating a **new** module, follow the
+post-Stage-5.1 layout below.
 
 ## Step-by-step
 
-1. Decide whether the feature needs a domain layer. Features with non-trivial business logic or
-   their own interactor (see `feature/exercise/.../domain/`, `feature/single-training/.../domain/`)
-   create a `domain/` package. Features that only forward to repositories
-   (`feature/all-trainings`, `feature/charts`, `feature/all-exercises`) skip it.
+1. Decide whether the feature needs a domain layer. Features with non-trivial business logic
+   or their own interactor (`feature/settings/.../domain/`,
+   `feature/exercise/.../domain/`, `feature/single-training/.../domain/`) create a `domain/`
+   package. Features that only forward to repositories (`feature/all-trainings`,
+   `feature/charts`, `feature/all-exercises`) skip it.
 
-2. Create the module directory tree under `feature/<name>/`:
+2. Create the module directory tree under `feature/<name>/`. Post-Stage-5.1 layout
+   (mirrors `feature/settings/`):
 
    ```
    feature/<name>/
    ├── build.gradle.kts
    └── src/
+       ├── main/AndroidManifest.xml
        ├── main/kotlin/io/github/stslex/workeeper/feature/<name_snake>/
-       │   ├── di/                 # <Name>Module, <Name>HandlerStore[+Impl], <Name>Processor, <Name>EntryPoint (if needed)
+       │   ├── di/                 # <Name>Module, <Name>HandlerStore[+Impl], <Name>Feature
        │   ├── domain/             # only if the feature has its own business logic
        │   ├── mvi/
-       │   │   ├── handler/        # ClickHandler, InputHandler, NavigationHandler, optionally PagingHandler / CommonHandler, plus <Name>Component
+       │   │   ├── handler/        # ClickHandler, InputHandler, NavigationHandler,
+       │   │   │                   # optional PagingHandler / CommonHandler, plus <Name>Component
        │   │   ├── model/          # UI models, mappers
        │   │   └── store/          # <Name>Store contract + <Name>StoreImpl
        │   └── ui/
        │       ├── components/
-       │       └── <Name>Screen.kt # or <Name>Widget.kt
-       ├── test/kotlin/...         # JUnit 5 unit tests
-       └── androidTest/kotlin/...  # @Smoke UI tests
+       │       ├── <Name>Screen.kt
+       │       └── <Name>Graph.kt   # NavGraphBuilder.<feature>Graph extension
+       ├── test/kotlin/...         # JUnit 5 unit tests (handlers, interactor)
+       └── androidTest/kotlin/...  # @Smoke UI tests (often stubs — see write-ui-test)
    ```
 
-3. Generate `feature/<name>/build.gradle.kts`. Mirror `feature/charts/build.gradle.kts`:
+3. Generate `feature/<name>/build.gradle.kts`. Mirror `feature/settings/build.gradle.kts`:
 
    ```kotlin
    plugins {
@@ -54,12 +84,15 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
 
    dependencies {
        implementation(project(":core:core"))
+
        implementation(project(":core:dataStore"))
        implementation(project(":core:ui:kit"))
        implementation(project(":core:ui:mvi"))
        implementation(project(":core:ui:navigation"))
        implementation(project(":core:exercise"))
+
        testImplementation(kotlin("test"))
+       testImplementation(libs.androidx.paging.testing) // only if the feature uses PagingHandler
 
        androidTestImplementation(libs.bundles.android.test)
        androidTestImplementation(libs.androidx.compose.ui.test.junit4)
@@ -69,79 +102,272 @@ description: Scaffold a new `feature/<name>` Gradle module with the project's MV
    ```
 
    Drop dependencies the feature does not use (e.g. omit `:core:exercise` if the feature does
-   not touch exercise/training/label repositories).
+   not touch exercise / training / tag repositories).
 
 4. Add the module to the root settings: `include(":feature:<name>")` in `settings.gradle.kts`.
 
-5. Add the route. Edit `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`
-   and add a `@Serializable` entry. Bottom-bar destinations go under `Screen.BottomBar`; detail
-   destinations are top-level data classes that carry route arguments.
+5. Add the route. Edit
+   `core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt`
+   and add a `@Serializable` entry. Bottom-bar destinations go under `Screen.BottomBar`;
+   detail destinations are top-level `data class` types that carry route arguments;
+   single-instance destinations are `data object`. Existing examples: `Screen.Settings` /
+   `Screen.Archive` (data objects), `Screen.Training(uuid)` / `Screen.Exercise(uuid, trainingUuid)`
+   (data classes).
 
-6. Generate the Store contract under `mvi/store/<Name>Store.kt`. Follow the contract conventions
-   in [documentation/architecture.md#mvi-contract](../../documentation/architecture.md#mvi-contract):
+6. Generate the Store contract under `mvi/store/<Name>Store.kt`. Conventions enforced by
+   the custom Detekt rules in
+   [documentation/lint-rules.md](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
 
-   - `interface <Name>Store : Store<State, Action, Event>`
-   - `data class State(val ...) : Store.State` — properties are `val`; collections are
-     `kotlinx.collections.immutable.ImmutableList` / `ImmutableSet` (never `MutableList` etc.).
-     Add a `companion object { val INITIAL = State(...) }` for tests.
-   - `sealed interface Action : Store.Action` with nested `Click`, `Input`, `Navigation`,
-     optionally `Paging` / `Common`.
-   - `sealed interface Event : Store.Event` — names follow the patterns enforced by
-     `MviEventNamingRule` (e.g. `*Success`, `*Error`, `Haptic*`, `Snackbar*`, `Navigate*`,
-     `Scroll*`).
+   - `internal interface <Name>Store : Store<State, Action, Event>`.
+   - `data class State(val ...) : Store.State` — properties are `val`; collections use
+     `kotlinx.collections.immutable` (`ImmutableList`, `ImmutableSet`). A
+     `companion object { fun init(...) = State(...) }` (or `INITIAL = State(...)`) keeps
+     fixture construction in tests cheap.
+   - `sealed interface Action : Store.Action` with nested categories under
+     `Click`, `Input`, `Navigation`, optionally `Paging`, `Common`. **Navigation actions
+     are always grouped under `Action.Navigation` — never modeled as `Event.Navigate*`.**
+     See the Canonical navigation pattern below.
+   - `sealed interface Event : Store.Event` for **UI side effects only**. Allowed name
+     patterns from `MviEventNamingRule` are `*Success`, `*Error`, `*Completed`, `*Started`,
+     `*Failed`, `*Requested`, plus tokens `Show`, `Haptic`, `Snackbar`, `Scroll`. Although
+     `Navigate` is technically in the rule's pattern list, the project's convention is
+     **never to use it** — emit `Action.Navigation.*` instead.
 
-7. Generate handlers under `mvi/handler/`. Use `feature/exercise/.../mvi/handler/ClickHandler.kt`
+7. Generate handlers under `mvi/handler/`. Use
+   `feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandler.kt`
    as the canonical reference. Each handler:
 
-   - is `@ViewModelScoped` and uses `@Inject` constructor injection (except `NavigationHandler`,
-     which constructs from the `<Name>Component`).
-   - implements `Handler<Action.<Category>>` from `core/ui/mvi/.../handler/Handler.kt`.
-   - receives the feature's `<Name>HandlerStore` to read state, mutate state, and emit events.
+   - Is `internal class`, `@ViewModelScoped`, with `@Inject` constructor injection (the
+     only exception is `NavigationHandler` — see Canonical navigation pattern below).
+     `MviHandlerConstructorRule` enforces `@Inject` and at least one parameter.
+   - Implements `Handler<Action.<Category>>` from
+     `core/ui/mvi/src/main/kotlin/io/github/stslex/workeeper/core/ui/mvi/handler/Handler.kt`.
+   - Receives the feature's `<Name>HandlerStore` interface (defined in `di/`) to read
+     state, mutate state via `updateState { it.copy(...) }`, dispatch other actions via
+     `consume(...)`, and emit events via `sendEvent(...)`.
 
 8. Generate `mvi/handler/<Name>Component.kt` extending `Component<Screen.<...>>` from
-   `core/ui/navigation/.../Component.kt`, plus `<Name>ComponentImpl` that the navigation graph
-   constructs. See `feature/exercise/.../mvi/handler/ExerciseComponent.kt`.
+   `core/ui/navigation/.../Component.kt`. The component carries the route data and exposes
+   a `companion object create(navigator: Navigator, ...)` factory that constructs the
+   feature's `NavigationHandler`. Reference:
+   `feature/all-trainings/.../mvi/handler/AllTrainingsComponent.kt` (no route args) or
+   `feature/exercise/.../ui/mvi/handler/ExerciseComponent.kt` (route args carried via
+   `data class Screen.Exercise`).
 
 9. Generate `mvi/store/<Name>StoreImpl.kt` extending `BaseStore<State, Action, Event>`,
    annotated `@HiltViewModel(assistedFactory = <Name>StoreImpl.Factory::class)`. The
-   `handlerCreator` lambda routes each `Action` subtype to the matching handler. See
-   `feature/exercise/.../ui/mvi/store/ExerciseStoreImpl.kt`.
+   `handlerCreator` lambda routes each `Action` subtype to the matching handler; the
+   `Action.Navigation` branch casts the assisted `<Name>Component` to the
+   `NavigationHandler`. Reference:
+   `feature/all-trainings/.../mvi/store/TrainingStoreImpl.kt` (lines 38-45) or
+   `feature/settings/.../mvi/store/SettingsStoreImpl.kt`.
 
 10. Generate the Hilt module at `di/<Name>Module.kt` with
-    `@InstallIn(ViewModelComponent::class)`. Bind the `<Name>HandlerStore` (and any interactor)
-    as `@ViewModelScoped`. See `feature/exercise/.../di/ExerciseModule.kt`.
+    `@InstallIn(ViewModelComponent::class)`. Bind the `<Name>HandlerStore`
+    (and any interactor) as `@ViewModelScoped`. Reference:
+    `feature/all-trainings/.../di/AllTrainingsModule.kt`.
 
-11. Generate `di/<Name>HandlerStoreImpl.kt` as a `@ViewModelScoped` `@Inject` class extending
-    `BaseHandlerStore<State, Action, Event>`. See
-    `feature/exercise/.../di/ExerciseHandlerStoreImpl.kt`.
+11. Generate `di/<Name>HandlerStore.kt` (the interface, e.g. `internal interface
+    SettingsHandlerStore : HandlerStore<State, Action, Event>`) and
+    `di/<Name>HandlerStoreImpl.kt` (`@ViewModelScoped`, `@Inject constructor()`,
+    extending `BaseHandlerStore<State, Action, Event>`). Reference:
+    `feature/all-trainings/.../di/TrainingHandlerStoreImpl.kt`.
 
-12. Generate `di/<Name>Processor.kt` implementing `Feature<TProcessor, TScreen, TComponent>`
-    from `core/ui/mvi/.../Feature.kt` and a `<feature>Graph(...)` extension on `NavGraphBuilder`.
-    See `feature/charts/.../di/ChartsStoreProcessor.kt`.
+12. Generate `di/<Name>Feature.kt` extending
+    `Feature<<Name>StoreProcessor, Screen.<X>, <Name>Component>` and overriding `processor`
+    to call `createProcessor<<Name>StoreImpl, <Name>StoreImpl.Factory>(screen)`. Reference:
+    `feature/all-trainings/.../di/TrainingsFeature.kt` or
+    `feature/settings/.../di/SettingsFeature.kt`. (The legacy `*StoreProcessor.kt` /
+    `*Processor.kt` naming in `feature/charts`, `feature/single-training`, and the older
+    `feature/exercise/di/ExerciseProcessor.kt` does the same job; new code uses
+    `*Feature.kt`.)
 
-13. Wire the navigation graph. Edit `app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt`
-    and call your new `<feature>Graph(modifier = ..., sharedTransitionScope = this@SharedTransitionLayout)`.
+13. Generate `ui/<Name>Graph.kt` — a `fun NavGraphBuilder.<feature>Graph(modifier: Modifier
+    = Modifier, ...)` extension. Inside, call `navComponentScreen(<Name>Feature) { processor
+    -> ... }` and consume only **UI-side** events through `processor.Handle { event -> ... }`
+    (haptics, external links, snackbar emissions, scroll commands). Pass
+    `processor.state.value` and `processor::consume` into your `<Name>Screen` /
+    `<Name>Widget`. Reference:
+    `feature/settings/.../ui/SettingsGraph.kt` and
+    `feature/all-trainings/.../ui/AllTrainingsGraph.kt`.
 
-14. If the feature is bottom-bar visible, add an entry in
+14. Wire the navigation graph into the host. Edit
+    `app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt` and call
+    your new `<feature>Graph(modifier = ..., sharedTransitionScope = this@SharedTransitionLayout)`.
+    The `sharedTransitionScope` parameter is only required for graphs that participate in
+    shared element transitions — see how `allTrainingsGraph` and `settingsGraph` differ.
+
+15. If the feature is bottom-bar visible, add an entry in
     `app/app/src/main/java/io/github/stslex/workeeper/bottom_app_bar/BottomBarItem.kt`.
 
-15. Generate the screen. `<Name>Screen.kt` (or `<Name>Widget.kt`) is a `@Composable` ending in
-    `Screen` and must take a `*State` parameter and an action/event handler parameter — this is
-    enforced by `ComposableStateRule`.
+16. Generate the screen. `<Name>Screen.kt` (or `<Name>Widget.kt`) is a `@Composable` ending
+    in `Screen` and must take both a `*State` parameter and an action/event handler
+    parameter — enforced by `ComposableStateRule`.
 
-16. Add a smoke UI test stub under
-    `feature/<name>/src/androidTest/kotlin/.../<Name>ScreenTest.kt` annotated `@Smoke`. Use
-    `BaseComposeTest` with `setTransitionContent { ... }`. See
-    [documentation/testing.md](../../documentation/testing.md) and the `write-ui-test` skill.
+17. Build the UI from `core/ui/kit` components and tokens (see Design system contract
+    below). Hardcoded `Color()`, `sp`, or `dp` outside `core/ui/kit/theme/` are not allowed.
+
+18. Add a smoke UI test stub under
+    `feature/<name>/src/androidTest/kotlin/.../<Name>ScreenTest.kt` annotated `@Smoke`. Most
+    new features start as a stub with a `TODO(feature-rewrite-tests)` marker (see the
+    `write-ui-test` skill).
+
+## Canonical navigation pattern
+
+Navigation is **always** routed through a feature's `NavigationHandler`. The graph
+composable knows nothing about routes or the `Navigator`. The full rationale lives at
+[documentation/architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+The shape:
+
+1. UI emits `Action.Navigation.<Something>` via `processor::consume(...)`.
+2. The `StoreImpl.handlerCreator` routes that action to the feature's `NavigationHandler`
+   (typically `is Action.Navigation -> component as NavigationHandler`).
+3. `NavigationHandler` receives `Navigator` (constructed by the feature's `Component.create`
+   factory at navigation time) and calls `navigator.navTo(Screen.X)` or `navigator.popBack()`.
+
+Concretely, a feature defines:
+
+```kotlin
+// In <Name>Store.kt:
+internal interface <Name>Store : Store<State, Action, Event> {
+
+    sealed interface Action : Store.Action {
+        sealed interface Navigation : Action {
+            data object Back : Navigation
+            data object OpenArchive : Navigation
+            // ... any other navigation targets
+        }
+        // ... Click, Input, Paging, Common as needed
+    }
+
+    sealed interface Event : Store.Event {
+        // ONLY UI-side effects: Haptic*, Snackbar*, Show*, Scroll*, *Success, *Error, *Completed.
+        // NEVER Navigate*. Navigation is Action.Navigation, full stop.
+    }
+}
+
+// In mvi/handler/NavigationHandler.kt:
+internal class NavigationHandler(
+    private val navigator: Navigator,
+) : <Name>Component(), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            Action.Navigation.Back -> navigator.popBack()
+            Action.Navigation.OpenArchive -> navigator.navTo(Screen.Archive)
+        }
+    }
+}
+
+// In mvi/handler/<Name>Component.kt:
+abstract class <Name>Component : Component<Screen.<X>>(Screen.<X>) {
+    companion object {
+        fun create(navigator: Navigator): <Name>Component = NavigationHandler(navigator)
+    }
+}
+```
+
+`MviHandlerConstructorRule` explicitly skips the `@Inject` requirement for classes named
+`NavigationHandler` (see `lint-rules/.../MviHandlerConstructorRule.kt:74`). Older
+NavigationHandlers in the codebase carry `@Suppress("MviHandlerConstructorRule")` — that
+suppression is unnecessary for the literal name `NavigationHandler`, only for variants like
+`SettingsNavigationHandler`. Either name compiles; prefer the bare `NavigationHandler` per
+the all-trainings reference.
+
+The graph composable (`<feature>Graph`) consumes **only** UI-side events:
+
+```kotlin
+fun NavGraphBuilder.<feature>Graph(modifier: Modifier = Modifier) {
+    navComponentScreen(<Name>Feature) { processor ->
+        val haptic = LocalHapticFeedback.current
+        val context = LocalContext.current
+
+        processor.Handle { event ->
+            when (event) {
+                is Event.Haptic -> haptic.performHapticFeedback(event.type)
+                is Event.ShowExternalLink -> context.startActivity(
+                    Intent(Intent.ACTION_VIEW, event.url.toUri())
+                        .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) },
+                )
+                // snackbar emissions, scroll commands, ...
+            }
+        }
+
+        <Name>Screen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+        )
+    }
+}
+```
+
+The graph composable **never** reads `LocalNavigator`, **never** calls `navigator.navTo` /
+`navigator.popBack` directly, and **never** consumes a `Navigate*` event (no such event
+exists — emitting one is wrong by convention). `LocalNavigator` lives in
+`core/ui/navigation/Navigator.kt` only so the root `App.kt` can provide a single instance
+into the composition tree.
+
+## Design system contract
+
+All visible UI is built from `core/ui/kit` components and `AppUi.*` token accessors. Full
+catalog is in [documentation/design-system.md](../../documentation/design-system.md).
+Quick reference:
+
+**Tokens** — read via `AppUi.*` inside any `@Composable`:
+
+- `AppUi.colors` — `LocalAppColors.current` (semantic palette: `accent`, `textPrimary`,
+  `textSecondary`, `textTertiary`, surface tiers, semantic statuses).
+- `AppUi.typography` — `LocalAppTypography.current` (Inter family, 13-slot M3 scale).
+- `AppUi.shapes` — `LocalAppShapes.current` (`small` / `medium` / `large`).
+- `AppUi.motion` — `LocalAppMotion.current` (durations + easings).
+- `AppUi.elevation` — `LocalAppElevation.current` (color-based surface tier mapping).
+- `LocalAppDimension.current` for spacing aliases (`screenEdge`, `cardPadding`, `iconMd`,
+  `heightSm`, etc.).
+
+**Components** — every shared UI primitive lives under
+`core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/`:
+
+| Component | File |
+|---|---|
+| `AppButton` | `components/button/AppButton.kt` |
+| `AppCard` | `components/card/AppCard.kt` |
+| `AppTextField` | `components/input/AppTextField.kt` |
+| `AppNumberInput` | `components/input/AppNumberInput.kt` |
+| `AppDialog` | `components/dialog/AppDialog.kt` |
+| `AppConfirmDialog` | `components/dialog/AppConfirmDialog.kt` |
+| `AppDatePickerDialog` | `components/dialog/AppDatePickerDialog.kt` |
+| `AppEmptyState` | `components/empty/AppEmptyState.kt` |
+| `AppListItem` | `components/list/AppListItem.kt` |
+| `AppTagChip` | `components/tag/AppTagChip.kt` |
+| `AppTagPicker` | `components/tag/AppTagPicker.kt` |
+| `AppTopAppBar` | `components/topbar/AppTopAppBar.kt` |
+| `AppBottomBar` | `components/bottombar/AppBottomBar.kt` |
+| `AppBottomSheet` | `components/sheet/AppBottomSheet.kt` |
+| `AppFAB` | `components/fab/AppFAB.kt` |
+| `AppLoadingIndicator` | `components/loading/AppLoadingIndicator.kt` |
+| `AppSetTypeChip` | `components/setchip/AppSetTypeChip.kt` |
+| `AppSegmentedControl` | `components/segmented/AppSegmentedControl.kt` |
+| `AppSnackbar` | `components/snackbar/AppSnackbar.kt` |
+| `AppSwipeAction` | `components/swipe/AppSwipeAction.kt` |
+
+**Forbidden in feature code**:
+
+- Hardcoded `Color(0xFFRRGGBB)` outside `core/ui/kit/theme/AppColors.kt`.
+- Hardcoded `12.sp` / `16.dp` outside `core/ui/kit/theme/{AppTypography,AppDimension,AppShapes}.kt`.
+- Re-implementing dialogs, snackbars, list rows, or segmented controls inside a feature
+  module — extend the shared component or land the variant in `core/ui/kit/`.
 
 ## Verification
 
 ```bash
 ./gradlew :feature:<name>:detekt :feature:<name>:lintDebug --no-configuration-cache
+./gradlew :feature:<name>:assembleDebug
+./gradlew :feature:<name>:testDebugUnitTest
 ```
 
-Both must pass. The detekt run exercises the custom MVI rules; if any fire, fix them rather
-than baselining (see the `refactor-with-mvi-rules` skill).
+The detekt run exercises the custom MVI rules; if any fire, fix them rather than baselining
+(see the `refactor-with-mvi-rules` skill).
 
 ## Common pitfalls
 
@@ -152,7 +378,15 @@ than baselining (see the `refactor-with-mvi-rules` skill).
 - **Do not use `MutableList` / `MutableSet` / `MutableMap` in `State`.** Use the
   `kotlinx.collections.immutable` types. `MviStateImmutabilityRule` will reject them.
 - **Do not use `var` in `State`.** Same rule — properties must be `val`.
-- **Do not forget the `convention.composeLibrary` plugin alias** in `build.gradle.kts`. Plain
-  `kotlin("jvm")` modules will not get Hilt, Compose, or the lint convention.
+- **Do not model navigation as `Event.Navigate*`.** Every navigation target is
+  `Action.Navigation.<X>` consumed by the feature's `NavigationHandler`. See the Canonical
+  navigation pattern above and the `refactor-with-mvi-rules` skill.
+- **Do not read `LocalNavigator` from the graph composable.** The root `App.kt` provides it
+  for the composition tree; the canonical read site is `NavigationHandler` (constructed via
+  the feature's `Component.create(navigator)` factory).
+- **Do not hardcode colors / sizes / type styles in feature code.** Pull from `AppUi.*` and
+  the `core/ui/kit` components. See the Design system contract above.
+- **Do not forget the `convention.composeLibrary` plugin alias** in `build.gradle.kts`.
+  Plain `kotlin("jvm")` modules will not get Hilt, Compose, or the lint convention.
 - **Do not bypass `Screen` for navigation.** Every navigable destination must be a
   `@Serializable` entry in `core/ui/navigation/.../Screen.kt`.

--- a/.claude/skills/refactor-with-mvi-rules.md
+++ b/.claude/skills/refactor-with-mvi-rules.md
@@ -1,6 +1,6 @@
 ---
 name: refactor-with-mvi-rules
-description: Resolve a custom Detekt MVI-architecture rule violation by reading the rule source under `lint-rules/.../lint_rules/`, applying the conformant fix, and verifying with `./gradlew detekt`.
+description: Resolve a custom Detekt MVI-architecture rule violation by reading the rule source under `lint-rules/.../lint_rules/`, applying the conformant fix (including the project convention that navigation flows through `Action.Navigation`, never `Event.Navigate*`), and verifying with `./gradlew detekt`.
 ---
 
 # Refactor to satisfy MVI Detekt rules
@@ -16,7 +16,11 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 ## Prerequisites
 
 - The detekt report (`<module>/build/reports/detekt/`) or the gradle output names the rule.
-- `documentation/lint-rules.md` is available for the catalog of rules with good/bad examples.
+- [documentation/lint-rules.md](../../documentation/lint-rules.md) has the catalog of rules
+  with good/bad examples.
+- [documentation/architecture.md](../../documentation/architecture.md#mvi-contract) describes
+  the MVI contract the rules enforce, including the canonical navigation pattern
+  (`Action.Navigation` + `NavigationHandler`, never `Event.Navigate*`).
 
 ## Step-by-step
 
@@ -37,29 +41,69 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
    triggers the report. The rule set is registered in `MviArchitectureRules.kt`.
 
 2. Apply the canonical fix. Examples and rationale live in
-   [documentation/lint-rules.md#custom-detekt-mvi-rules](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
+   [documentation/lint-rules.md → Custom Detekt MVI rules](../../documentation/lint-rules.md#custom-detekt-mvi-rules):
 
    - **`MviStateImmutabilityRule`** — convert the class to `data class` (or `sealed`),
      change every `var` to `val`, replace `MutableList<T>` / `MutableSet<T>` /
      `MutableMap<K, V>` with the `kotlinx.collections.immutable` types
      (`ImmutableList`, `ImmutableSet`, `ImmutableMap`).
+
    - **`MviActionNamingRule`** — make the `*Action` class `sealed` (interface or class).
-     Group nested actions under categories: `Click`, `Input`, `Navigation`, optionally
-     `Paging`, `Common`.
+     Group nested actions under the project's standard top-level categories: `Click`,
+     `Input`, `Navigation`, optionally `Paging`, `Common`. Verified shape across the v1
+     features (e.g. `feature/all-trainings/.../mvi/store/TrainingStore.kt`,
+     `feature/settings/.../mvi/store/SettingsStore.kt`):
+
+     ```kotlin
+     sealed interface Action : Store.Action {
+         sealed interface Click : Action { /* ... */ }
+         sealed interface Input : Action { /* ... */ }
+         sealed interface Navigation : Action { /* ... */ }
+         sealed interface Paging : Action { /* ... */ }
+         // sealed interface Common : Action { /* ... */ }   when needed
+     }
+     ```
+
    - **`MviEventNamingRule`** — make the outer `*Event` `sealed`. Each nested event must
      either end in one of `Success`, `Error`, `Completed`, `Started`, `Failed`, `Requested`,
      **or** contain one of `Show`, `Navigate`, `Haptic`, `Snackbar`, `Scroll`. Rename to
      match.
+
+     **Project convention layered on top of the rule:** Events are for UI side effects
+     only. Allowed in practice: `Haptic*` (e.g. `Event.Haptic(type)`), `Snackbar*`,
+     `Show*` (e.g. `Event.ShowExternalLink(url)`), `Scroll*`, `*Success`, `*Error`,
+     `*Completed`. **`Navigate*` is not allowed by convention even though the rule's
+     pattern would accept it.** Navigation is `Action.Navigation.<X>` consumed by the
+     feature's `NavigationHandler`. See
+     [architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+     If a `Navigate*` event slipped in, the fix is to:
+
+     1. Add an `Action.Navigation.<X>` entry on the feature's Store contract.
+     2. Move the route call into the feature's `NavigationHandler.invoke(action)` branch.
+     3. Replace `processor.Handle { Event.Navigate* -> navigator.navTo(...) }` with
+        `processor.consume(Action.Navigation.<X>)` at the call site, or drop the event
+        emission entirely if no caller needed it.
+     4. Delete the `Navigate*` event.
+
    - **`MviHandlerNamingRule`** — `*Handler` must not be a `data class`. Member functions
      starting with `Handle` must contain `Action` (e.g. `HandleClickAction`).
+
    - **`MviStoreExtensionRule`** — `*StoreImpl` must extend `BaseStore`. `*Store`
      interfaces (excluding `*HandlerStore`) must implement `Store`.
+
    - **`MviHandlerConstructorRule`** — `*Handler` classes must have a primary constructor
-     annotated `@Inject` and at least one parameter. The only exception is
-     `NavigationHandler`, which is constructed from the feature's `*Component` rather than
-     via Hilt.
+     annotated `@Inject` and at least one parameter. The rule's source explicitly skips
+     the literal class name `NavigationHandler`
+     (`lint-rules/.../MviHandlerConstructorRule.kt:74`), which is constructed from the
+     feature's `*Component.create(navigator)` factory rather than via Hilt — so
+     `internal class NavigationHandler(private val navigator: Navigator) : ...` is
+     conformant. Variants like `SettingsNavigationHandler` still trip the rule and require
+     `@Suppress("MviHandlerConstructorRule")`; prefer the bare `NavigationHandler` name
+     for new code.
+
    - **`MviStoreStateRule`** — the inner `State` class of a `*Store` must be
      `data class State(...) : Store.State`.
+
    - **`HiltScopeRule`** — apply scope by class-name pattern (the mapping is in
      `lint-rules/.../lint_rules/ScopeClassType.kt`):
      - Names containing `Repository` / `DataStore` / `Database` / `StoreDispatchers` →
@@ -67,8 +111,10 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
      - Names containing `Handler` / `Store` / `Interactor` / `Mapper` →
        `@ViewModelScoped`.
      The rule also reports if a class carries the *other* category's annotation.
+
    - **`ComposableStateRule`** — `@Composable` functions whose name ends in `Screen`
-     must take a `*State` parameter and an action/event handler parameter.
+     must take a `*State` parameter and an action/event handler parameter (typically a
+     `consume: (Action) -> Unit` lambda).
 
 3. Re-run detekt for the affected module:
 
@@ -80,9 +126,10 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 
 4. If the rule fired on legacy code that is genuinely out of scope for the current task,
    prefer narrowing the change to the smallest unit that satisfies the rule rather than
-   adding a baseline entry. The codebase's policy (per
-   [documentation/lint-rules.md#baselines](../../documentation/lint-rules.md#baselines)) is to
-   use baselines only when introducing a brand-new rule against established legacy code.
+   adding a baseline entry. The codebase's policy
+   ([documentation/lint-rules.md → Baselines](../../documentation/lint-rules.md#baselines))
+   is to use baselines only when introducing a brand-new rule against established legacy
+   code.
 
 ## Verification
 
@@ -90,14 +137,14 @@ description: Resolve a custom Detekt MVI-architecture rule violation by reading 
 ./gradlew detekt
 ```
 
-Run at the project root to verify the violation cleared and no new ones surfaced. For changes
-to `*Store.kt` / handlers / Composables, also re-run the relevant unit tests and Compose UI
-tests (see the `write-handler-test` and `write-ui-test` skills).
+Run at the project root to verify the violation cleared and no new ones surfaced. For
+changes to `*Store.kt` / handlers / Composables, also re-run the relevant unit tests and
+Compose UI tests (see the `write-handler-test` and `write-ui-test` skills).
 
 ## Common pitfalls
 
-- **Do not add the violation to `lint-rules/detekt-baseline.xml`.** Baselines are for legacy
-  code that predates the rule, not for new violations.
+- **Do not add the violation to `lint-rules/detekt-baseline.xml`.** Baselines are for
+  legacy code that predates the rule, not for new violations.
 - **Do not suppress with `@Suppress("MviStateImmutabilityRule")` etc. on production code.**
   The `core/ui/mvi` module suppresses some rules at the type-parameter level
   (`@Suppress("MviStoreStateRule", "MviStoreExtensionRule", "MviStateImmutabilityRule")` on
@@ -106,9 +153,12 @@ tests (see the `write-handler-test` and `write-ui-test` skills).
 - **Do not move offending code outside `mvi/` to dodge the rule.** Several rules gate on
   whether the file's package contains `mvi` or its path contains `/mvi/`. Hiding the file
   silences the rule but breaks the architecture and will surprise the next contributor.
-- **Do not mix scope annotations.** `HiltScopeRule` rejects `@Singleton` on a class whose name
-  matches the `@ViewModelScoped` set (and vice-versa). Pick the scope that matches the class
-  name; if neither fits, rename the class.
-- **Do not change rule sources to make a violation go away.** If a rule's intent is wrong for
-  the codebase, that is a separate, larger conversation — open an issue rather than editing
-  `lint-rules/.../lint_rules/*.kt` mid-feature work.
+- **Do not introduce a `Navigate*` event to "fix" a navigation flow.** Add an
+  `Action.Navigation.<X>` and route through the feature's `NavigationHandler` instead.
+  See [architecture.md → Navigation flow (canonical pattern)](../../documentation/architecture.md#navigation-flow-canonical-pattern).
+- **Do not mix scope annotations.** `HiltScopeRule` rejects `@Singleton` on a class whose
+  name matches the `@ViewModelScoped` set (and vice-versa). Pick the scope that matches
+  the class name; if neither fits, rename the class.
+- **Do not change rule sources to make a violation go away.** If a rule's intent is wrong
+  for the codebase, that is a separate, larger conversation — open an issue rather than
+  editing `lint-rules/.../lint_rules/*.kt` mid-feature work.

--- a/.claude/skills/write-handler-test.md
+++ b/.claude/skills/write-handler-test.md
@@ -1,6 +1,6 @@
 ---
 name: write-handler-test
-description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the project's mocked `HandlerStore` + `TestScope` pattern from `feature/single-training`.
+description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the project's mocked `<Name>HandlerStore` + `MutableStateFlow` pattern from `feature/settings/`. Includes a NavigationHandler template that mocks `Navigator` and asserts `navTo` / `popBack` per `Action.Navigation`.
 ---
 
 # Write a handler / store unit test
@@ -11,79 +11,173 @@ description: Write a JUnit 5 unit test for an MVI Handler or StoreImpl using the
 - "Test the click handler for feature X"
 - "Cover `<...>StoreImpl` with unit tests"
 - "Write tests for an MVI action"
+- "Add a NavigationHandler test"
 
 ## Prerequisites
 
 - The handler or store under test exists.
-- The feature's module already pulls in `kotlin("test")` and the project's `test` bundle (most
-  feature `build.gradle.kts` files do — see `feature/charts/build.gradle.kts`).
-- `documentation/testing.md` is available for the broader strategy.
+- The feature's module already pulls in `kotlin("test")` and the project's `test` bundle
+  (every feature `build.gradle.kts` does — see `feature/settings/build.gradle.kts`).
+- [documentation/testing.md](../../documentation/testing.md) has the broader strategy.
+
+## Reference tests
+
+Use the **`feature/settings/`** test classes as the canonical patterns — they are the only
+real handler tests in the codebase right now. The older feature handler tests in
+`feature/all-trainings`, `feature/all-exercises`, `feature/exercise`,
+`feature/single-training`, and `feature/charts` are 10-line `placeholder() = Unit` stubs
+with `TODO(feature-rewrite)` markers; **do not copy from them** — they exist only so the
+modules still compile.
+
+Canonical references:
+
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsClickHandlerTest.kt`
+  — straight `verify { store.sendEvent(...) }` / `verify { store.consume(...) }` with no
+  state mutation.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsInputHandlerTest.kt`
+  — uses `MutableStateFlow` + `every { updateState(any()) } answers { ... }` to actually
+  mutate state inside the test.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/ArchiveClickHandlerTest.kt`
+  — fuller example with `coVerify`, `slot<T>()` capture, and state-conditional branches.
+- `feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/SettingsNavigationHandlerTest.kt`
+  — minimal `Navigator` mock + per-`Action.Navigation` assertion. See
+  [NavigationHandler test template](#navigationhandler-test-template) below.
 
 ## Step-by-step
 
-1. Locate a reference test in the same feature when one exists. Otherwise use:
-
-   - `feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/ui/mvi/handler/ClickHandlerTest.kt`
-   - `feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandlerTest.kt`
-   - `feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/mvi/handler/PagingHandlerTest.kt`
-
-   These set the project conventions.
-
-2. Place the new test under
+1. Place the new test under
    `feature/<name>/src/test/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<sub-package>/<HandlerName>Test.kt`,
    mirroring the production package. Use `internal class` visibility.
 
-3. Use these imports:
+2. Use these imports (drop the ones you do not need):
 
    ```kotlin
-   import org.junit.jupiter.api.Test
-   import org.junit.jupiter.api.Assertions.assertEquals
    import io.mockk.coEvery
    import io.mockk.coVerify
    import io.mockk.every
    import io.mockk.mockk
+   import io.mockk.slot
    import io.mockk.verify
    import kotlinx.coroutines.flow.MutableStateFlow
-   import kotlinx.coroutines.test.TestCoroutineScheduler
-   import kotlinx.coroutines.test.TestScope
-   import kotlinx.coroutines.test.UnconfinedTestDispatcher
-   import kotlinx.coroutines.test.runTest
-   import io.github.stslex.workeeper.core.core.coroutine.scope.AppCoroutineScope
+   import org.junit.jupiter.api.Assertions.assertEquals
+   import org.junit.jupiter.api.Assertions.assertTrue
+   import org.junit.jupiter.api.Test
    ```
 
    Always use `org.junit.jupiter.api.Test` (JUnit 5), never `org.junit.Test`.
 
-4. Build the test fixture:
+3. Build the test fixture. The current project pattern is intentionally minimal — no
+   `TestScope`, no `UnconfinedTestDispatcher`, no `AppCoroutineScope` plumbing. Mock the
+   `<Name>HandlerStore` directly and stub only what the handler actually reads:
 
-   - Construct any collaborators (interactor, mapper, repository) with
-     `mockk<X>(relaxed = true)`.
-   - Build a `TestCoroutineScheduler`, an `UnconfinedTestDispatcher(scheduler)`, and a
-     `TestScope(dispatcher)`.
-   - Build the initial `<Store>.State` and put it inside a `MutableStateFlow`.
-   - Construct a `mockk<<Name>HandlerStore>(relaxed = true)` and stub:
-     - `every { state } returns stateFlow`
-     - `every { scope } returns AppCoroutineScope(testScope, dispatcher, dispatcher)`
-     - For handlers that call `store.launch { ... }`, stub the `launch` overload to actually
-       execute the coroutine. Copy the `every { this@mockk.launch<Any>(...) } answers { ... }`
-       block from `feature/single-training/.../ClickHandlerTest.kt` lines 67-80.
+   ```kotlin
+   private val store = mockk<<Name>HandlerStore>(relaxed = true)
+   private val handler = <Name>ClickHandler(store)
+   ```
 
-5. Construct the handler under test with the mocked store and collaborators.
+   For a handler that mutates state via `updateState { it.copy(...) }`, wire the state
+   flow so the lambda runs:
 
-6. Write **one `@Test` method per `Action` subclass** the handler dispatches. The naming
-   convention used in the codebase: `<actionInWords>_<expectation>()`, for example
-   `clickSave_callsInteractor()` or `clickClose_emitsHapticAndPopsBack()`.
+   ```kotlin
+   private val initialState = State(/* ... */)
+   private val stateFlow = MutableStateFlow(initialState)
+   private val store = mockk<<Name>HandlerStore>(relaxed = true).apply {
+       every { state } returns stateFlow
+       every { updateState(any()) } answers {
+           val update = firstArg<(State) -> State>()
+           stateFlow.value = update(stateFlow.value)
+       }
+   }
+   ```
 
-7. Inside each test:
+   For collaborators (interactor, mapper, repository), use
+   `mockk<X>(relaxed = true)` and stub specific calls with `coEvery { ... } returns ...`
+   (suspend) or `every { ... } returns ...` (plain).
 
-   - Call the handler: `handler.invoke(Action.Click.Save)` (or use `@Test fun foo() = runTest { ... }` if you need to await suspending behavior).
-   - Assert state mutations with `assertEquals(expected, stateFlow.value)`.
-   - Assert events with `verify { store.sendEvent(eq(Event.Haptic)) }`.
-   - Assert collaborator calls with `coVerify { interactor.save(any()) }` (use `coVerify` for
-     suspend functions; `verify` for plain ones).
+4. Construct the handler under test with the mocked store and collaborators.
+
+5. Write **one `@Test` method per `Action` subclass** the handler dispatches. Naming
+   convention used in the codebase (backtick-quoted descriptions, mirroring
+   `SettingsClickHandlerTest`):
+
+   ```kotlin
+   @Test
+   fun `OnArchiveClick emits Haptic ContextClick then consumes OpenArchive`() { /* ... */ }
+   ```
+
+6. Inside each test:
+
+   - Call the handler: `handler.invoke(Action.Click.OnArchiveClick)`. If the handler is
+     suspending, wrap in `runTest { ... }`.
+   - Assert state mutations with `assertEquals(expected, stateFlow.value.<field>)`.
+   - Assert events with a `mutableListOf<Event>()` capture or `slot<Event>()`:
+     ```kotlin
+     val captured = mutableListOf<Event>()
+     verify(exactly = 1) { store.sendEvent(capture(captured)) }
+     assertHaptic(captured.single(), HapticFeedbackType.ContextClick)
+     ```
+     Or for a single emission:
+     ```kotlin
+     val captured = slot<Event>()
+     verify(exactly = 1) { store.sendEvent(capture(captured)) }
+     assertEquals(Event.ShowExternalLink(URL), captured.captured)
+     ```
+   - Assert dispatched actions with `verify { store.consume(eq(Action.Navigation.OpenArchive)) }`.
+   - Assert collaborator calls with `coVerify { interactor.save(any()) }` for suspend
+     functions, `verify` for plain ones.
    - Capture argument shapes with `slot<T>()` when the assertion needs the actual payload.
+   - Pull a small `assertHaptic(event, expected)` private helper (see
+     `SettingsClickHandlerTest.kt:56-59`) when many tests assert on `Event.Haptic` shape.
 
-8. Use `kotlinx.collections.immutable.persistentListOf()` / `persistentSetOf()` for collection
-   literals in the fixture — `State` requires immutable collections.
+7. Use `kotlinx.collections.immutable.persistentListOf()` / `persistentSetOf()` for
+   collection literals in the State fixture — `State` requires immutable collections.
+
+## NavigationHandler test template
+
+The full template, lifted directly from
+`feature/settings/.../SettingsNavigationHandlerTest.kt`:
+
+```kotlin
+package io.github.stslex.workeeper.feature.<name_snake>.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.<name_snake>.mvi.store.<Name>Store.Action
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+internal class NavigationHandlerTest {
+
+    private val navigator = mockk<Navigator>(relaxed = true)
+    private val handler = NavigationHandler(navigator)
+
+    @Test
+    fun `Back triggers popBack`() {
+        handler.invoke(Action.Navigation.Back)
+        verify(exactly = 1) { navigator.popBack() }
+    }
+
+    @Test
+    fun `OpenArchive navigates to Screen Archive`() {
+        handler.invoke(Action.Navigation.OpenArchive)
+        verify(exactly = 1) { navigator.navTo(Screen.Archive) }
+    }
+}
+```
+
+Notes:
+
+- `NavigationHandler` is constructed directly with the mocked `Navigator` — no Hilt graph,
+  no store, no `HandlerStore` mock. The class skips `@Inject` because
+  `MviHandlerConstructorRule` exempts the literal name `NavigationHandler` (see
+  `lint-rules/.../MviHandlerConstructorRule.kt:74`); test instantiation uses the same
+  plain constructor.
+- One `@Test` per `Action.Navigation.<X>` subclass. Each verifies exactly one
+  `navigator.navTo(Screen.<X>)` or `navigator.popBack()` call, with `exactly = 1`.
+- For variants like `SettingsNavigationHandler` that nest under a `*Component` for
+  feature-specific reasons, instantiate with the same plain constructor — the test does
+  not need to know about the `Component` superclass.
 
 ## Verification
 
@@ -100,13 +194,19 @@ Run the full module test task. Targeting a single class also works:
 ## Common pitfalls
 
 - **One action per test.** Do not pack multiple `handler.invoke(...)` calls with different
-  `Action` subtypes into one `@Test`. The reference tests have one assertion thread per case;
-  match that.
-- **Do not mock the `Store` itself.** Mock the `<Name>HandlerStore` (the handler's collaborator).
-  The store is the system under test for `*StoreImpl` tests, never a mock there.
-- **Do not import `org.junit.Test`.** This codebase is on JUnit 5. The Robolectric extension
-  plugin (`robolectric-junit5`) is wired for JVM tests that need Android stubs.
-- **Do not use real dispatchers.** Use `UnconfinedTestDispatcher` and `TestScope`. Real
-  dispatchers will cause flaky waits.
+  `Action` subtypes into one `@Test`. The `feature/settings/` tests have one assertion
+  thread per case; match that.
+- **Do not mock the `Store` itself.** Mock the `<Name>HandlerStore` (the handler's
+  collaborator). The store is the system under test for `*StoreImpl` tests, never a mock
+  there.
+- **Do not import `org.junit.Test`.** This codebase is on JUnit 5. The Robolectric
+  extension plugin (`robolectric-junit5`) is wired for JVM tests that need Android stubs.
+- **Do not stand up `TestScope` / `UnconfinedTestDispatcher` / `AppCoroutineScope`
+  unless the handler under test actually launches coroutines through `store.launch { ... }`.**
+  The current `feature/settings/` tests demonstrate that mocking the `HandlerStore` with
+  `relaxed = true` and stubbing only `state` + `updateState` covers most handler shapes.
+  Reach for the test scheduler stack only when a handler uses `launch { }` or `flow {}`.
 - **Do not assert on private fields.** Drive tests through public `Action` invocations and
-  observe the public `state`/`event` surface.
+  observe the public `state`/`event`/`consume` surface on the mocked HandlerStore.
+- **Do not copy the older 10-line `placeholder() = Unit` stubs.** They mark handlers
+  awaiting a real test pass; the patterns above are what to write in their place.

--- a/.claude/skills/write-ui-test.md
+++ b/.claude/skills/write-ui-test.md
@@ -1,6 +1,6 @@
 ---
 name: write-ui-test
-description: Write a `@Smoke` Compose UI test that drives a feature widget with mocked state, asserts on `testTag`s, and verifies dispatched MVI actions through `ActionCapture`.
+description: Add a `@Smoke` Compose UI test for a feature screen — either a stub with a `TODO(feature-rewrite-tests)` marker (the current default during the v1 rewrite) or a full-fidelity test that drives a widget with mocked state, asserts on `testTag`s, and verifies dispatched MVI actions through `ActionCapture`.
 ---
 
 # Write a UI test
@@ -11,11 +11,29 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
 - "Cover the `<Feature>` widget with Compose tests"
 - "Write a smoke test for X"
 - "Add an accessibility / edge-case test for screen Y"
+- "Stub a `@Smoke` test for the new feature"
+
+## Current state of UI tests in the repo
+
+Every feature module currently has a placeholder `@Smoke` UI test class with no body —
+just `BaseComposeTest` + `createComposeRule()` + a `TODO(feature-rewrite-tests)` (or
+`TODO(feature-rewrite)`) comment. The Stage 3 cleanup left these in place so the modules
+still compile and the `@Smoke` annotation surface is wired, but real assertions are
+deferred until each feature stabilizes during the v1 rewrite. Examples:
+
+- `feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt`
+- `feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt`
+- `feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt`
+- All five `feature/*/src/androidTest/.../*ScreenTest.kt` follow the same shape.
+
+Default: when scaffolding a brand-new feature, ship the **stub** form (see
+[Stub form](#stub-form-default-for-new-features) below). When the feature stabilizes and
+you want real coverage, expand the stub into the [Full form](#full-form-when-the-feature-is-stable).
 
 ## Prerequisites
 
 - The feature module's `build.gradle.kts` already has the test dependencies (mirror
-  `feature/charts/build.gradle.kts`):
+  `feature/settings/build.gradle.kts`):
 
   ```kotlin
   androidTestImplementation(libs.bundles.android.test)
@@ -24,44 +42,80 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
   debugImplementation(libs.androidx.compose.ui.test.manifest)
   ```
 
-- The screen / widget under test exposes its interactive elements via `Modifier.testTag(...)`.
-- `documentation/testing.md` is available for the broader strategy.
+- For full-form tests, the screen / widget under test exposes its interactive elements via
+  `Modifier.testTag(...)`.
+- [documentation/testing.md](../../documentation/testing.md) has the broader strategy.
 
-## Step-by-step
+## Stub form (default for new features)
 
-1. Default to `@Smoke`. Reach for `@Regression` only when the test must drive the real Hilt
-   graph and database via `@HiltAndroidTest` + `createAndroidComposeRule<MainActivity>()`.
-   See [documentation/testing.md](../../documentation/testing.md) for the choice criteria.
+Place the new test under
+`feature/<name>/src/androidTest/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<Name>ScreenTest.kt`.
+Mirror the production package. Lifted directly from
+`feature/settings/.../SettingsScreenTest.kt`:
 
-2. Use these reference tests to copy the structure:
+```kotlin
+package io.github.stslex.workeeper.feature.<name_snake>
 
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt`
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenEdgeCasesTest.kt`
-   - `feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenAccessibilityTest.kt`
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
+import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Rule
+import org.junit.runner.RunWith
 
-3. Place the new test under
-   `feature/<name>/src/androidTest/kotlin/io/github/stslex/workeeper/feature/<name_snake>/<NameOfTest>.kt`.
-   Mirror the production package.
+@Smoke
+@RunWith(AndroidJUnit4::class)
+class <Name>ScreenTest : BaseComposeTest() {
 
-4. Skeleton:
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // TODO(feature-rewrite-tests): exercise <name> after Stage <X> stabilises.
+}
+```
+
+Notes on the stub:
+
+- The class still extends `BaseComposeTest` and declares `createComposeRule()` so the test
+  surface is wired and the module compiles cleanly with the `@Smoke` annotation
+  filterable from CI.
+- The `TODO(...)` text records what to add and when. Two markers exist in the codebase —
+  `TODO(feature-rewrite-tests)` (newer, used by `feature/settings/`) and
+  `TODO(feature-rewrite)` (older, used by `feature/all-trainings/` etc.). Either is fine;
+  the new convention is `TODO(feature-rewrite-tests)`.
+- No `@Test` methods are required for the stub. The class compiles and is picked up by the
+  `@Smoke` filter as a no-op.
+
+## Full form (when the feature is stable)
+
+When the feature is no longer in active rewrite, expand the stub into a fully-asserting
+smoke test. There are no current full-form examples in the repo (all real tests are in the
+handler-test layer), so the template below is derived from `BaseComposeTest` and the
+test-utils helpers in `core/ui/test-utils/`.
+
+1. Default to `@Smoke`. Reach for `@Regression` only when the test must drive the real
+   Hilt graph and database via `@HiltAndroidTest` + `createAndroidComposeRule<MainActivity>()`.
+   See [documentation/testing.md → Choosing a category](../../documentation/testing.md#choosing-a-category).
+
+2. Use this skeleton for a screen that participates in shared element transitions:
 
    ```kotlin
    @Smoke
    @RunWith(AndroidJUnit4::class)
    @SuppressLint("UnusedContentLambdaTargetStateParameter")
-   internal class <Feature>ScreenTest : BaseComposeTest() {
+   internal class <Name>ScreenTest : BaseComposeTest() {
 
        @get:Rule
        val composeRule = createComposeRule()
 
        @Test
        fun <feature>_<scenario>_<expectation>() {
-           val state = <Feature>Store.State.INITIAL.copy(/* ... */)
-           val actionCapture = createActionCapture<<Feature>Store.Action>()
+           val state = <Name>Store.State.INITIAL.copy(/* ... */)
+           val actionCapture = createActionCapture<<Name>Store.Action>()
 
            composeRule.mainClock.autoAdvance = false
            composeRule.setTransitionContent { animatedContentScope, modifier ->
-               <Feature>Widget(
+               <Name>Widget(
                    state = state,
                    modifier = modifier,
                    consume = actionCapture,
@@ -73,28 +127,34 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
            composeRule.mainClock.advanceTimeBy(100)
            composeRule.waitForIdle()
 
-           composeRule.onNodeWithTag("<Feature>Button").performClick()
+           composeRule.onNodeWithTag("<Name>Button").performClick()
 
-           actionCapture.capturedFirst<<Feature>Store.Action.Click.<...>>()
+           actionCapture.capturedFirst<<Name>Store.Action.Click.<...>>()
        }
    }
    ```
 
-   Key methods come from `core/ui/test-utils/.../BaseComposeTest.kt`:
+   For screens without shared element transitions (e.g. Settings / Archive), drop the
+   `setTransitionContent` wrapper and call `composeRule.setContent { ... }` with the
+   screen composable directly.
+
+3. Helpers from `core/ui/test-utils/.../BaseComposeTest.kt`:
 
    - `setTransitionContent { animatedContentScope, modifier -> ... }` wraps the widget in
      `SharedTransitionScope` + `AnimatedContent`, so widgets expecting
-     `sharedTransitionScope` and `animatedContentScope` parameters work without standing up
-     `AppNavigationHost`.
-   - `createActionCapture<Action>()` returns an `ActionCapture<Action>` you can pass directly as
-     the `consume` callback. Inspection helpers: `assertCaptured<A>()`, `capturedFirst<A>()`,
-     `capturedLast<A>()`, `assertCapturedExactly(action)`, `assertCapturedCount<A>(n)`,
+     `sharedTransitionScope` and `animatedContentScope` parameters work without standing
+     up `AppNavigationHost`.
+   - `createActionCapture<Action>()` returns an `ActionCapture<Action>` you can pass
+     directly as the `consume` callback. Inspection helpers:
+     `assertCaptured<A>()`, `captured<A>()`, `capturedFirst<A>()`, `capturedLast<A>()`,
+     `assertCapturedExactly(action)`, `assertCapturedCount<A>(n)`,
      `assertCapturedOnce<A>()`, `clear()`, `getAll()`.
 
-5. Use the test-utils helpers for data and inputs:
+4. Helpers for data and inputs:
 
-   - **Paging** state: `PagingTestUtils.createPagingFlow(items)` or
-     `PagingTestUtils.createEmptyPagingFlow()`. For error scenarios use
+   - **Paging** state: `PagingTestUtils.createPagingFlow(items)` /
+     `PagingTestUtils.createEmptyPagingFlow()` /
+     `PagingTestUtils.createErrorPagingFlow()`. For richer error scenarios:
      `PagingTestUtils.TestPagingSource(items, shouldFail = true, errorMessage = "...")`.
    - **Mock data**: `MockDataFactory.createUuids(count)`,
      `MockDataFactory.createTestNames(prefix, count)`,
@@ -102,7 +162,7 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
    - **Text input**: `composeRule.onNodeWithTag("...").performTextReplacement("new value")`
      (clears + types in one call).
 
-6. Test-tag conventions (must match what the production widget sets):
+5. Test-tag conventions (must match what the production widget sets):
 
    - Screen-level: `"<Feature>Screen"`.
    - Widget root: `"<Feature>Widget"`.
@@ -110,14 +170,16 @@ description: Write a `@Smoke` Compose UI test that drives a feature widget with 
    - List: `"<Feature>List"`. List item: `"<Feature>Item_${item.uuid}"`.
    - Dialog: `"<Feature>Dialog"`.
 
-   If the production widget is missing a needed tag, add it via `Modifier.testTag(...)` —
-   do not work around with positional finders.
+   If the production widget is missing a needed tag, add it via `Modifier.testTag(...)`
+   — do not work around with positional finders.
 
-7. Cover the obvious cases first (basic render, primary click, primary input). Extend with edge
-   cases (empty state, very long text, special characters, large lists, rapid clicks) and
-   accessibility checks (`assertHasClickAction()`, focus / semantics) in separate test classes
-   when there are enough of them, mirroring the all-exercises split into
-   `<...>ScreenTest`, `<...>ScreenEdgeCasesTest`, `<...>ScreenAccessibilityTest`.
+6. Cover the obvious cases first (basic render, primary click, primary input). Extend with
+   edge cases (empty state, very long text, special characters, large lists, rapid clicks)
+   and accessibility checks (`assertHasClickAction()`, focus / semantics) in separate test
+   classes when there are enough of them, mirroring the all-exercises naming split into
+   `<Name>ScreenTest`, `<Name>ScreenEdgeCasesTest`, `<Name>ScreenAccessibilityTest`. Note
+   that those split files currently also exist as 18-line stubs — the naming pattern is
+   what to mirror, not the bodies.
 
 ## Verification
 
@@ -131,14 +193,16 @@ Reports land at `feature/<name>/build/reports/androidTests/connected/index.html`
 
 ## Common pitfalls
 
-- **Never combine `@Smoke` with `@HiltAndroidTest`.** Smoke tests do not stand up a real DI
-  graph. Use `createComposeRule()`, not `createAndroidComposeRule<MainActivity>()`.
-- **Do not use real repositories or the database.** All collaborators are mocked or fed via
-  `State`. Real DI belongs in `@Regression` tests only.
+- **Never combine `@Smoke` with `@HiltAndroidTest`.** Smoke tests do not stand up a real
+  DI graph. Use `createComposeRule()`, not `createAndroidComposeRule<MainActivity>()`.
+- **Do not use real repositories or the database.** All collaborators are mocked or fed
+  via `State`. Real DI belongs in `@Regression` tests only.
+- **Do not delete an existing stub when scaffolding a new feature** — the stub is the
+  intended scaffold. Replace it with the full form when the feature stabilizes.
 - **Do not skip `composeRule.mainClock.advanceTimeBy(100)` + `waitForIdle()`** after
-  `setTransitionContent`. The shared-transition wrapper schedules animations, and the assertion
-  may run before composition settles.
-- **Do not assert on positional `onChildAt(...)` finders.** Use `testTag` / `onNodeWithText`
-  finders so the test does not break when layout changes.
-- **Do not use `org.junit.jupiter.api.Test`** in instrumented tests. UI tests use AndroidX's
-  JUnit 4 runner: `org.junit.Test`, `@RunWith(AndroidJUnit4::class)`.
+  `setTransitionContent`. The shared-transition wrapper schedules animations, and the
+  assertion may run before composition settles.
+- **Do not assert on positional `onChildAt(...)` finders.** Use `testTag` /
+  `onNodeWithText` finders so the test does not break when layout changes.
+- **Do not use `org.junit.jupiter.api.Test`** in instrumented tests. UI tests use
+  AndroidX's JUnit 4 runner: `org.junit.Test`, `@RunWith(AndroidJUnit4::class)`.


### PR DESCRIPTION
## Summary

Refresh the five `.claude/skills/` files so they reflect the current state of the codebase after the v3 → v4 schema work, the v1 design system landing, and the Stage 5.1 Settings/Archive feature. The previously-shipped skills were authored against db v2, the older `core/ui/kit` shape, and a navigation flow that has since been replaced by the canonical `Action.Navigation` + `NavigationHandler` pattern.

This PR is **docs only** — no Kotlin code is touched, and there is no compilation risk.

## What changed per file

### `add-database-migration.md`
- Reframed around the **current destructive-migration policy** (`fallbackToDestructiveMigrationFrom(dropAllTables = true, 2, 3)` in `CoreDatabaseModule.kt:36`), which the previous skill explicitly forbade.
- Removed stale references to `Migration12.kt`, `SetsTypeConverter`, `StringConverter`, the `core/database/.../migrations/` folder (no longer exists on disk), and the `addMigrations(MIGRATION_1_2, ...)` chain.
- Updated schema location to `core/database/schemas/.../AppDatabase/{1,2,3,4}.json` and the live `AppDatabase` version (4).
- Added a "When to switch back to non-destructive migrations" section that captures the future playbook (`Migration<X><Y>` class, `MigrationTestHelper` instrumented test) for the moment after the first Play Store release.
- Cross-references `documentation/db-redesign.md` and `documentation/architecture.md`.

### `add-feature.md`
- Added an explicit **Canonical navigation pattern** section showing the full shape — `Action.Navigation.<X>` enum, `NavigationHandler(navigator: Navigator)` (no `@Inject`, exempted by `MviHandlerConstructorRule:74`), `<Name>Component.create(navigator)` factory, store `handlerCreator` casting `component as NavigationHandler`, and the graph composable consuming **only** UI-side events (`Haptic`, `ShowExternalLink`, `Snackbar*`, `Scroll*`).
- Reinforces that `Event.Navigate*` is forbidden by convention even though `MviEventNamingRule` accepts the pattern. References `feature/all-trainings/.../mvi/handler/NavigationHandler.kt` and `feature/all-trainings/.../ui/AllTrainingsGraph.kt` as the literal canonical implementation.
- Added a **Design system contract** section: `AppUi.colors` / `AppUi.typography` / `AppUi.shapes` / `AppUi.motion` / `AppUi.elevation` token accessors, the 20-row component table (file paths under `core/ui/kit/components/`), and an explicit ban on hardcoded `Color()` / `sp` / `dp` outside `core/ui/kit/theme/`.
- Updated module-layout step to mirror the post-Stage-5.1 `feature/settings/` shape (`<Name>Feature.kt` instead of legacy `<Name>Processor.kt`; `<Name>Graph.kt` extension).
- Cross-references `documentation/architecture.md`, `documentation/design-system.md`, `documentation/lint-rules.md`, and `documentation/feature-specs/settings-archive.md`.

### `refactor-with-mvi-rules.md`
- Verified Action top-level categories — `Click`, `Input`, `Navigation`, optionally `Paging`, `Common` — match what is in `feature/all-trainings/.../mvi/store/TrainingStore.kt` and `feature/settings/.../mvi/store/SettingsStore.kt`.
- Added an explicit project convention layered on top of `MviEventNamingRule`: `Navigate*` events are forbidden even though the rule's pattern would accept the token. Includes a four-step playbook for converting a `Navigate*` event into an `Action.Navigation.<X>` consumed by `NavigationHandler`.
- Clarified the `MviHandlerConstructorRule` exemption: the rule explicitly skips the literal class name `NavigationHandler` (`lint-rules/.../MviHandlerConstructorRule.kt:74`), so the bare-constructor form is conformant. Variants like `SettingsNavigationHandler` still need `@Suppress(...)`; prefer the bare name for new code.

### `write-handler-test.md`
- Replaced the stale reference list. The previously-cited tests in `feature/single-training`, `feature/exercise`, and `feature/all-exercises` are now 10-line `placeholder() = Unit` stubs; the canonical real tests are in `feature/settings/src/test/.../mvi/handler/` (`SettingsClickHandlerTest`, `SettingsInputHandlerTest`, `SettingsNavigationHandlerTest`, `ArchiveClickHandlerTest`).
- Replaced the heavyweight `TestCoroutineScheduler` + `UnconfinedTestDispatcher` + `TestScope` + `AppCoroutineScope` fixture with the simpler current pattern (mock `<Name>HandlerStore(relaxed = true)`, `every { state } returns stateFlow`, `every { updateState(any()) } answers { ... }`). Reach for the test scheduler stack only when a handler launches coroutines through `store.launch { ... }`.
- Added a **NavigationHandler test template** — verbatim from `SettingsNavigationHandlerTest.kt` — that mocks `Navigator` and asserts `navigator.navTo(Screen.<X>)` / `navigator.popBack()` per `Action.Navigation` subclass.

### `write-ui-test.md`
- Made the **stub form** the documented default for new features. Every existing `feature/*/src/androidTest/.../*ScreenTest.kt` is currently an 18-line `BaseComposeTest` + `createComposeRule()` + `TODO(feature-rewrite-tests)` stub; the skill now describes that pattern explicitly with the two existing TODO marker variants (`feature-rewrite-tests` is the new convention used by `feature/settings/`, `feature-rewrite` is the older variant in the other features).
- Kept the **full form** template for when a feature stabilizes. Updated reference paths and removed claims that all-exercises has fully-asserting smoke tests (it currently has stubs).

## Contradictions surfaced (flagged, not auto-resolved)

These came up during verification and need a human decision separate from this PR:

1. **`documentation/architecture.md` references deleted `core/ui/kit` types.** Lines 31-32 list `AppSnackBar` (capital B), `BasePagingColumnItem`, and `TextInputField` as kit components — none of those classes exist on disk anymore. The current names are `AppSnackbar` (lowercase b, file `core/ui/kit/components/snackbar/AppSnackbar.kt`), no `BasePagingColumnItem` (only the `PagingUiState.kt` state holder), and `TextInputField` is gone (only the `text_input_field/model/{MenuItem.kt,PropertyHolder.kt}` data classes survive). I did not edit `architecture.md` in this PR — flag for follow-up.
2. **`documentation/architecture.md → Data layer` is still describing v2.** Lines 290-297 say "current schema version is 2; schemas for both versions are exported … 1→2 migration lives in `Migration12.kt`". That whole block is outdated by `db-redesign.md` (v3) plus the Stage 5.1 v3→v4 column add. The skills now point readers at `db-redesign.md` for the current state, but the architecture.md paragraph itself should be rewritten in a follow-up.
3. **Architecture says NavigationHandler "constructs from the feature's `*Component`"; some recent NavigationHandlers carry `@Suppress("MviHandlerConstructorRule")`.** The lint rule explicitly exempts the literal name `NavigationHandler`, so the bare-named handler in `feature/all-trainings` does not need the suppression — but `SettingsNavigationHandler` does. The skills now document this; whether to rename the settings variants to bare `NavigationHandler` is a separate cleanup decision.

## Out-of-scope follow-ups

- Update `documentation/architecture.md` "Data layer" section to v3/v4 + the new entity catalog (9 entities, no `TrainingLabelEntity`, no `SetsEntity` blob).
- Update `documentation/architecture.md` "core/ui/kit" line 31-32 listing to the actual current component set.
- Decide whether to rename `SettingsNavigationHandler` → `NavigationHandler` (drops the `@Suppress`).

## Test plan

- [x] Verified every file path cited in the updated skills exists on disk via a path-existence sweep (52 paths, all present).
- [x] Verified every documentation anchor (`#navigation-flow-canonical-pattern`, `#custom-detekt-mvi-rules`, `#baselines`, `#choosing-a-category`, `#migration-strategy`) resolves to a real heading.
- [x] Swept the skills for forbidden references (`StringConverter`, `SetsTypeConverter`, `TrainingLabelEntity`, `BaseAppDialog`, `AppActionButton`, `AppSnackBar` capital-B, `TextInputField`, `SearchPagingWidget`, `Migration12`, `Event.Navigate`) — all remaining hits are negative-context citations ("was deleted", "do not model navigation as Event.Navigate*").
- [ ] No code change → no `./gradlew` runs needed.