### PR TITLE
feat(home): full Home dashboard + Past session detail (Stage 5.5)

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":feature:settings"))
     implementation(project(":feature:home"))
     implementation(project(":feature:live-workout"))
+    implementation(project(":feature:past-session"))
 
     implementation(platform(libs.google.firebase.bom))
     implementation(libs.google.firebase.analytics)

--- a/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
@@ -20,6 +20,7 @@ import io.github.stslex.workeeper.feature.charts.ui.chartsGraph
 import io.github.stslex.workeeper.feature.exercise.ui.exerciseGraph
 import io.github.stslex.workeeper.feature.home.ui.homeGraph
 import io.github.stslex.workeeper.feature.live_workout.ui.liveWorkoutGraph
+import io.github.stslex.workeeper.feature.past_session.ui.pastSessionGraph
 import io.github.stslex.workeeper.feature.settings.ui.archiveGraph
 import io.github.stslex.workeeper.feature.settings.ui.settingsGraph
 import io.github.stslex.workeeper.feature.single_training.ui.singleTrainingsGraph
@@ -74,6 +75,9 @@ internal fun AppNavigationHost(
             )
             liveWorkoutGraph(
                 modifier = Modifier.testTag("LiveWorkoutGraph"),
+            )
+            pastSessionGraph(
+                modifier = Modifier.testTag("PastSessionGraph"),
             )
             settingsGraph(
                 modifier = Modifier.testTag("SettingsGraph"),

--- a/app/app/src/main/java/io/github/stslex/workeeper/navigation/NavigatorImpl.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/navigation/NavigatorImpl.kt
@@ -39,6 +39,22 @@ class NavigatorImpl @Inject constructor(
         navController.popBackStack()
     }
 
+    override fun replaceTo(screen: Screen) {
+        logger.d("replaceTo $screen")
+        try {
+            val currentRoute = holder.navigator.currentDestination?.route ?: return
+            navController.navigate(screen) {
+                popUpTo(currentRoute) {
+                    inclusive = true
+                    saveState = false
+                }
+                launchSingleTop = true
+            }
+        } catch (ignore: Exception) {
+            logger.e(ignore, "screen: $screen")
+        }
+    }
+
     companion object {
 
         private const val TAG = "NAVIGATION"

--- a/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
@@ -30,5 +30,6 @@ class RootComponentImpl(
         is Screen.LiveWorkout -> LiveWorkoutComponent.create(navigator, screen)
         Screen.Settings -> SettingsComponent.create(navigator)
         Screen.Archive -> ArchiveComponent.create(navigator)
+        is Screen.PastSession -> TODO("Wired in P6 once feature/past-session module exists")
     }
 }

--- a/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
@@ -10,6 +10,7 @@ import io.github.stslex.workeeper.feature.charts.mvi.handler.ChartsComponent
 import io.github.stslex.workeeper.feature.exercise.mvi.handler.ExerciseComponent
 import io.github.stslex.workeeper.feature.home.mvi.handler.HomeComponent
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.LiveWorkoutComponent
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.PastSessionComponent
 import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveComponent
 import io.github.stslex.workeeper.feature.settings.mvi.handler.SettingsComponent
 import io.github.stslex.workeeper.feature.single_training.mvi.handler.SingleTrainingComponent
@@ -30,6 +31,6 @@ class RootComponentImpl(
         is Screen.LiveWorkout -> LiveWorkoutComponent.create(navigator, screen)
         Screen.Settings -> SettingsComponent.create(navigator)
         Screen.Archive -> ArchiveComponent.create(navigator)
-        is Screen.PastSession -> TODO("Wired in P6 once feature/past-session module exists")
+        is Screen.PastSession -> PastSessionComponent.create(navigator, screen)
     }
 }

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/time/RelativeTimeFormat.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/time/RelativeTimeFormat.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.time
+
+import android.text.format.DateUtils
+
+/**
+ * Formats [eventMillis] as a localized relative-time string ("just now", "5 min ago",
+ * "2 days ago", or an absolute date once the gap exceeds the week boundary). Uses
+ * Android's [DateUtils] so the output respects the system locale automatically.
+ */
+fun formatRelativeTime(nowMillis: Long, eventMillis: Long): String =
+    DateUtils.getRelativeTimeSpanString(
+        eventMillis,
+        nowMillis,
+        DateUtils.MINUTE_IN_MILLIS,
+        DateUtils.FORMAT_ABBREV_RELATIVE,
+    ).toString()

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/RecentSessionRow.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/RecentSessionRow.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.database.session
+
+import androidx.room.ColumnInfo
+import kotlin.uuid.Uuid
+
+/**
+ * Projection for the Home recent-sessions list. Joins finished sessions with their training
+ * row plus aggregated counts of performed exercises and logged sets so each row renders
+ * without an extra round trip per session.
+ */
+data class RecentSessionRow(
+    @ColumnInfo(name = "session_uuid") val sessionUuid: Uuid,
+    @ColumnInfo(name = "training_uuid") val trainingUuid: Uuid,
+    @ColumnInfo(name = "training_name") val trainingName: String,
+    @ColumnInfo(name = "is_adhoc") val isAdhoc: Boolean,
+    @ColumnInfo(name = "started_at") val startedAt: Long,
+    @ColumnInfo(name = "finished_at") val finishedAt: Long,
+    @ColumnInfo(name = "exercise_count") val exerciseCount: Int,
+    @ColumnInfo(name = "set_count") val setCount: Int,
+)

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/SessionDao.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/session/SessionDao.kt
@@ -59,6 +59,28 @@ interface SessionDao {
 
     @Query(
         """
+        SELECT s.uuid AS session_uuid,
+               s.training_uuid AS training_uuid,
+               t.name AS training_name,
+               t.is_adhoc AS is_adhoc,
+               s.started_at AS started_at,
+               s.finished_at AS finished_at,
+               (SELECT COUNT(*) FROM performed_exercise_table pe
+                  WHERE pe.session_uuid = s.uuid AND pe.skipped = 0) AS exercise_count,
+               (SELECT COUNT(*) FROM set_table st
+                  JOIN performed_exercise_table pe2 ON pe2.uuid = st.performed_exercise_uuid
+                  WHERE pe2.session_uuid = s.uuid) AS set_count
+        FROM session_table s
+        INNER JOIN training_table t ON t.uuid = s.training_uuid
+        WHERE s.state = 'FINISHED' AND s.finished_at IS NOT NULL
+        ORDER BY s.finished_at DESC
+        LIMIT :limit
+        """,
+    )
+    fun observeRecentWithStats(limit: Int): Flow<List<RecentSessionRow>>
+
+    @Query(
+        """
         SELECT * FROM session_table
         WHERE state = 'FINISHED'
         ORDER BY finished_at DESC

--- a/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingDao.kt
+++ b/core/database/src/main/kotlin/io/github/stslex/workeeper/core/database/training/TrainingDao.kt
@@ -70,6 +70,24 @@ interface TrainingDao {
     )
     fun pagedActiveWithStatsByTags(tagUuids: List<Uuid>): PagingSource<Int, TrainingListItemRow>
 
+    @Query(
+        """
+        SELECT t.uuid, t.name, t.description, t.is_adhoc, t.archived, t.created_at, t.archived_at,
+               (SELECT COUNT(*) FROM training_exercise_table WHERE training_uuid = t.uuid) AS exercise_count,
+               (SELECT MAX(s.finished_at) FROM session_table s
+                  WHERE s.training_uuid = t.uuid AND s.state = 'FINISHED') AS last_session_at,
+               (SELECT s.uuid FROM session_table s
+                  WHERE s.training_uuid = t.uuid AND s.state = 'IN_PROGRESS' LIMIT 1) AS active_session_uuid,
+               (SELECT s.started_at FROM session_table s
+                  WHERE s.training_uuid = t.uuid AND s.state = 'IN_PROGRESS' LIMIT 1) AS active_session_started_at
+        FROM training_table t
+        WHERE t.archived = 0 AND t.is_adhoc = 0
+        ORDER BY (last_session_at IS NULL), last_session_at DESC, t.name COLLATE NOCASE ASC
+        LIMIT :limit
+        """,
+    )
+    fun observeRecentTemplates(limit: Int): Flow<List<TrainingListItemRow>>
+
     @Query("SELECT * FROM training_table WHERE archived = 1 ORDER BY name COLLATE NOCASE ASC")
     fun pagedArchived(): PagingSource<Int, TrainingEntity>
 

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/SessionRepository.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/SessionRepository.kt
@@ -2,7 +2,9 @@ package io.github.stslex.workeeper.core.exercise.session
 
 import androidx.paging.PagingData
 import io.github.stslex.workeeper.core.exercise.session.model.ActiveSessionInfo
+import io.github.stslex.workeeper.core.exercise.session.model.RecentSessionDataModel
 import io.github.stslex.workeeper.core.exercise.session.model.SessionDataModel
+import io.github.stslex.workeeper.core.exercise.session.model.SessionDetailDataModel
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("TooManyFunctions")
@@ -30,6 +32,19 @@ interface SessionRepository {
     suspend fun getActive(): SessionDataModel?
 
     fun observeRecent(limit: Int): Flow<List<SessionDataModel>>
+
+    /**
+     * Hot stream of the most recent finished sessions (newest first), with the per-row
+     * stats the Home recent list needs (training name, exercise count, set count).
+     */
+    fun observeRecentWithStats(limit: Int): Flow<List<RecentSessionDataModel>>
+
+    /**
+     * One-shot hierarchical fetch for the Past session detail screen. Returns the session
+     * row plus all performed exercises and their sets. Returns `null` when the session
+     * does not exist (e.g. it was deleted between navigation and load).
+     */
+    suspend fun getSessionDetail(sessionUuid: String): SessionDetailDataModel?
 
     fun pagedFinished(): Flow<PagingData<SessionDataModel>>
 

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/SessionRepositoryImpl.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/SessionRepositoryImpl.kt
@@ -5,12 +5,22 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.database.exercise.ExerciseDao
+import io.github.stslex.workeeper.core.database.session.PerformedExerciseDao
 import io.github.stslex.workeeper.core.database.session.PerformedExerciseEntity
 import io.github.stslex.workeeper.core.database.session.SessionDao
 import io.github.stslex.workeeper.core.database.session.SessionEntity
 import io.github.stslex.workeeper.core.database.session.SessionStateEntity
+import io.github.stslex.workeeper.core.database.session.SetDao
+import io.github.stslex.workeeper.core.database.training.TrainingDao
+import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel
+import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel.Companion.toData
+import io.github.stslex.workeeper.core.exercise.exercise.model.toData
 import io.github.stslex.workeeper.core.exercise.session.model.ActiveSessionInfo
+import io.github.stslex.workeeper.core.exercise.session.model.PerformedExerciseDetailDataModel
+import io.github.stslex.workeeper.core.exercise.session.model.RecentSessionDataModel
 import io.github.stslex.workeeper.core.exercise.session.model.SessionDataModel
+import io.github.stslex.workeeper.core.exercise.session.model.SessionDetailDataModel
 import io.github.stslex.workeeper.core.exercise.session.model.toData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -21,10 +31,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.uuid.Uuid
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @Singleton
 internal class SessionRepositoryImpl @Inject constructor(
     private val dao: SessionDao,
+    private val performedExerciseDao: PerformedExerciseDao,
+    private val setDao: SetDao,
+    private val trainingDao: TrainingDao,
+    private val exerciseDao: ExerciseDao,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : SessionRepository {
 
@@ -81,6 +95,53 @@ internal class SessionRepositoryImpl @Inject constructor(
         .observeRecent(limit)
         .map { list -> list.map { it.toData() } }
         .flowOn(ioDispatcher)
+
+    override fun observeRecentWithStats(
+        limit: Int,
+    ): Flow<List<RecentSessionDataModel>> = dao
+        .observeRecentWithStats(limit)
+        .map { rows -> rows.map { it.toData() } }
+        .flowOn(ioDispatcher)
+
+    override suspend fun getSessionDetail(
+        sessionUuid: String,
+    ): SessionDetailDataModel? = withContext(ioDispatcher) {
+        val sessionId = Uuid.parse(sessionUuid)
+        val session = dao.getById(sessionId) ?: return@withContext null
+        val finishedAt = session.finishedAt ?: return@withContext null
+        val training = trainingDao.getById(session.trainingUuid) ?: return@withContext null
+        val performed = performedExerciseDao
+            .getBySession(sessionId)
+            .sortedBy { it.position }
+        val exerciseUuids = performed.map { it.exerciseUuid }.distinct()
+        val exerciseByUuid = exerciseDao
+            .getByUuids(exerciseUuids)
+            .associateBy { it.uuid }
+        val exercises = performed.map { row ->
+            PerformedExerciseDetailDataModel(
+                performedExerciseUuid = row.uuid.toString(),
+                exerciseUuid = row.exerciseUuid.toString(),
+                exerciseName = exerciseByUuid[row.exerciseUuid]?.name.orEmpty(),
+                exerciseType = exerciseByUuid[row.exerciseUuid]?.type?.toData()
+                    ?: ExerciseTypeDataModel.WEIGHTED,
+                position = row.position,
+                skipped = row.skipped,
+                sets = setDao
+                    .getByPerformedExercise(row.uuid)
+                    .sortedBy { it.position }
+                    .map { it.toData() },
+            )
+        }
+        SessionDetailDataModel(
+            sessionUuid = session.uuid.toString(),
+            trainingUuid = session.trainingUuid.toString(),
+            trainingName = training.name,
+            isAdhoc = training.isAdhoc,
+            startedAt = session.startedAt,
+            finishedAt = finishedAt,
+            exercises = exercises,
+        )
+    }
 
     override fun pagedFinished(): Flow<PagingData<SessionDataModel>> = Pager(
         config = pagingConfig,

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/model/RecentSessionDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/model/RecentSessionDataModel.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.exercise.session.model
+
+import io.github.stslex.workeeper.core.database.session.RecentSessionRow
+
+/**
+ * Domain model for the Home recent-sessions list. Mirrors [RecentSessionRow] but exposes
+ * String UUIDs the way feature modules consume them — pre-formatted display strings live in
+ * UI mappers, not here.
+ */
+data class RecentSessionDataModel(
+    val sessionUuid: String,
+    val trainingUuid: String,
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val startedAt: Long,
+    val finishedAt: Long,
+    val exerciseCount: Int,
+    val setCount: Int,
+)
+
+internal fun RecentSessionRow.toData(): RecentSessionDataModel = RecentSessionDataModel(
+    sessionUuid = sessionUuid.toString(),
+    trainingUuid = trainingUuid.toString(),
+    trainingName = trainingName,
+    isAdhoc = isAdhoc,
+    startedAt = startedAt,
+    finishedAt = finishedAt,
+    exerciseCount = exerciseCount,
+    setCount = setCount,
+)

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/model/SessionDetailDataModel.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/session/model/SessionDetailDataModel.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.exercise.session.model
+
+import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+
+/**
+ * One-shot hierarchical view of a finished session, used by the Past session detail screen.
+ * Carries enough info to render the header (training name, timestamps), the per-exercise
+ * breakdown (with `exerciseType` so the UI knows whether to show the weight column), and
+ * the underlying sets ready for inline edit.
+ */
+data class SessionDetailDataModel(
+    val sessionUuid: String,
+    val trainingUuid: String,
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val startedAt: Long,
+    val finishedAt: Long,
+    val exercises: List<PerformedExerciseDetailDataModel>,
+)
+
+data class PerformedExerciseDetailDataModel(
+    val performedExerciseUuid: String,
+    val exerciseUuid: String,
+    val exerciseName: String,
+    val exerciseType: ExerciseTypeDataModel,
+    val position: Int,
+    val skipped: Boolean,
+    val sets: List<SetsDataModel>,
+)

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepository.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepository.kt
@@ -46,6 +46,12 @@ interface TrainingRepository {
     ): Flow<PagingData<TrainingListItem>>
 
     /**
+     * Hot stream of recent template trainings, ordered by `lastSessionAt DESC` (trainings
+     * never used come last, sorted by name). Powers the Home training-picker bottom sheet.
+     */
+    fun observeRecentTemplates(limit: Int): Flow<List<TrainingListItem>>
+
+    /**
      * Bulk-archive a batch of trainings in a single transaction. Trainings with an active
      * (in-progress) session are excluded; the returned [BulkArchiveOutcome] reports how
      * many were archived and which got skipped.

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepositoryImpl.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/training/TrainingRepositoryImpl.kt
@@ -143,6 +143,13 @@ class TrainingRepositoryImpl @Inject constructor(
     override fun observeArchivedCount(): Flow<Int> = dao.observeArchivedCount()
         .flowOn(ioDispatcher)
 
+    override fun observeRecentTemplates(
+        limit: Int,
+    ): Flow<List<TrainingListItem>> = dao
+        .observeRecentTemplates(limit)
+        .map { rows -> rows.map { row -> row.toData(labels = trainingTagDao.getTagNames(row.uuid)) } }
+        .flowOn(ioDispatcher)
+
     override suspend fun countSessionsUsing(
         trainingUuid: String,
     ): Int = withContext(ioDispatcher) {

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Navigator.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Navigator.kt
@@ -12,6 +12,17 @@ interface Navigator {
     fun navTo(screen: Screen)
 
     fun popBack()
+
+    /**
+     * Navigate to [screen] and pop the current destination off the back stack. After this
+     * call, the back stack tip is [screen]; the back gesture from [screen] lands on what
+     * was below the popped destination.
+     *
+     * Used when a screen finishes a one-shot operation and wants to redirect the user
+     * forward without leaving the now-stale screen behind (e.g. Live workout → Past
+     * session detail after finish).
+     */
+    fun replaceTo(screen: Screen)
 }
 
 val LocalNavigator = staticCompositionLocalOf<Navigator> {

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
@@ -64,6 +64,11 @@ sealed interface Screen {
     @Serializable
     data object Archive : Screen
 
+    @Serializable
+    data class PastSession(
+        val sessionUuid: String,
+    ) : Screen
+
     companion object {
 
         @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)

--- a/documentation/feature-specs/home-and-past-session.md
+++ b/documentation/feature-specs/home-and-past-session.md
@@ -1,0 +1,1169 @@
+# Feature spec — Home dashboard expansion + Past session detail (Stage 5.5)
+
+This is the Stage 5.5 feature spec — the **fifth and final v1 feature stage**, after Settings +
+Archive (5.1), Exercises (5.2), Trainings (5.3), Live workout + minimal Home banner (5.4). After
+this PR merges, every feature in `product.md → v1` is shipped. It builds on:
+
+- [product.md](../product.md) — `v1` features #4 (Past session detail), #5 (Home dashboard basic),
+  #12 (Edit past session)
+- [ux-architecture.md](../ux-architecture.md) — Home, Training picker, Past session detail
+- [data-needs.md](../data-needs.md) — `4. Past session detail`, `5. Home dashboard`
+- [db-redesign.md](../db-redesign.md), [db-redesign-plan-model.md](../db-redesign-plan-model.md)
+- [design-system.md](../design-system.md)
+- [architecture.md](../architecture.md) — Navigation flow, Pre-formatted UI fields, DataModel
+  hygiene, Back gesture handling, consumeOnMain
+- [feature-specs/live-workout.md](live-workout.md) — patterns to mirror, finish flow change
+- [feature-specs/trainings.md](trainings.md) — patterns to mirror
+
+## Scope
+
+Three deliverables, plus one navigation infrastructure tweak:
+
+- **Home dashboard expansion** — Start CTA when no active session, Recent sessions list, plus the
+  active-session banner from 5.4 unchanged.
+- **Training picker bottom sheet** — modal sheet listing recent-used templates + "see all" →
+  Trainings tab. Inline composable inside `feature/home` (not promoted to `core/ui`).
+- **Past session detail screen** — new feature module `feature/past-session`. View finished
+  session (header + per-exercise breakdown + sets), edit set values inline, delete the session.
+- **Navigator extension** — single new method `replaceTo(screen)` so `feature/live-workout` can
+  finish into Past session detail without leaving Live workout on the back stack.
+
+This PR also rewires the Live workout finish flow (5.4 popped back to Training detail; 5.5 replaces
+with Past session detail) and connects `feature/single-training`'s already-stubbed `OpenSession`
+action.
+
+## Out of scope (explicitly v2 or deferred)
+
+- Achievement block on Home — v2.
+- Stats dashboard / weekly volume widget — v2.
+- Quick notes inbox — v2.
+- Session summary as a separate screen — folded into Past session detail (same UI, finish flow lands
+  there).
+- PR detection on saved sets — v2.
+- Edit add/remove exercises on a finished session — v1 edit is set-level only (correct mistakes, not
+  restructure).
+- Reverting a finished session to in-progress — never allowed.
+
+## Module structure
+
+```
+feature/
+├── home/                          # MODIFIED — was Stage 5.4 stub
+│   └── src/main/kotlin/.../feature/home/
+│       ├── di/                    # unchanged shape; new bindings for picker interactor methods
+│       ├── domain/
+│       │   ├── HomeInteractor.kt              # MODIFIED — adds observeRecent, observeRecentTrainings, startSessionFromTraining
+│       │   └── HomeInteractorImpl.kt
+│       ├── mvi/
+│       │   ├── handler/
+│       │   │   ├── ClickHandler.kt            # MODIFIED — Start CTA + recent row + picker selections
+│       │   │   ├── CommonHandler.kt
+│       │   │   ├── HomeComponent.kt
+│       │   │   └── NavigationHandler.kt       # MODIFIED — adds OpenPastSession, OpenAllTrainings, OpenLiveWorkoutFresh
+│       │   ├── mapper/
+│       │   │   └── HomeUiMapper.kt            # NEW — ActiveSessionWithStats → ActiveSessionInfo,
+│       │   │                                   # SessionDataModel → RecentSessionItem,
+│       │   │                                   # TrainingListItem → PickerTrainingItem
+│       │   ├── model/                         # NEW
+│       │   │   ├── RecentSessionItem.kt
+│       │   │   └── PickerTrainingItem.kt
+│       │   └── store/
+│       │       ├── HomeStore.kt               # MODIFIED — see MVI surface below
+│       │       └── HomeStoreImpl.kt
+│       └── ui/
+│           ├── HomeGraph.kt                   # MODIFIED — wire haptic + bottom sheet host
+│           ├── HomeScreen.kt                  # MODIFIED — Start CTA + recent list + picker
+│           └── components/
+│               ├── ActiveSessionBanner.kt     # unchanged from 5.4
+│               ├── HomeStartCard.kt           # NEW
+│               ├── RecentSessionRow.kt        # NEW
+│               └── TrainingPickerSheet.kt     # NEW (private to feature/home)
+│
+├── past-session/                  # NEW MODULE
+│   └── src/main/kotlin/.../feature/past_session/
+│       ├── di/
+│       │   ├── PastSessionFeature.kt          # exposes Feature<...>
+│       │   ├── PastSessionHandlerStore.kt
+│       │   ├── PastSessionHandlerStoreImpl.kt
+│       │   └── PastSessionModule.kt
+│       ├── domain/
+│       │   ├── PastSessionInteractor.kt
+│       │   └── PastSessionInteractorImpl.kt
+│       ├── mvi/
+│       │   ├── handler/
+│       │   │   ├── ClickHandler.kt
+│       │   │   ├── CommonHandler.kt
+│       │   │   ├── InputHandler.kt
+│       │   │   ├── NavigationHandler.kt
+│       │   │   └── PastSessionComponent.kt
+│       │   ├── mapper/
+│       │   │   └── PastSessionUiMapper.kt
+│       │   ├── model/
+│       │   │   ├── PastExerciseUiModel.kt
+│       │   │   ├── PastSetUiModel.kt
+│       │   │   └── PastSessionUiModels.kt
+│       │   └── store/
+│       │       ├── PastSessionStore.kt
+│       │       └── PastSessionStoreImpl.kt
+│       └── ui/
+│           ├── PastSessionGraph.kt
+│           ├── PastSessionScreen.kt
+│           └── components/
+│               ├── PastSessionHeader.kt
+│               ├── PastExerciseCard.kt
+│               ├── PastSetEditRow.kt
+│               └── DeleteConfirmDialog.kt
+│
+├── live-workout/                  # MODIFIED — finish flow rewired
+│   └── ... (only NavigationHandler + ClickHandler changed)
+│
+└── single-training/               # MODIFIED — OpenSession stub wired
+    └── ... (only NavigationHandler changed; one line)
+
+core/
+├── database/                      # MODIFIED
+│   └── src/main/kotlin/.../core/database/
+│       ├── session/
+│       │   ├── SessionDao.kt              # +observeRecentWithStats(limit)
+│       │   ├── RecentSessionRow.kt        # NEW (DTO for the new query)
+│       │   └── SessionDetailRow.kt        # NEW (DTO for past session detail one-shot)
+│       └── training/
+│           └── TrainingDao.kt             # +observeRecentTemplates(limit)
+│
+├── exercise/                      # MODIFIED
+│   └── src/main/kotlin/.../core/exercise/
+│       ├── session/
+│       │   ├── SessionRepository.kt       # +observeRecentWithStats, +getSessionDetail
+│       │   ├── SessionRepositoryImpl.kt
+│       │   ├── SetRepository.kt           # +updateSet, +deleteSet (already exposed?)
+│       │   └── model/
+│       │       ├── RecentSessionDataModel.kt   # NEW
+│       │       └── SessionDetailDataModel.kt   # NEW (with nested exercises + sets)
+│       └── training/
+│           └── TrainingRepository.kt      # +observeRecentTemplates
+│
+└── ui/navigation/                 # MODIFIED — Navigator gets replaceTo
+    └── src/main/kotlin/.../core/ui/navigation/
+        ├── Navigator.kt                   # +fun replaceTo(screen: Screen)
+        └── Screen.kt                      # +data class PastSession(sessionUuid: String)
+```
+
+App-level wiring:
+
+- `app/app/.../navigation/NavigatorImpl.kt` — implement `replaceTo`.
+- `app/app/.../host/AppNavigationHost.kt` — register `pastSessionGraph(...)`.
+- `app/app/.../navigation/RootComponentImpl.kt` — produce `PastSessionComponent`.
+
+## Core flow
+
+### Home flow
+
+```
+                    ┌─────────────────────────────┐
+                    │  Home (Bottom tab, default) │
+                    └──────────────┬──────────────┘
+                                   │
+                    observeActiveSessionWithStats
+                    observeRecentWithStats(limit=10)
+                                   │
+              ┌────────────────────┼─────────────────────┐
+              │                    │                     │
+       active session?     no active, no recent     no active, recent>0
+              │                    │                     │
+              ▼                    ▼                     ▼
+     ┌──────────────┐   ┌──────────────────┐   ┌──────────────────────┐
+     │ Banner +     │   │ Empty state      │   │ Start CTA + recent   │
+     │ recent list  │   │ + Start CTA card │   │ list                 │
+     └──────┬───────┘   └────────┬─────────┘   └──────────┬───────────┘
+            │                    │                        │
+            ▼ tap banner         ▼ tap Start              ▼ tap row / Start
+     ┌──────────────┐   ┌──────────────────┐   ┌──────────────────────┐
+     │ Live workout │   │ Picker bottom    │   │ Past session detail  │
+     │ (resume)     │   │ sheet            │   │   or picker sheet    │
+     └──────────────┘   └────────┬─────────┘   └──────────────────────┘
+                                 │
+                       tap a template
+                                 │
+                                 ▼
+                       Live workout (fresh)
+```
+
+State machine for Home:
+
+- `isLoading = true` until first emission of `observeActiveSessionWithStats` AND
+  `observeRecentWithStats` both arrive.
+- `activeSession` non-null → render banner; recent list still rendered below banner if
+  `recent.isNotEmpty()`.
+- `activeSession` null AND `recent.isEmpty()` → empty state (icon + headline + Start CTA card).
+- `activeSession` null AND `recent.isNotEmpty()` → Start CTA card on top, then recent list.
+
+The picker is a `ModalBottomSheet` with `pickerVisible: Boolean` in State. Selecting a template
+emits `Action.Click.OnPickerTrainingSelected(trainingUuid)` →
+`Action.Navigation.OpenLiveWorkoutFresh(trainingUuid)` →
+`navigator.navTo(Screen.LiveWorkout(sessionUuid = null, trainingUuid = trainingUuid))`. The sheet
+closes via `pickerVisible = false` on selection or dismiss.
+
+### Past session detail flow
+
+```
+                ┌─────────────────────────┐
+                │  Past session detail    │
+                └────────────┬────────────┘
+                             │
+              load via getSessionDetail(uuid)
+                             │
+                ┌────────────┼─────────────┐
+                │            │             │
+            isLoading    Loaded(detail)  Error
+                             │
+            ┌────────────────┼─────────────┬──────────────┐
+            │                │             │              │
+       view sets         edit set       delete         back gesture
+            │                │           session       (no dirty
+            │                ▼             │           interception
+            │       OnSetWeightChange      ▼           in v1 — see
+            │       OnSetRepsChange   AppConfirmDialog discard rule
+            │       OnSetTypeChange   confirm → delete  below)
+            │                │        → popBack
+            │           debounced
+            │            persist
+            │           via update
+            └────────────────┴
+```
+
+On entry: Store calls `interactor.getSessionDetail(sessionUuid)` once, holds in State as
+`detail: SessionDetailUiModel`. Edits flow through
+`Action.Input.OnSetWeightChange/OnSetRepsChange/OnSetTypeChange` — handler updates the local State
+row immediately (optimistic) and persists with debounce (300ms after last input on that field,
+similar to existing input patterns; if no debounce primitive exists in repo, just persist on input
+directly — the repo write is cheap).
+
+Add-set / remove-set on a finished session is **out of scope for v1**. Edit is per-set (weight,
+reps, type) only. Document this constraint in the spec for review.
+
+Delete: `Action.Click.OnDeleteClick` → confirmation dialog → `Action.Click.OnDeleteConfirm` →
+repository deletes session (CASCADE removes performed_exercise + set rows) →
+`Action.Navigation.Back` → `navigator.popBack()`.
+
+### Live workout finish (changed from 5.4)
+
+Stage 5.4 currently:
+
+```
+processFinishConfirm() → repository.finishSession(...) → consumeOnMain(Action.Navigation.Back) → popBack to whichever screen entered Live workout
+```
+
+Stage 5.5:
+
+```
+processFinishConfirm() → repository.finishSession(...) → consumeOnMain(Action.Navigation.OpenPastSession(sessionUuid)) → navigator.replaceTo(Screen.PastSession(sessionUuid))
+```
+
+`replaceTo` is a new Navigator method that does the equivalent of `navTo` plus pop the current
+destination. From Past session detail, the system back gesture or top-bar arrow lands on whatever
+was below Live workout (Home or Training detail). This gives "complete a workout, immediately review
+what you did" UX.
+
+The existing `Action.Navigation.BackToHome` is removed — it was a 5.4 placeholder. Cancel session (
+which already used `Navigation.Back`) keeps `popBack()`.
+
+## Data layer additions
+
+### `core/database/session/SessionDao.kt`
+
+Add two queries.
+
+**`observeRecentWithStats(limit)`** — Home recent list with everything the row needs in one shot:
+
+```kotlin
+@Query(
+    """
+    SELECT s.uuid AS session_uuid,
+           s.training_uuid AS training_uuid,
+           t.name AS training_name,
+           t.is_adhoc AS is_adhoc,
+           s.started_at AS started_at,
+           s.finished_at AS finished_at,
+           (SELECT COUNT(*) FROM performed_exercise_table pe
+              WHERE pe.session_uuid = s.uuid AND pe.skipped = 0) AS exercise_count,
+           (SELECT COUNT(*) FROM set_table st
+              JOIN performed_exercise_table pe2 ON pe2.uuid = st.performed_exercise_uuid
+              WHERE pe2.session_uuid = s.uuid) AS set_count
+    FROM session_table s
+    INNER JOIN training_table t ON t.uuid = s.training_uuid
+    WHERE s.state = 'FINISHED'
+    ORDER BY s.finished_at DESC
+    LIMIT :limit
+    """,
+)
+fun observeRecentWithStats(limit: Int): Flow<List<RecentSessionRow>>
+```
+
+`RecentSessionRow` (new DTO):
+
+```kotlin
+data class RecentSessionRow(
+    @ColumnInfo(name = "session_uuid") val sessionUuid: Uuid,
+    @ColumnInfo(name = "training_uuid") val trainingUuid: Uuid,
+    @ColumnInfo(name = "training_name") val trainingName: String,
+    @ColumnInfo(name = "is_adhoc") val isAdhoc: Boolean,
+    @ColumnInfo(name = "started_at") val startedAt: Long,
+    @ColumnInfo(name = "finished_at") val finishedAt: Long,
+    @ColumnInfo(name = "exercise_count") val exerciseCount: Int,
+    @ColumnInfo(name = "set_count") val setCount: Int,
+)
+```
+
+Index check: `session(state, finished_at DESC)` is already covered by existing indices
+`session(state)` + `session(finished_at)`. SQLite query planner can use either; for v1 limit=10 the
+cost is negligible. If perf becomes an issue, add composite `session(state, finished_at)` later. *
+*Do not add prematurely.**
+
+**`getSessionDetail(sessionUuid)`** — one-shot for Past session detail. Returns the session row +
+all performed_exercise rows + all set rows joined, deserialized into a hierarchical model. Three
+options:
+
+1. Three separate suspend queries (`getSession`, `getPerformedBySession`, `getSetsBySession`) —
+   simplest.
+2. `@Transaction`-decorated method that runs the three suspends in one DB transaction and assembles
+   the result.
+3. One mega-query with JOINs and deserialize manually.
+
+**Pick option 2.** Avoids inconsistency window (finished_at could change between calls — unlikely
+but cheap to defend against), avoids manual row-flattening of option 3.
+
+```kotlin
+@Transaction
+suspend fun getSessionDetail(sessionUuid: Uuid): SessionDetailRow? {
+    val session = getById(sessionUuid) ?: return null
+    val performed = performedDao.getBySession(sessionUuid)
+    val setsByPerformed = performed.associate { pe ->
+        pe.uuid to setDao.getByPerformedExercise(pe.uuid)
+    }
+    val training = trainingDao.getById(session.trainingUuid)
+    val exerciseNames = exerciseDao.getByIds(performed.map { it.exerciseUuid })
+        .associateBy { it.uuid }
+    return SessionDetailRow(session, performed, setsByPerformed, training, exerciseNames)
+}
+```
+
+Where `SessionDetailRow` is a plain data holder (not an `@Entity`):
+
+```kotlin
+data class SessionDetailRow(
+    val session: SessionEntity,
+    val performed: List<PerformedExerciseEntity>,
+    val setsByPerformed: Map<Uuid, List<SetEntity>>,
+    val training: TrainingEntity?,
+    val exerciseByUuid: Map<Uuid, ExerciseEntity>,
+)
+```
+
+Note: this requires `SessionDao` to depend on `PerformedExerciseDao`, `SetDao`, `TrainingDao`,
+`ExerciseDao`. Room doesn't allow @Dao classes to inject other DAOs directly. Two options:
+
+- Move `getSessionDetail` to a higher level — implement in `SessionRepositoryImpl` which already has
+  all four DAOs injected. **Pick this.**
+- Use Room's transaction-via-AppDatabase (`db.withTransaction { ... }`).
+
+So actual placement: `SessionRepositoryImpl.getSessionDetail(uuid): SessionDetailDataModel?` does
+the `db.withTransaction { ... }` block. The DAO does NOT change for this part — only the new
+`observeRecentWithStats` query.
+
+### `core/database/training/TrainingDao.kt`
+
+Add `observeRecentTemplates(limit)`:
+
+```kotlin
+@Query(
+    """
+    SELECT t.uuid, t.name, t.description, t.is_adhoc, t.archived, t.created_at, t.archived_at,
+           (SELECT COUNT(*) FROM training_exercise_table WHERE training_uuid = t.uuid) AS exercise_count,
+           (SELECT MAX(s.finished_at) FROM session_table s
+              WHERE s.training_uuid = t.uuid AND s.state = 'FINISHED') AS last_session_at,
+           (SELECT s.uuid FROM session_table s
+              WHERE s.training_uuid = t.uuid AND s.state = 'IN_PROGRESS' LIMIT 1) AS active_session_uuid,
+           (SELECT s.started_at FROM session_table s
+              WHERE s.training_uuid = t.uuid AND s.state = 'IN_PROGRESS' LIMIT 1) AS active_session_started_at
+    FROM training_table t
+    WHERE t.archived = 0 AND t.is_adhoc = 0
+    ORDER BY (last_session_at IS NULL), last_session_at DESC, t.name COLLATE NOCASE ASC
+    LIMIT :limit
+    """,
+)
+fun observeRecentTemplates(limit: Int): Flow<List<TrainingListItemRow>>
+```
+
+Reuses existing `TrainingListItemRow`. Ordering: trainings with at least one finished session come
+first, ordered by `last_session_at DESC`; trainings never used come after, ordered by name. The
+picker shows top 5 by default.
+
+### Repositories
+
+`core/exercise/session/SessionRepository.kt` adds:
+
+```kotlin
+fun observeRecentWithStats(limit: Int): Flow<List<RecentSessionDataModel>>
+
+suspend fun getSessionDetail(sessionUuid: String): SessionDetailDataModel?
+```
+
+`core/exercise/training/TrainingRepository.kt` adds:
+
+```kotlin
+fun observeRecentTemplates(limit: Int): Flow<List<TrainingListItem>>
+```
+
+(reuses existing `TrainingListItem` domain model from Trainings tab).
+
+`core/exercise/session/SetRepository.kt` — verify it exposes update + delete on a per-set basis. If
+yes, leave alone. If no, add:
+
+```kotlin
+suspend fun updateSet(set: SetDataModel)
+suspend fun deleteSet(setUuid: String)
+```
+
+(Audit during implementation. The existing `SetRepositoryImpl` may already cover this for
+live-workout's add/delete-set actions — if so, reuse.)
+
+### New domain models
+
+`core/exercise/session/model/RecentSessionDataModel.kt`:
+
+```kotlin
+data class RecentSessionDataModel(
+    val sessionUuid: String,
+    val trainingUuid: String,
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val startedAt: Long,
+    val finishedAt: Long,
+    val exerciseCount: Int,
+    val setCount: Int,
+)
+```
+
+`core/exercise/session/model/SessionDetailDataModel.kt`:
+
+```kotlin
+data class SessionDetailDataModel(
+    val sessionUuid: String,
+    val trainingUuid: String,
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val startedAt: Long,
+    val finishedAt: Long,
+    val exercises: List<PerformedExerciseDetailDataModel>,
+)
+
+data class PerformedExerciseDetailDataModel(
+    val performedExerciseUuid: String,
+    val exerciseUuid: String,
+    val exerciseName: String,
+    val position: Int,
+    val skipped: Boolean,
+    val sets: List<SetDataModel>,
+)
+```
+
+Note: domain models carry **only domain data**. Pre-formatted UI strings (relative time labels,
+duration labels) live in UI types — `RecentSessionItem`, `PastSessionUiModel` — produced by mappers
+in the consuming feature module. Per `architecture.md → UI types vs domain types` and the
+canonical "pre-formatted UI fields belong in State" rule.
+
+## Navigation surface
+
+### `core/ui/navigation/Screen.kt`
+
+Add:
+
+```kotlin
+@Serializable
+data class PastSession(
+    val sessionUuid: String,
+) : Screen
+```
+
+### `core/ui/navigation/Navigator.kt`
+
+Extend interface:
+
+```kotlin
+@Stable
+interface Navigator {
+    val navController: NavHostController
+    fun navTo(screen: Screen)
+    fun popBack()
+
+    /**
+     * Navigate to [screen] and remove the current destination from the back stack.
+     * After this call, the back stack tip is [screen]; the back gesture from [screen]
+     * lands on what was below the popped destination.
+     *
+     * Used when a screen finishes a one-shot operation and wants to redirect the user
+     * forward without leaving the now-stale screen behind (e.g. Live workout → Past
+     * session detail after finish).
+     */
+    fun replaceTo(screen: Screen)
+}
+```
+
+`NavigatorImpl.replaceTo`:
+
+```kotlin
+override fun replaceTo(screen: Screen) {
+    logger.d("replaceTo $screen")
+    try {
+        val currentRoute = holder.navigator.currentDestination?.route ?: return
+        navController.navigate(screen) {
+            popUpTo(currentRoute) {
+                inclusive = true
+                saveState = false
+            }
+            launchSingleTop = true
+        }
+    } catch (ignore: Exception) {
+        logger.e(ignore, "screen: $screen")
+    }
+}
+```
+
+`saveState = false` is intentional — the popped destination is a finished Live workout, no point
+saving its state. Distinguishes from `navTo` where `isSingleTop` saves state.
+
+### Routes covered
+
+```
+Screen.BottomBar.Home  →  Screen.LiveWorkout(sessionUuid = activeSessionUuid)         (resume from banner; existing)
+Screen.BottomBar.Home  →  Screen.LiveWorkout(trainingUuid = pickedTraining)            (fresh from picker; new)
+Screen.BottomBar.Home  →  Screen.BottomBar.AllTrainings                                (picker "see all"; new)
+Screen.BottomBar.Home  →  Screen.PastSession(sessionUuid)                              (recent row tap; new)
+Screen.Training        →  Screen.PastSession(sessionUuid)                              (single-training pastSessions; new)
+Screen.LiveWorkout     ⤳  Screen.PastSession(sessionUuid)  (replaceTo, post-finish)    (new, replaces 5.4 popBack)
+```
+
+The `Home → AllTrainings` transition uses `navTo(Screen.BottomBar.AllTrainings)` —
+`isSingleTop = true` on `BottomBar` already handles the bottom-bar-tap semantics, but double-check
+that arriving at `AllTrainings` from Home (not via the bottom bar tap) renders the correct selected
+tab in `WorkeeperBottomAppBar`. If not, the bottom-bar selection tracking logic in
+`NavHostControllerHolder` handles it because route changes flow through the same NavController.
+
+## MVI surface — `feature/home`
+
+### State
+
+```kotlin
+@Stable
+data class State(
+    val activeSession: ActiveSessionInfo?,
+    val recent: ImmutableList<RecentSessionItem>,
+    val isLoading: Boolean,
+    val nowMillis: Long,
+    val picker: PickerState,
+) : Store.State {
+
+    @Stable
+    data class ActiveSessionInfo(
+        val sessionUuid: String,
+        val trainingUuid: String,
+        val trainingName: String,
+        val startedAt: Long,
+        val doneCount: Int,
+        val totalCount: Int,
+        val elapsedDurationLabel: String,        // pre-formatted in mapper
+    ) {
+        fun elapsedMillis(now: Long): Long = (now - startedAt).coerceAtLeast(0L)
+    }
+
+    @Stable
+    data class RecentSessionItem(
+        val sessionUuid: String,
+        val trainingName: String,                // localized "Ad-hoc workout" if isAdhoc
+        val isAdhoc: Boolean,
+        val finishedAtRelativeLabel: String,     // pre-formatted "2 days ago"
+        val durationLabel: String,               // pre-formatted "47 min"
+        val statsLabel: String,                  // pre-formatted "5 exercises · 18 sets"
+    )
+
+    @Stable
+    sealed interface PickerState {
+        data object Hidden : PickerState
+        data class Visible(
+            val templates: ImmutableList<PickerTrainingItem>,
+            val isLoading: Boolean,
+        ) : PickerState
+    }
+
+    @Stable
+    data class PickerTrainingItem(
+        val trainingUuid: String,
+        val name: String,
+        val exerciseCountLabel: String,          // pre-formatted "6 exercises"
+        val lastSessionRelativeLabel: String?,   // pre-formatted "3 days ago" or null if never used
+    )
+
+    val showStartCta: Boolean get() = activeSession == null
+    val showRecentList: Boolean get() = recent.isNotEmpty()
+    val showEmptyState: Boolean get() = !isLoading && activeSession == null && recent.isEmpty()
+    val showPicker: Boolean get() = picker is PickerState.Visible
+
+    companion object {
+        val INITIAL = State(
+            activeSession = null,
+            recent = persistentListOf(),
+            isLoading = true,
+            nowMillis = 0L,
+            picker = PickerState.Hidden,
+        )
+    }
+}
+```
+
+### Action
+
+```kotlin
+@Stable
+sealed interface Action : Store.Action {
+
+    sealed interface Click : Action {
+        data object OnActiveSessionClick : Click
+        data object OnSettingsClick : Click
+        data class OnRecentSessionClick(val sessionUuid: String) : Click
+        data object OnStartTrainingClick : Click             // opens picker
+        data class OnPickerTrainingSelected(val trainingUuid: String) : Click
+        data object OnPickerSeeAllClick : Click              // → AllTrainings
+        data object OnPickerDismiss : Click
+    }
+
+    sealed interface Navigation : Action {
+        data class OpenLiveWorkoutResume(val sessionUuid: String) : Navigation
+        data class OpenLiveWorkoutFresh(val trainingUuid: String) : Navigation
+        data class OpenPastSession(val sessionUuid: String) : Navigation
+        data object OpenSettings : Navigation
+        data object OpenAllTrainings : Navigation
+    }
+
+    sealed interface Common : Action {
+        data object Init : Common
+        data object TimerTick : Common
+    }
+}
+```
+
+### Event
+
+Unchanged structure from 5.4:
+
+```kotlin
+@Stable
+sealed interface Event : Store.Event {
+    data class HapticClick(val type: HapticFeedbackType) : Event
+}
+```
+
+### Handlers
+
+- **`CommonHandler`** — on `Init`, launches three flows: `observeActiveSessionWithStats`,
+  `observeRecentWithStats(limit = HOME_RECENT_LIMIT)` where `HOME_RECENT_LIMIT = 10`, and a tick
+  flow at 1Hz for `nowMillis` (already exists from 5.4 — confirm it stays; nowMillis is for the
+  active banner's elapsed label, not the recent list).
+- **`ClickHandler`** — routes clicks. `OnStartTrainingClick` triggers picker load (calls
+  `interactor.observeRecentTemplates(PICKER_LIMIT)` once, sets `picker = Visible(loading)` then
+  populates), all `On*Click` haptics emit `Event.HapticClick`. `OnPickerTrainingSelected` closes
+  picker and emits `Action.Navigation.OpenLiveWorkoutFresh`. `OnRecentSessionClick` emits
+  `Action.Navigation.OpenPastSession`.
+- **`NavigationHandler`** — exact same shape as 5.4 NavigationHandler, extended with the new
+  Navigation variants.
+
+```kotlin
+@Suppress("MviHandlerConstructorRule")
+internal class NavigationHandler(
+    private val navigator: Navigator,
+    data: Screen.BottomBar.Home,
+) : HomeComponent(data), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            is Action.Navigation.OpenLiveWorkoutResume ->
+                navigator.navTo(
+                    Screen.LiveWorkout(
+                        sessionUuid = action.sessionUuid,
+                        trainingUuid = null
+                    )
+                )
+            is Action.Navigation.OpenLiveWorkoutFresh ->
+                navigator.navTo(
+                    Screen.LiveWorkout(
+                        sessionUuid = null,
+                        trainingUuid = action.trainingUuid
+                    )
+                )
+            is Action.Navigation.OpenPastSession ->
+                navigator.navTo(Screen.PastSession(action.sessionUuid))
+            Action.Navigation.OpenSettings -> navigator.navTo(Screen.Settings)
+            Action.Navigation.OpenAllTrainings -> navigator.navTo(Screen.BottomBar.AllTrainings)
+        }
+    }
+}
+```
+
+### Picker loading note
+
+The picker is loaded lazily on first open, NOT eagerly on `Init`. Reasoning:
+
+- Most Home opens have an active session → Start CTA never shown → picker query never runs.
+- When user taps Start CTA, sheet shows briefly with `isLoading = true`; query returns within a
+  frame on warm DB.
+- Avoids holding a hot Flow that updates the picker continuously when the sheet is closed.
+
+Acceptable cost: ~50-100ms perceived latency on first picker open. If this becomes noticeable in QA,
+switch to eager hot Flow.
+
+## MVI surface — `feature/past-session` (new)
+
+### Component
+
+```kotlin
+internal abstract class PastSessionComponent(
+    val data: Screen.PastSession,
+) : Component
+```
+
+### State
+
+```kotlin
+@Stable
+data class State(
+    val sessionUuid: String,                    // from route
+    val phase: Phase,
+    val deleteDialogVisible: Boolean,
+) : Store.State {
+
+    @Stable
+    sealed interface Phase {
+        data object Loading : Phase
+        data class Loaded(val detail: PastSessionUiModel) : Phase
+        data class Error(val errorType: ErrorType) : Phase
+    }
+
+    @Stable
+    data class PastSessionUiModel(
+        val trainingName: String,                // localized
+        val isAdhoc: Boolean,
+        val finishedAtAbsoluteLabel: String,     // pre-formatted "Mon, Apr 27, 19:42"
+        val durationLabel: String,               // pre-formatted "47 min"
+        val totalsLabel: String,                 // pre-formatted "5 exercises · 18 sets"
+        val volumeLabel: String?,                // pre-formatted "1,250 kg total" or null if no weighted sets
+        val exercises: ImmutableList<PastExerciseUiModel>,
+    )
+
+    @Stable
+    data class PastExerciseUiModel(
+        val performedExerciseUuid: String,
+        val exerciseName: String,
+        val position: Int,
+        val skipped: Boolean,
+        val isWeighted: Boolean,                 // from underlying ExerciseEntity.type
+        val sets: ImmutableList<PastSetUiModel>,
+    )
+
+    @Stable
+    data class PastSetUiModel(
+        val setUuid: String,
+        val position: Int,
+        val type: SetTypeUiModel,                // reuse existing UI enum
+        val weightInput: String,                 // editable raw text (stable for TextField)
+        val repsInput: String,
+        val weightError: Boolean,
+        val repsError: Boolean,
+    )
+
+    enum class ErrorType { SessionNotFound, LoadFailed }
+
+    val canDelete: Boolean get() = phase is Phase.Loaded
+}
+```
+
+### Action
+
+```kotlin
+@Stable
+sealed interface Action : Store.Action {
+
+    sealed interface Click : Action {
+        data object OnBackClick : Click
+        data object OnDeleteClick : Click
+        data object OnDeleteConfirm : Click
+        data object OnDeleteDismiss : Click
+        data class OnSetTypeChange(val setUuid: String, val type: SetTypeUiModel) : Click
+        data class OnRetryLoad : Click
+    }
+
+    sealed interface Input : Action {
+        data class OnSetWeightChange(val setUuid: String, val raw: String) : Input
+        data class OnSetRepsChange(val setUuid: String, val raw: String) : Input
+    }
+
+    sealed interface Navigation : Action {
+        data object Back : Navigation
+    }
+
+    sealed interface Common : Action {
+        data object Init : Common
+    }
+}
+```
+
+### Event
+
+```kotlin
+@Stable
+sealed interface Event : Store.Event {
+    data class HapticClick(val type: HapticFeedbackType) : Event
+    data class ShowError(val errorType: ErrorType) : Event   // enum-typed per architecture rule
+    data object DeletedSnackbar : Event
+}
+```
+
+### Handlers
+
+- **`CommonHandler`** — `Init` calls `interactor.getSessionDetail(sessionUuid)` once and updates
+  State. On null result, emit `Phase.Error(SessionNotFound)`. On exception,
+  `Phase.Error(LoadFailed)`.
+- **`InputHandler`** — `OnSetWeightChange` / `OnSetRepsChange` — parse raw to value, validate (
+  weight ≥ 0 OR null for unweighted; reps > 0), update UI state (raw text for stability),
+  debounce-persist on success. Validation errors flip per-row error flags but DO NOT block typing.
+  The persist call uses `interactor.updateSet(...)` and ignores the result on success. On failure,
+  emit `Event.ShowError(SaveFailed)` and revert the State row to its last known good value.
+- **`ClickHandler`** — `OnDeleteClick` shows confirmation; `OnDeleteConfirm` calls
+  `interactor.deleteSession(sessionUuid)` then `consumeOnMain(Action.Navigation.Back)` then
+  `Event.DeletedSnackbar`. `OnSetTypeChange` updates type immediately (no debounce — user picks
+  once). `OnRetryLoad` re-runs Init.
+- **`NavigationHandler`** — `Back → navigator.popBack()`.
+
+### Compose surface
+
+`PastSessionScreen(state, consume)`:
+
+- Top-level `Scaffold` with
+  `AppTopAppBar(title = state.detail?.trainingName ?: stringResource(loading_title), navigationIcon = back, actions = { delete IconButton when canDelete })`.
+- `when (state.phase)` switches between loading indicator, error state with retry button, loaded
+  list.
+- Loaded: `LazyColumn` with header item (`PastSessionHeader`) + per-exercise items (
+  `PastExerciseCard` containing rows of `PastSetEditRow`).
+- Delete dialog rendered conditionally when `state.deleteDialogVisible`.
+
+`PastExerciseCard` shows position, name, skipped chip if skipped, then either "no sets" empty or
+list of `PastSetEditRow`.
+
+`PastSetEditRow` mirrors the live-workout set row visually: type chip, weight TextField, reps
+TextField. No "mark done" checkbox here — every set is already done. Stable `key` per row for
+TextField identity preservation (per architecture.md → TextField inputs).
+
+### Discard / back gesture
+
+Past session detail does NOT need `interceptBack`. Edits persist immediately (debounced). On back
+gesture, the user's most recent edits may be in-flight; we accept that — repository write is fast.
+If a stronger guarantee is desired, add `BackHandler(enabled = state.hasInflightWrites) { ... }`
+later. Document this as v1 simplification.
+
+## MVI surface — `feature/single-training` (one-line wire-up)
+
+In `feature/single-training/.../mvi/handler/NavigationHandler.kt`, replace the no-op stub:
+
+```kotlin
+// Before:
+is Action.Navigation.OpenSession -> Unit
+
+// After:
+is Action.Navigation.OpenSession ->
+navigator.navTo(Screen.PastSession(action.sessionUuid))
+```
+
+Remove the inline TODO comment.
+
+## MVI surface — `feature/live-workout` finish change
+
+Two edits:
+
+1. `LiveWorkoutStore.kt` — replace `Action.Navigation.BackToHome` with
+   `Action.Navigation.OpenPastSession(val sessionUuid: String)`.
+2. `ClickHandler.kt::processFinishConfirm` — change `consumeOnMain(Action.Navigation.Back)` (after
+   `repository.finishSession(...)`) to
+   `consumeOnMain(Action.Navigation.OpenPastSession(state.value.sessionUuid))`.
+3. `NavigationHandler.kt` — add
+   `is Action.Navigation.OpenPastSession -> navigator.replaceTo(Screen.PastSession(action.sessionUuid))`.
+   Remove `BackToHome` branch.
+
+The cancel-session path (which deletes the session in-progress) keeps
+`Action.Navigation.Back → popBack()`. No PastSession transition there because the session was
+deleted — no UUID to view.
+
+## DataModel hygiene audit
+
+Per `architecture.md → DataModel hygiene`, audit every `*DataModel` touched by 5.5:
+
+- `SessionDataModel` — confirm no obsolete fields. Currently has uuid, trainingUuid, state,
+  startedAt, finishedAt. All used. ✓
+- `RecentSessionDataModel` (new) — no legacy. ✓ (designed greenfield)
+- `SessionDetailDataModel` (new) — same. ✓
+- `PerformedExerciseDataModel` — used by Live workout; check it doesn't carry phantom fields when
+  consumed by past-session interactor. If it carries any field that 5.5 doesn't read AND that no
+  other consumer reads, delete.
+- `SetDataModel` — same audit.
+- `TrainingListItem` — reused for picker. Check that picker's `PickerTrainingItem` only consumes the
+  fields it needs (uuid, name, exerciseCount, lastSessionAt) — if `TrainingListItem` carries
+  `activeSessionUuid` / `activeSessionStartedAt` and 5.5 picker mapper doesn't read them, that's
+  fine because Trainings tab reads them. Don't delete cross-feature fields.
+
+Surface findings in the PR description: "Phantom fields removed: X. Callsites updated: feature/Y,
+feature/Z."
+
+## Localization
+
+Every user-facing string goes to `feature/home/src/main/res/values/strings.xml` and
+`values-ru/strings.xml` (and same pair for `feature/past-session`). Per architecture.md →
+Localization.
+
+Strings to add (English; mirror in ru):
+
+```xml
+<!-- feature/home -->
+<string name="feature_home_start_cta_title">Start a workout</string><string
+name="feature_home_start_cta_subtitle">Pick a training template
+</string><string name="feature_home_recent_section_title">Recent sessions</string><string
+name="feature_home_recent_adhoc_label">Ad-hoc workout
+</string><string name="feature_home_picker_title">Choose a training</string><string
+name="feature_home_picker_see_all">See all templates
+</string><string name="feature_home_picker_empty">No templates yet</string>
+
+<plurals name="feature_home_recent_exercises_count">
+<item quantity="one">%d exercise</item>
+<item quantity="other">%d exercises</item>
+</plurals><plurals name="feature_home_recent_sets_count">
+<item quantity="one">%d set</item>
+<item quantity="other">%d sets</item>
+</plurals>
+
+    <!-- feature/past-session -->
+<string name="feature_past_session_loading_title">Past session</string><string
+name="feature_past_session_error_not_found">Session not found
+</string><string name="feature_past_session_error_load_failed">Could not load session
+</string><string name="feature_past_session_action_retry">Retry</string><string
+name="feature_past_session_action_delete">Delete
+</string><string name="feature_past_session_delete_dialog_title">Delete session?</string><string
+name="feature_past_session_delete_dialog_body">This permanently removes the session and all its
+sets. The training template is unchanged.
+</string><string name="feature_past_session_delete_dialog_confirm">Delete</string><string
+name="feature_past_session_deleted_snackbar">Session deleted
+</string><string name="feature_past_session_skipped_chip">Skipped</string><string
+name="feature_past_session_no_sets">No sets logged
+</string><string name="feature_past_session_volume_label">%1$s kg total</string><string
+name="feature_past_session_save_failed_snackbar">Could not save change — try again
+</string>
+```
+
+Russian forms must include `few` quantity for plurals (упражнение / упражнения / упражнений; сет /
+сета / сетов).
+
+Pre-formatted labels (`durationLabel`, `finishedAtRelativeLabel`, `finishedAtAbsoluteLabel`,
+`statsLabel`, `volumeLabel`) are produced by mappers, not Composables. Use existing
+`formatElapsedDuration` from `core/core/time` (already used in 5.4 banner) for durations. For
+relative time, add `formatRelativeTime(nowMillis, eventMillis): String` to `core/core/time` if
+absent, returning localized "just now / 5 min ago / 2 days ago / Mar 12" with `Locale.current`. For
+absolute, use `DateTimeFormatter` with localized pattern.
+
+If `core/core/time` doesn't yet have `formatRelativeTime`, add it as part of this stage (small,
+well-tested utility).
+
+## Testing requirements
+
+### Unit tests
+
+- `feature/home`:
+    - `ClickHandlerTest` — every `Action.Click` variant produces correct State change + Navigation
+      Action.
+    - `CommonHandlerTest` — `Init` subscribes to active + recent flows; State updates correctly on
+      combined emissions; `isLoading` flips correctly when both flows have emitted at least once.
+    - `NavigationHandlerTest` — every Navigation variant calls correct `navigator.*` method.
+    - `HomeUiMapperTest` — `RecentSessionDataModel → RecentSessionItem` mapping with adhoc +
+      non-adhoc, with all stat combinations; `TrainingListItem → PickerTrainingItem` mapping with
+      never-used + recently-used.
+    - `HomeInteractorImplTest` — flows wire correctly to repository.
+- `feature/past-session`:
+    - `ClickHandlerTest` — delete flow (click → dialog → confirm → delete + back + snackbar); retry;
+      type change.
+    - `InputHandlerTest` — weight/reps validation, debounced persist, error revert.
+    - `CommonHandlerTest` — Init success, Init not-found, Init error.
+    - `NavigationHandlerTest` — Back → popBack.
+    - `PastSessionUiMapperTest` — `SessionDetailDataModel → PastSessionUiModel` with all variants (
+      skipped exercise, weighted vs unweighted, no sets exercise).
+    - `PastSessionInteractorImplTest` — getSessionDetail/updateSet/deleteSession wire correctly.
+- `feature/live-workout`:
+    - Update `ClickHandlerTest::processFinishConfirm` — assert
+      `Action.Navigation.OpenPastSession(uuid)` is consumed (was `Action.Navigation.Back`).
+    - Update `NavigationHandlerTest` — `OpenPastSession` calls
+      `navigator.replaceTo(Screen.PastSession(uuid))`.
+- `feature/single-training`:
+    - Update `NavigationHandlerTest` — `OpenSession` calls
+      `navigator.navTo(Screen.PastSession(uuid))` (was no-op).
+- `core/database`:
+    - `SessionDaoTest::observeRecentWithStats` — verifies join + counts + ordering with mixed
+      adhoc/non-adhoc + skipped exercises + sessions without sets.
+    - `TrainingDaoTest::observeRecentTemplates` — never-used last, used-recently-first,
+      archived/adhoc filtered out.
+- `core/exercise`:
+    - `SessionRepositoryImplTest::getSessionDetail` — returns null for unknown uuid, returns
+      hierarchical model for known uuid.
+
+### Compose tests
+
+- `HomeScreenTest` — every state branch (loading, empty, recent-only, banner-only, banner+recent,
+  picker-visible) renders correct elements; tapping recent row emits correct Action; picker
+  selection emits correct Action.
+- `PastSessionScreenTest` — loading, error, loaded, delete dialog visible/hidden; tapping delete
+  shows dialog; confirm fires Action; weight/reps TextField emits Input.
+
+### Integration tests
+
+- `HomeIntegrationTest` (in `app/dev` or feature `androidTest`) — start with empty DB, see empty
+  state; insert finished session via repo, see recent row; insert active session via repo, see
+  banner.
+- `PastSessionIntegrationTest` — open past session, edit a set's weight, leave screen, reopen —
+  change persisted.
+
+### Smoke / Regression annotation
+
+Cover the canonical flow with `@Smoke`:
+
+- Open Home with no data → empty state.
+- Open Home with active session → banner.
+- Tap banner → Live workout (resume).
+- Finish workout → land on Past session detail.
+- Back from Past session → land on entry point.
+
+## Verification gate
+
+Before marking PR ready for review:
+
+- `./gradlew assembleDebug` passes (whole project).
+- `./gradlew testDebugUnitTest` passes.
+- `./gradlew detekt` passes (no new findings).
+- `./gradlew lintDebug` passes (no new findings).
+- App launches.
+    - **Empty DB / no sessions yet:** Home shows empty state with Start CTA. Tap Start → picker
+      opens with "No templates yet" if also no trainings, or with template list. Pick template →
+      Live workout (fresh).
+    - **One finished session, no active:** Home shows Start CTA + recent list with one row. Tap
+      row → Past session detail loads.
+    - **Active session in progress:** Home shows banner + recent list (if any prior finished). Tap
+      banner → Live workout resume.
+    - **Live workout finish flow:** Start a session, log sets, finish → land on Past session
+      detail (NOT Training detail). Top-bar back → land on whatever entered Live workout (Home or
+      Training).
+    - **Past session edit:** Open past session, change weight on a set, leave screen, reopen →
+      change persisted. Same for reps and type.
+    - **Past session delete:** Open past session, tap delete, confirm → land on entry, snackbar
+      visible. Verify session gone from Home recent list and from Training detail past sessions.
+    - **Past session not found (manual test):** Navigate to
+      `Screen.PastSession("00000000-0000-0000-0000-000000000000")` via deep test — error state with
+      retry button.
+    - **Picker:** Tap "see all templates" → switch to Trainings tab.
+- In RU locale, all new strings translated; plurals correct.
+
+## Constraints
+
+- **Phantom shims related to DataModel audit are in scope** — must be removed.
+- **Other phantom shims** stay (e.g. `AppDimension` legacy nested objects).
+- **LICENSE / SPDX headers** — `SPDX-License-Identifier: GPL-3.0-only` on every new file.
+- Do NOT implement add/remove exercises on a finished session (v2 — full restructure of finished
+  session).
+- Do NOT implement Session summary as a separate screen — Past session detail is the post-finish
+  destination.
+- Do NOT implement PR detection / personal records (v2).
+- Do NOT implement quick notes inbox (v2).
+- Do NOT implement Stats dashboard / weekly volume widget (v2).
+
+## PR structure
+
+**Two PRs in sequence:**
+
+### PR A — `docs(architecture): apply pending diffs from Stage 5.4 review`
+
+Apply the 5 diffs from previous session's `architecture-diffs.md` to`documentation/architecture.md`:
+
+1. Navigation flow → `consumeOnMain` subsubsection.
+2. Event conventions → enum-typed error events bullet.
+3. Compose UI conventions → new "Pre-formatted UI fields" subsection.
+4. File intro → tech-debt.md link.
+5. HandlerStore description → cross-ref to `consumeOnMain`.
+
+Small docs-only PR. Title: `docs(architecture): apply pending diffs from Stage 5.4 review`. Body:
+brief summary of what each diff documents, line-count delta.
+
+Merge before PR B.
+
+## Prompt for agent
+
+Implement Stage 5.5 per documentation/feature-specs/home-and-past-session.md.
+
+Branch: feat/stage-5-5-home-past-session
+PR title: feat(home): full Home dashboard + Past session detail (Stage 5.5)
+
+Read the full spec before starting. Key callouts:
+
+Scope:
+
+- New module feature/past-session (view + edit + delete)
+- Home expansion: Start CTA, recent sessions list, training picker bottom sheet
+- Live workout finish flow rewire (5.4 behavior change — finish → Past session
+  detail, not Training detail)
+- Navigator.replaceTo(screen) — single new method on the Navigator interface
+- 2 new DAO queries (SessionDao.observeRecentWithStats,
+  TrainingDao.observeRecentTemplates) + SessionRepositoryImpl.getSessionDetail
+  using db.withTransaction { ... }
+- DataModel hygiene audit per spec section (surface findings in PR body)
+
+Constraints:
+
+- SPDX-License-Identifier: GPL-3.0-only on every new file
+- Edit past session = set-level only (weight/reps/type). Add/remove sets and
+  add/remove exercises on a finished session are out of scope (v2)
+- Live workout finish lands on Past session detail via Navigator.replaceTo —
+  NOT popBack to Training detail. This is intentional per spec
+- No Session summary as separate screen — Past session detail handles both
+  post-finish and historical-view roles
+- No Stats card on Home (v2). Per-row stats on recent list only
+- Picker loaded lazily on first open, not eagerly on Init
+- All user-facing strings in res/values + res/values-ru with proper plurals
+  (RU needs "few" quantity)
+
+Open as DRAFT PR. Mark ready-for-review only after the full Verification gate
+in the spec passes (7 manual scenarios + assembleDebug + testDebugUnitTest +
+detekt + lintDebug).
+
+PR body must include:
+
+- Files changed grouped by module
+- DataModel audit findings (which fields removed, which features touched)
+- Note: "Stage 5.4 finish flow changed: popBack → replaceTo PastSession (intentional)"
+- Note: "Stage 5.5 closes v1 product scope. Next: v1.5 (image attachment), v2"
+
+Stop condition: draft PR opened, verification gate report in PR body, ready
+for my review.
+
+### PR B — `feat(home): full Home dashboard + Past session detail (Stage 5.5)`
+
+Draft PR. Body must include:
+
+- Lists changed files grouped by module.
+- DataModel audit summary (which fields removed, callsite counts per feature).
+- Brief summary of new feature behavior (Home Start CTA + recent list + picker; Past session detail
+  view + edit + delete; Live workout finish flow change).
+- Explicit note: "Stage 5.4 finish-flow behavior changed from popBack to replaceTo PastSession. This
+  is intentional per Stage 5.5 spec."
+- Explicit note: "Stage 5.5 closes v1 product scope. Next milestones are v1.5 (image attachment) and
+  v2."
+
+Mark ready for review after the verification gate passes.

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractor.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractor.kt
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.home.domain
 
-import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore
+import io.github.stslex.workeeper.core.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.exercise.session.model.RecentSessionDataModel
+import io.github.stslex.workeeper.core.exercise.training.TrainingListItem
 import kotlinx.coroutines.flow.Flow
 
 internal interface HomeInteractor {
 
-    fun observeActiveSession(): Flow<HomeStore.State.ActiveSessionInfo?>
+    fun observeActiveSession(): Flow<SessionRepository.ActiveSessionWithStats?>
+
+    fun observeRecent(limit: Int): Flow<List<RecentSessionDataModel>>
+
+    fun observeRecentTrainings(limit: Int): Flow<List<TrainingListItem>>
 }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractorImpl.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractorImpl.kt
@@ -3,36 +3,31 @@ package io.github.stslex.workeeper.feature.home.domain
 
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
-import io.github.stslex.workeeper.core.core.time.formatElapsedDuration
 import io.github.stslex.workeeper.core.exercise.session.SessionRepository
-import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore
+import io.github.stslex.workeeper.core.exercise.session.model.RecentSessionDataModel
+import io.github.stslex.workeeper.core.exercise.training.TrainingListItem
+import io.github.stslex.workeeper.core.exercise.training.TrainingRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @ViewModelScoped
 internal class HomeInteractorImpl @Inject constructor(
     private val sessionRepository: SessionRepository,
+    private val trainingRepository: TrainingRepository,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : HomeInteractor {
 
-    override fun observeActiveSession(): Flow<HomeStore.State.ActiveSessionInfo?> =
+    override fun observeActiveSession(): Flow<SessionRepository.ActiveSessionWithStats?> =
         sessionRepository.observeActiveSessionWithStats()
-            .map { row ->
-                row?.let {
-                    val now = System.currentTimeMillis()
-                    HomeStore.State.ActiveSessionInfo(
-                        sessionUuid = it.sessionUuid,
-                        trainingUuid = it.trainingUuid,
-                        trainingName = it.trainingName,
-                        startedAt = it.startedAt,
-                        doneCount = it.doneCount,
-                        totalCount = it.totalCount,
-                        elapsedDurationLabel = formatElapsedDuration(now - it.startedAt),
-                    )
-                }
-            }
+            .flowOn(defaultDispatcher)
+
+    override fun observeRecent(limit: Int): Flow<List<RecentSessionDataModel>> =
+        sessionRepository.observeRecentWithStats(limit)
+            .flowOn(defaultDispatcher)
+
+    override fun observeRecentTrainings(limit: Int): Flow<List<TrainingListItem>> =
+        trainingRepository.observeRecentTemplates(limit)
             .flowOn(defaultDispatcher)
 }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/ClickHandler.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/ClickHandler.kt
@@ -3,14 +3,23 @@ package io.github.stslex.workeeper.feature.home.mvi.handler
 
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.feature.home.di.HomeHandlerStore
+import io.github.stslex.workeeper.feature.home.domain.HomeInteractor
+import io.github.stslex.workeeper.feature.home.mvi.mapper.toPickerItems
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Event
+import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State
+import kotlinx.collections.immutable.persistentListOf
 import javax.inject.Inject
+
+private const val PICKER_LIMIT = 5
 
 @ViewModelScoped
 internal class ClickHandler @Inject constructor(
+    private val interactor: HomeInteractor,
+    private val resourceWrapper: ResourceWrapper,
     store: HomeHandlerStore,
 ) : Handler<Action.Click>, HomeHandlerStore by store {
 
@@ -18,17 +27,70 @@ internal class ClickHandler @Inject constructor(
         when (action) {
             Action.Click.OnActiveSessionClick -> processSessionClick()
             Action.Click.OnSettingsClick -> processSettingsClick()
+            is Action.Click.OnRecentSessionClick -> processRecentSessionClick(action.sessionUuid)
+            Action.Click.OnStartTrainingClick -> processStartTrainingClick()
+            is Action.Click.OnPickerTrainingSelected -> processPickerSelected(action.trainingUuid)
+            Action.Click.OnPickerSeeAllClick -> processPickerSeeAll()
+            Action.Click.OnPickerDismiss -> processPickerDismiss()
         }
     }
 
     private fun processSessionClick() {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
         val session = state.value.activeSession ?: return
-        consume(Action.Navigation.OpenLiveWorkout(session.sessionUuid))
+        consume(Action.Navigation.OpenLiveWorkoutResume(session.sessionUuid))
     }
 
     private fun processSettingsClick() {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
         consume(Action.Navigation.OpenSettings)
+    }
+
+    private fun processRecentSessionClick(sessionUuid: String) {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        consume(Action.Navigation.OpenPastSession(sessionUuid))
+    }
+
+    private fun processStartTrainingClick() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { current ->
+            current.copy(
+                picker = State.PickerState.Visible(
+                    templates = persistentListOf(),
+                    isLoading = true,
+                ),
+            )
+        }
+        scope.launch(interactor.observeRecentTrainings(PICKER_LIMIT)) { trainings ->
+            val now = state.value.nowMillis.takeIf { it > 0L } ?: System.currentTimeMillis()
+            updateStateImmediate { current ->
+                if (current.picker is State.PickerState.Visible) {
+                    current.copy(
+                        picker = State.PickerState.Visible(
+                            templates = trainings.toPickerItems(now, resourceWrapper),
+                            isLoading = false,
+                        ),
+                    )
+                } else {
+                    current
+                }
+            }
+        }
+    }
+
+    private fun processPickerSelected(trainingUuid: String) {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { it.copy(picker = State.PickerState.Hidden) }
+        consume(Action.Navigation.OpenLiveWorkoutFresh(trainingUuid))
+    }
+
+    private fun processPickerSeeAll() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { it.copy(picker = State.PickerState.Hidden) }
+        consume(Action.Navigation.OpenAllTrainings)
+    }
+
+    private fun processPickerDismiss() {
+        updateState { it.copy(picker = State.PickerState.Hidden) }
     }
 }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/CommonHandler.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/CommonHandler.kt
@@ -2,20 +2,25 @@
 package io.github.stslex.workeeper.feature.home.mvi.handler
 
 import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.core.time.formatElapsedDuration
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.feature.home.di.HomeHandlerStore
 import io.github.stslex.workeeper.feature.home.domain.HomeInteractor
+import io.github.stslex.workeeper.feature.home.mvi.mapper.toRecentItems
+import io.github.stslex.workeeper.feature.home.mvi.mapper.toUi
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import javax.inject.Inject
 
 private const val TIMER_TICK_MS = 1000L
+private const val HOME_RECENT_LIMIT = 10
 
 @ViewModelScoped
 internal class CommonHandler @Inject constructor(
     private val interactor: HomeInteractor,
+    private val resourceWrapper: ResourceWrapper,
     store: HomeHandlerStore,
 ) : Handler<Action.Common>, HomeHandlerStore by store {
 
@@ -27,12 +32,23 @@ internal class CommonHandler @Inject constructor(
     }
 
     private fun processInit() {
-        scope.launch(interactor.observeActiveSession()) { session ->
+        scope.launch(interactor.observeActiveSession()) { row ->
             updateStateImmediate { current ->
+                val now = if (current.nowMillis == 0L) System.currentTimeMillis() else current.nowMillis
                 current.copy(
-                    activeSession = session,
-                    isLoading = false,
-                    nowMillis = if (current.nowMillis == 0L) System.currentTimeMillis() else current.nowMillis,
+                    activeSession = row?.toUi(now, resourceWrapper),
+                    isActiveLoaded = true,
+                    nowMillis = now,
+                )
+            }
+        }
+        scope.launch(interactor.observeRecent(HOME_RECENT_LIMIT)) { sessions ->
+            updateStateImmediate { current ->
+                val now = if (current.nowMillis == 0L) System.currentTimeMillis() else current.nowMillis
+                current.copy(
+                    recent = sessions.toRecentItems(now, resourceWrapper),
+                    isRecentLoaded = true,
+                    nowMillis = now,
                 )
             }
         }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/NavigationHandler.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/NavigationHandler.kt
@@ -13,14 +13,26 @@ internal class NavigationHandler(
 
     override fun invoke(action: Action.Navigation) {
         when (action) {
-            is Action.Navigation.OpenLiveWorkout -> navigator.navTo(
+            is Action.Navigation.OpenLiveWorkoutResume -> navigator.navTo(
                 Screen.LiveWorkout(
                     sessionUuid = action.sessionUuid,
                     trainingUuid = null,
                 ),
             )
 
+            is Action.Navigation.OpenLiveWorkoutFresh -> navigator.navTo(
+                Screen.LiveWorkout(
+                    sessionUuid = null,
+                    trainingUuid = action.trainingUuid,
+                ),
+            )
+
+            is Action.Navigation.OpenPastSession -> navigator.navTo(
+                Screen.PastSession(sessionUuid = action.sessionUuid),
+            )
+
             Action.Navigation.OpenSettings -> navigator.navTo(Screen.Settings)
+            Action.Navigation.OpenAllTrainings -> navigator.navTo(Screen.BottomBar.AllTrainings)
         }
     }
 }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/mapper/HomeUiMapper.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/mapper/HomeUiMapper.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.mvi.mapper
+
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.core.time.formatElapsedDuration
+import io.github.stslex.workeeper.core.core.time.formatRelativeTime
+import io.github.stslex.workeeper.core.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.exercise.session.model.RecentSessionDataModel
+import io.github.stslex.workeeper.core.exercise.training.TrainingListItem
+import io.github.stslex.workeeper.feature.home.R
+import io.github.stslex.workeeper.feature.home.mvi.model.PickerTrainingItem
+import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
+import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State.ActiveSessionInfo
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+internal fun SessionRepository.ActiveSessionWithStats.toUi(
+    nowMillis: Long,
+    resourceWrapper: ResourceWrapper,
+): ActiveSessionInfo = ActiveSessionInfo(
+    sessionUuid = sessionUuid,
+    trainingUuid = trainingUuid,
+    trainingName = if (isAdhoc) {
+        resourceWrapper.getString(R.string.feature_home_recent_adhoc_label)
+    } else {
+        trainingName
+    },
+    startedAt = startedAt,
+    doneCount = doneCount,
+    totalCount = totalCount,
+    elapsedDurationLabel = formatElapsedDuration(nowMillis - startedAt),
+)
+
+internal fun List<RecentSessionDataModel>.toRecentItems(
+    nowMillis: Long,
+    resourceWrapper: ResourceWrapper,
+): ImmutableList<RecentSessionItem> = map { session ->
+    val trainingName = if (session.isAdhoc) {
+        resourceWrapper.getString(R.string.feature_home_recent_adhoc_label)
+    } else {
+        session.trainingName
+    }
+    val statsLabel = resourceWrapper.getString(
+        R.string.feature_home_recent_stats_format,
+        resourceWrapper.getQuantityString(
+            R.plurals.feature_home_recent_exercises_count,
+            session.exerciseCount,
+            session.exerciseCount,
+        ),
+        resourceWrapper.getQuantityString(
+            R.plurals.feature_home_recent_sets_count,
+            session.setCount,
+            session.setCount,
+        ),
+    )
+    RecentSessionItem(
+        sessionUuid = session.sessionUuid,
+        trainingName = trainingName,
+        isAdhoc = session.isAdhoc,
+        finishedAtRelativeLabel = formatRelativeTime(nowMillis, session.finishedAt),
+        durationLabel = formatElapsedDuration(session.finishedAt - session.startedAt),
+        statsLabel = statsLabel,
+    )
+}.toImmutableList()
+
+internal fun List<TrainingListItem>.toPickerItems(
+    nowMillis: Long,
+    resourceWrapper: ResourceWrapper,
+): ImmutableList<PickerTrainingItem> = map { training ->
+    PickerTrainingItem(
+        trainingUuid = training.data.uuid,
+        name = training.data.name,
+        exerciseCountLabel = resourceWrapper.getQuantityString(
+            R.plurals.feature_home_recent_exercises_count,
+            training.exerciseCount,
+            training.exerciseCount,
+        ),
+        lastSessionRelativeLabel = training.lastSessionAt?.let {
+            formatRelativeTime(nowMillis, it)
+        },
+    )
+}.toImmutableList()

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/model/PickerTrainingItem.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/model/PickerTrainingItem.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.mvi.model
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Row in the training-picker bottom sheet. Pre-formatted strings come from
+ * `HomeUiMapper`; the picker Composable renders them as-is.
+ */
+@Stable
+data class PickerTrainingItem(
+    val trainingUuid: String,
+    val name: String,
+    val exerciseCountLabel: String,
+    val lastSessionRelativeLabel: String?,
+)

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/model/RecentSessionItem.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/model/RecentSessionItem.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.mvi.model
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Pre-formatted UI row for the Home recent-sessions list. All display text is shaped by
+ * `HomeUiMapper`; the Composable just renders the strings.
+ */
+@Stable
+data class RecentSessionItem(
+    val sessionUuid: String,
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val finishedAtRelativeLabel: String,
+    val durationLabel: String,
+    val statsLabel: String,
+)

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/store/HomeStore.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/mvi/store/HomeStore.kt
@@ -4,14 +4,21 @@ package io.github.stslex.workeeper.feature.home.mvi.store
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.mvi.Store
+import io.github.stslex.workeeper.feature.home.mvi.model.PickerTrainingItem
+import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal interface HomeStore : Store<HomeStore.State, HomeStore.Action, HomeStore.Event> {
 
     @Stable
     data class State(
         val activeSession: ActiveSessionInfo?,
+        val recent: ImmutableList<RecentSessionItem>,
         val nowMillis: Long,
-        val isLoading: Boolean,
+        val isActiveLoaded: Boolean,
+        val isRecentLoaded: Boolean,
+        val picker: PickerState,
     ) : Store.State {
 
         @Stable
@@ -27,11 +34,33 @@ internal interface HomeStore : Store<HomeStore.State, HomeStore.Action, HomeStor
             fun elapsedMillis(now: Long): Long = (now - startedAt).coerceAtLeast(0L)
         }
 
+        @Stable
+        sealed interface PickerState {
+            @Stable
+            data object Hidden : PickerState
+
+            @Stable
+            data class Visible(
+                val templates: ImmutableList<PickerTrainingItem>,
+                val isLoading: Boolean,
+            ) : PickerState
+        }
+
+        val isLoading: Boolean get() = !isActiveLoaded || !isRecentLoaded
+        val showStartCta: Boolean get() = activeSession == null && !isLoading
+        val showRecentList: Boolean get() = recent.isNotEmpty()
+        val showEmptyState: Boolean
+            get() = !isLoading && activeSession == null && recent.isEmpty()
+        val showPicker: Boolean get() = picker is PickerState.Visible
+
         companion object {
             val INITIAL = State(
                 activeSession = null,
+                recent = persistentListOf(),
                 nowMillis = 0L,
-                isLoading = true,
+                isActiveLoaded = false,
+                isRecentLoaded = false,
+                picker = PickerState.Hidden,
             )
         }
     }
@@ -42,11 +71,19 @@ internal interface HomeStore : Store<HomeStore.State, HomeStore.Action, HomeStor
         sealed interface Click : Action {
             data object OnActiveSessionClick : Click
             data object OnSettingsClick : Click
+            data class OnRecentSessionClick(val sessionUuid: String) : Click
+            data object OnStartTrainingClick : Click
+            data class OnPickerTrainingSelected(val trainingUuid: String) : Click
+            data object OnPickerSeeAllClick : Click
+            data object OnPickerDismiss : Click
         }
 
         sealed interface Navigation : Action {
-            data class OpenLiveWorkout(val sessionUuid: String) : Navigation
+            data class OpenLiveWorkoutResume(val sessionUuid: String) : Navigation
+            data class OpenLiveWorkoutFresh(val trainingUuid: String) : Navigation
+            data class OpenPastSession(val sessionUuid: String) : Navigation
             data object OpenSettings : Navigation
+            data object OpenAllTrainings : Navigation
         }
 
         sealed interface Common : Action {

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/HomeGraph.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/HomeGraph.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
 import io.github.stslex.workeeper.feature.home.di.HomeFeature
+import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Event
+import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State
+import io.github.stslex.workeeper.feature.home.ui.components.TrainingPickerSheet
 
 fun NavGraphBuilder.homeGraph(
     modifier: Modifier = Modifier,
@@ -20,10 +23,22 @@ fun NavGraphBuilder.homeGraph(
             }
         }
 
+        val state = processor.state.value
         HomeScreen(
             modifier = modifier,
-            state = processor.state.value,
+            state = state,
             consume = processor::consume,
         )
+
+        (state.picker as? State.PickerState.Visible)?.let { visible ->
+            TrainingPickerSheet(
+                state = visible,
+                onSelect = { uuid ->
+                    processor.consume(Action.Click.OnPickerTrainingSelected(trainingUuid = uuid))
+                },
+                onSeeAll = { processor.consume(Action.Click.OnPickerSeeAllClick) },
+                onDismiss = { processor.consume(Action.Click.OnPickerDismiss) },
+            )
+        }
     }
 }

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/HomeScreen.kt
@@ -2,18 +2,19 @@
 package io.github.stslex.workeeper.feature.home.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -26,9 +27,13 @@ import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
 import io.github.stslex.workeeper.feature.home.R
+import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State
 import io.github.stslex.workeeper.feature.home.ui.components.ActiveSessionBanner
+import io.github.stslex.workeeper.feature.home.ui.components.HomeStartCard
+import io.github.stslex.workeeper.feature.home.ui.components.RecentSessionRow
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun HomeScreen(
@@ -36,7 +41,7 @@ internal fun HomeScreen(
     consume: (Action) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    androidx.compose.foundation.layout.Column(
         modifier = modifier
             .fillMaxSize()
             .background(AppUi.colors.surfaceTier0)
@@ -56,28 +61,77 @@ internal fun HomeScreen(
             },
         )
         when {
-            state.isLoading -> AppLoadingIndicator(
+            state.isLoading -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) { AppLoadingIndicator() }
+
+            state.showEmptyState -> EmptyContent(
+                onStart = { consume(Action.Click.OnStartTrainingClick) },
                 modifier = Modifier.fillMaxSize(),
             )
 
-            state.activeSession != null -> Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = AppDimension.screenEdge),
-            ) {
-                Spacer(Modifier.height(AppDimension.Space.lg))
+            else -> ListContent(
+                state = state,
+                consume = consume,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyContent(
+    onStart: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        AppEmptyState(
+            headline = stringResource(R.string.feature_home_empty_headline),
+            supportingText = stringResource(R.string.feature_home_empty_supporting),
+            icon = Icons.Filled.FitnessCenter,
+            actionLabel = stringResource(R.string.feature_home_start_cta_title),
+            onAction = onStart,
+        )
+    }
+}
+
+@Composable
+private fun ListContent(
+    state: State,
+    consume: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(
+            horizontal = AppDimension.screenEdge,
+            vertical = AppDimension.Space.md,
+        ),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+    ) {
+        state.activeSession?.let { session ->
+            item(key = "active") {
                 ActiveSessionBanner(
-                    info = state.activeSession,
+                    info = session,
                     onClick = { consume(Action.Click.OnActiveSessionClick) },
                 )
             }
-
-            else -> AppEmptyState(
-                modifier = Modifier.fillMaxSize(),
-                headline = stringResource(R.string.feature_home_empty_headline),
-                supportingText = stringResource(R.string.feature_home_empty_supporting),
-                icon = Icons.Filled.FitnessCenter,
-            )
+        }
+        if (state.showStartCta) {
+            item(key = "start") {
+                HomeStartCard(onClick = { consume(Action.Click.OnStartTrainingClick) })
+            }
+        }
+        if (state.showRecentList) {
+            items(items = state.recent, key = { it.sessionUuid }) { recent ->
+                RecentSessionRow(
+                    item = recent,
+                    onClick = {
+                        consume(Action.Click.OnRecentSessionClick(sessionUuid = recent.sessionUuid))
+                    },
+                )
+            }
         }
     }
 }
@@ -87,26 +141,7 @@ internal fun HomeScreen(
 private fun HomeScreenEmptyLightPreview() {
     AppTheme(themeMode = ThemeMode.LIGHT) {
         HomeScreen(
-            state = State(
-                activeSession = null,
-                nowMillis = 0L,
-                isLoading = false,
-            ),
-            consume = {},
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun HomeScreenEmptyDarkPreview() {
-    AppTheme(themeMode = ThemeMode.DARK) {
-        HomeScreen(
-            state = State(
-                activeSession = null,
-                nowMillis = 0L,
-                isLoading = false,
-            ),
+            state = State.INITIAL.copy(isActiveLoaded = true, isRecentLoaded = true),
             consume = {},
         )
     }
@@ -117,8 +152,8 @@ private fun HomeScreenEmptyDarkPreview() {
 private fun HomeScreenWithSessionPreview() {
     AppTheme(themeMode = ThemeMode.DARK) {
         HomeScreen(
-            state = State(
-                activeSession = io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State.ActiveSessionInfo(
+            state = State.INITIAL.copy(
+                activeSession = State.ActiveSessionInfo(
                     sessionUuid = "s",
                     trainingUuid = "t",
                     trainingName = "Push Day",
@@ -128,7 +163,32 @@ private fun HomeScreenWithSessionPreview() {
                     elapsedDurationLabel = "12:34",
                 ),
                 nowMillis = 12 * 60_000L + 34_000L,
-                isLoading = false,
+                isActiveLoaded = true,
+                isRecentLoaded = true,
+            ),
+            consume = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HomeScreenStartCtaWithRecentPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        HomeScreen(
+            state = State.INITIAL.copy(
+                isActiveLoaded = true,
+                isRecentLoaded = true,
+                recent = persistentListOf(
+                    RecentSessionItem(
+                        sessionUuid = "s1",
+                        trainingName = "Push day",
+                        isAdhoc = false,
+                        finishedAtRelativeLabel = "Yesterday",
+                        durationLabel = "47:12",
+                        statsLabel = "5 exercises · 18 sets",
+                    ),
+                ),
             ),
             consume = {},
         )

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/HomeStartCard.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/HomeStartCard.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.card.AppCard
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.home.R
+
+@Composable
+internal fun HomeStartCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("HomeStartCard"),
+        onClick = onClick,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.PlayArrow,
+                contentDescription = null,
+                tint = AppUi.colors.accent,
+            )
+            Text(
+                text = stringResource(R.string.feature_home_start_cta_title),
+                style = AppUi.typography.titleLarge,
+                color = AppUi.colors.textPrimary,
+            )
+            Text(
+                text = stringResource(R.string.feature_home_start_cta_subtitle),
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+        }
+    }
+}
+
+@Preview(name = "Light")
+@Composable
+private fun HomeStartCardLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        HomeStartCard(onClick = {})
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun HomeStartCardDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        HomeStartCard(onClick = {})
+    }
+}

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/RecentSessionRow.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/RecentSessionRow.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.card.AppCard
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
+
+@Composable
+internal fun RecentSessionRow(
+    item: RecentSessionItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppCard(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xxs),
+        ) {
+            Text(
+                text = item.trainingName,
+                style = AppUi.typography.titleMedium,
+                color = AppUi.colors.textPrimary,
+            )
+            Text(
+                text = item.statsLabel,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+            Text(
+                text = "${item.finishedAtRelativeLabel} · ${item.durationLabel}",
+                style = AppUi.typography.labelSmall,
+                color = AppUi.colors.textTertiary,
+            )
+        }
+    }
+}
+
+@Preview(name = "Light")
+@Composable
+private fun RecentSessionRowLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        RecentSessionRow(item = stubItem(), onClick = {})
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun RecentSessionRowDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        RecentSessionRow(item = stubItem(), onClick = {})
+    }
+}
+
+private fun stubItem(): RecentSessionItem = RecentSessionItem(
+    sessionUuid = "s",
+    trainingName = "Push day",
+    isAdhoc = false,
+    finishedAtRelativeLabel = "2 days ago",
+    durationLabel = "47:00",
+    statsLabel = "5 exercises · 18 sets",
+)

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/TrainingPickerSheet.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/TrainingPickerSheet.kt
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.home.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.empty.AppEmptyState
+import io.github.stslex.workeeper.core.ui.kit.components.loading.AppLoadingIndicator
+import io.github.stslex.workeeper.core.ui.kit.components.sheet.AppBottomSheet
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.home.R
+import io.github.stslex.workeeper.feature.home.mvi.model.PickerTrainingItem
+import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun TrainingPickerSheet(
+    state: State.PickerState.Visible,
+    onSelect: (String) -> Unit,
+    onSeeAll: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AppBottomSheet(
+        onDismiss = onDismiss,
+        modifier = Modifier.testTag("TrainingPickerSheet"),
+    ) {
+        Text(
+            text = stringResource(R.string.feature_home_picker_title),
+            style = AppUi.typography.titleLarge,
+            color = AppUi.colors.textPrimary,
+        )
+        when {
+            state.isLoading -> Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = AppDimension.Space.xl),
+                contentAlignment = Alignment.Center,
+            ) { AppLoadingIndicator() }
+
+            state.templates.isEmpty() -> AppEmptyState(
+                headline = stringResource(R.string.feature_home_picker_empty),
+            )
+
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+            ) {
+                items(items = state.templates, key = { it.trainingUuid }) { template ->
+                    PickerRow(template = template, onClick = { onSelect(template.trainingUuid) })
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onSeeAll)
+                .padding(vertical = AppDimension.Space.md),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.feature_home_picker_see_all),
+                style = AppUi.typography.labelLarge,
+                color = AppUi.colors.accent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PickerRow(
+    template: PickerTrainingItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = AppDimension.Space.sm),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xxs),
+    ) {
+        Text(
+            text = template.name,
+            style = AppUi.typography.titleMedium,
+            color = AppUi.colors.textPrimary,
+        )
+        val subtitle = listOfNotNull(
+            template.exerciseCountLabel,
+            template.lastSessionRelativeLabel,
+        ).joinToString(separator = " · ")
+        if (subtitle.isNotBlank()) {
+            Text(
+                text = subtitle,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+        }
+    }
+}
+
+@Preview(name = "Loaded — Light")
+@Composable
+private fun TrainingPickerSheetLoadedLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        TrainingPickerSheet(
+            state = State.PickerState.Visible(
+                templates = persistentListOf(
+                    PickerTrainingItem(
+                        trainingUuid = "t1",
+                        name = "Push day",
+                        exerciseCountLabel = "6 exercises",
+                        lastSessionRelativeLabel = "3 days ago",
+                    ),
+                ),
+                isLoading = false,
+            ),
+            onSelect = {},
+            onSeeAll = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(name = "Loading — Dark")
+@Composable
+private fun TrainingPickerSheetLoadingDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        TrainingPickerSheet(
+            state = State.PickerState.Visible(templates = persistentListOf(), isLoading = true),
+            onSelect = {},
+            onSeeAll = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(name = "Empty — Dark")
+@Composable
+private fun TrainingPickerSheetEmptyDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        TrainingPickerSheet(
+            state = State.PickerState.Visible(templates = persistentListOf(), isLoading = false),
+            onSelect = {},
+            onSeeAll = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/feature/home/src/main/res/values-ru/strings.xml
+++ b/feature/home/src/main/res/values-ru/strings.xml
@@ -9,7 +9,6 @@
 
     <string name="feature_home_start_cta_title">Начать тренировку</string>
     <string name="feature_home_start_cta_subtitle">Выберите шаблон тренировки</string>
-    <string name="feature_home_recent_section_title">Недавние сессии</string>
     <string name="feature_home_recent_adhoc_label">Свободная тренировка</string>
     <string name="feature_home_recent_stats_format">%1$s · %2$s</string>
 

--- a/feature/home/src/main/res/values-ru/strings.xml
+++ b/feature/home/src/main/res/values-ru/strings.xml
@@ -4,6 +4,30 @@
     <string name="feature_home_active_session_label">Сессия в процессе</string>
     <string name="feature_home_active_session_progress_format">%1$d из %2$d</string>
     <string name="feature_home_empty_headline">Готовы тренироваться</string>
-    <string name="feature_home_empty_supporting">Начните тренировку на вкладке Тренировки</string>
+    <string name="feature_home_empty_supporting">Начните тренировку, чтобы записать первую сессию</string>
     <string name="feature_home_settings">Настройки</string>
+
+    <string name="feature_home_start_cta_title">Начать тренировку</string>
+    <string name="feature_home_start_cta_subtitle">Выберите шаблон тренировки</string>
+    <string name="feature_home_recent_section_title">Недавние сессии</string>
+    <string name="feature_home_recent_adhoc_label">Свободная тренировка</string>
+    <string name="feature_home_recent_stats_format">%1$s · %2$s</string>
+
+    <string name="feature_home_picker_title">Выберите тренировку</string>
+    <string name="feature_home_picker_see_all">Все шаблоны</string>
+    <string name="feature_home_picker_empty">Пока нет шаблонов</string>
+
+    <plurals name="feature_home_recent_exercises_count">
+        <item quantity="one">%d упражнение</item>
+        <item quantity="few">%d упражнения</item>
+        <item quantity="many">%d упражнений</item>
+        <item quantity="other">%d упражнений</item>
+    </plurals>
+
+    <plurals name="feature_home_recent_sets_count">
+        <item quantity="one">%d подход</item>
+        <item quantity="few">%d подхода</item>
+        <item quantity="many">%d подходов</item>
+        <item quantity="other">%d подходов</item>
+    </plurals>
 </resources>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
 
     <string name="feature_home_start_cta_title">Start a workout</string>
     <string name="feature_home_start_cta_subtitle">Pick a training template</string>
-    <string name="feature_home_recent_section_title">Recent sessions</string>
     <string name="feature_home_recent_adhoc_label">Ad-hoc workout</string>
     <string name="feature_home_recent_stats_format">%1$s · %2$s</string>
 

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -4,6 +4,26 @@
     <string name="feature_home_active_session_label">Session in progress</string>
     <string name="feature_home_active_session_progress_format" tools:ignore="PluralsCandidate">%1$d of %2$d done</string>
     <string name="feature_home_empty_headline">Ready when you are</string>
-    <string name="feature_home_empty_supporting">Start a training from the Trainings tab</string>
+    <string name="feature_home_empty_supporting">Start a training to log your first session</string>
     <string name="feature_home_settings">Settings</string>
+
+    <string name="feature_home_start_cta_title">Start a workout</string>
+    <string name="feature_home_start_cta_subtitle">Pick a training template</string>
+    <string name="feature_home_recent_section_title">Recent sessions</string>
+    <string name="feature_home_recent_adhoc_label">Ad-hoc workout</string>
+    <string name="feature_home_recent_stats_format">%1$s · %2$s</string>
+
+    <string name="feature_home_picker_title">Choose a training</string>
+    <string name="feature_home_picker_see_all">See all templates</string>
+    <string name="feature_home_picker_empty">No templates yet</string>
+
+    <plurals name="feature_home_recent_exercises_count">
+        <item quantity="one">%d exercise</item>
+        <item quantity="other">%d exercises</item>
+    </plurals>
+
+    <plurals name="feature_home_recent_sets_count">
+        <item quantity="one">%d set</item>
+        <item quantity="other">%d sets</item>
+    </plurals>
 </resources>

--- a/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractorImplTest.kt
+++ b/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/domain/HomeInteractorImplTest.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.home.domain
 
 import io.github.stslex.workeeper.core.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.exercise.training.TrainingRepository
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -9,39 +10,33 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class HomeInteractorImplTest {
 
     private val sessionRepository = mockk<SessionRepository>(relaxed = true)
+    private val trainingRepository = mockk<TrainingRepository>(relaxed = true)
     private val interactor = HomeInteractorImpl(
         sessionRepository = sessionRepository,
+        trainingRepository = trainingRepository,
         defaultDispatcher = Dispatchers.Unconfined,
     )
 
     @Test
-    fun `observeActiveSession maps repository model to Home ActiveSessionInfo`() = runTest {
-        every { sessionRepository.observeActiveSessionWithStats() } returns flowOf(
-            SessionRepository.ActiveSessionWithStats(
-                sessionUuid = "session-1",
-                trainingUuid = "training-1",
-                trainingName = "Push Day",
-                isAdhoc = false,
-                startedAt = 123L,
-                totalCount = 5,
-                doneCount = 2,
-            ),
+    fun `observeActiveSession forwards repository ActiveSessionWithStats`() = runTest {
+        val row = SessionRepository.ActiveSessionWithStats(
+            sessionUuid = "session-1",
+            trainingUuid = "training-1",
+            trainingName = "Push Day",
+            isAdhoc = false,
+            startedAt = 123L,
+            totalCount = 5,
+            doneCount = 2,
         )
+        every { sessionRepository.observeActiveSessionWithStats() } returns flowOf(row)
 
         val mapped = interactor.observeActiveSession().first()
 
-        assertEquals("session-1", mapped?.sessionUuid)
-        assertEquals("training-1", mapped?.trainingUuid)
-        assertEquals("Push Day", mapped?.trainingName)
-        assertEquals(123L, mapped?.startedAt)
-        assertEquals(5, mapped?.totalCount)
-        assertEquals(2, mapped?.doneCount)
-        assertTrue(mapped?.elapsedDurationLabel?.isNotBlank() == true)
+        assertEquals(row, mapped)
     }
 }

--- a/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/ClickHandlerTest.kt
+++ b/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/ClickHandlerTest.kt
@@ -2,7 +2,10 @@
 package io.github.stslex.workeeper.feature.home.mvi.handler
 
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import io.github.stslex.workeeper.core.core.coroutine.scope.AppCoroutineScope
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.feature.home.di.HomeHandlerStore
+import io.github.stslex.workeeper.feature.home.domain.HomeInteractor
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Event
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.State
@@ -10,18 +13,22 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class ClickHandlerTest {
 
-    private val baseState = State.INITIAL.copy(isLoading = false)
+    private val baseState = State.INITIAL.copy(isActiveLoaded = true, isRecentLoaded = true)
+    private val interactor = mockk<HomeInteractor>(relaxed = true)
+    private val resources = mockk<ResourceWrapper>(relaxed = true)
 
     @Test
     fun `OnSettingsClick consumes OpenSettings navigation and emits HapticClick`() {
         val store = newStore(baseState)
-        val handler = ClickHandler(store)
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
 
         handler.invoke(Action.Click.OnSettingsClick)
 
@@ -34,7 +41,7 @@ internal class ClickHandlerTest {
     @Test
     fun `OnActiveSessionClick is a no-op when no active session`() {
         val store = newStore(baseState)
-        val handler = ClickHandler(store)
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
 
         handler.invoke(Action.Click.OnActiveSessionClick)
 
@@ -42,7 +49,7 @@ internal class ClickHandlerTest {
     }
 
     @Test
-    fun `OnActiveSessionClick consumes OpenLiveWorkout with the session uuid`() {
+    fun `OnActiveSessionClick consumes OpenLiveWorkoutResume with the session uuid`() {
         val active = State.ActiveSessionInfo(
             sessionUuid = "session-7",
             trainingUuid = "training-1",
@@ -53,22 +60,69 @@ internal class ClickHandlerTest {
             elapsedDurationLabel = "00:10",
         )
         val store = newStore(baseState.copy(activeSession = active))
-        val handler = ClickHandler(store)
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
 
         handler.invoke(Action.Click.OnActiveSessionClick)
 
         verify(exactly = 1) {
-            store.consume(Action.Navigation.OpenLiveWorkout(sessionUuid = "session-7"))
+            store.consume(Action.Navigation.OpenLiveWorkoutResume(sessionUuid = "session-7"))
         }
         val captured = slot<Event>()
         verify(exactly = 1) { store.sendEvent(capture(captured)) }
         assertEquals(HapticFeedbackType.ContextClick, (captured.captured as Event.HapticClick).type)
     }
 
+    @Test
+    fun `OnRecentSessionClick consumes OpenPastSession with the session uuid`() {
+        val store = newStore(baseState)
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
+
+        handler.invoke(Action.Click.OnRecentSessionClick(sessionUuid = "session-22"))
+
+        verify(exactly = 1) {
+            store.consume(Action.Navigation.OpenPastSession(sessionUuid = "session-22"))
+        }
+    }
+
+    @Test
+    fun `OnPickerSeeAllClick hides picker and consumes OpenAllTrainings`() {
+        val visiblePicker = State.PickerState.Visible(
+            templates = kotlinx.collections.immutable.persistentListOf(),
+            isLoading = false,
+        )
+        val store = newStore(baseState.copy(picker = visiblePicker))
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
+
+        handler.invoke(Action.Click.OnPickerSeeAllClick)
+
+        verify(exactly = 1) { store.consume(Action.Navigation.OpenAllTrainings) }
+    }
+
+    @Test
+    fun `OnPickerTrainingSelected consumes OpenLiveWorkoutFresh with the training uuid`() {
+        val visiblePicker = State.PickerState.Visible(
+            templates = kotlinx.collections.immutable.persistentListOf(),
+            isLoading = false,
+        )
+        val store = newStore(baseState.copy(picker = visiblePicker))
+        val handler = ClickHandler(interactor = interactor, resourceWrapper = resources, store = store)
+
+        handler.invoke(Action.Click.OnPickerTrainingSelected(trainingUuid = "tpl-1"))
+
+        verify(exactly = 1) {
+            store.consume(Action.Navigation.OpenLiveWorkoutFresh(trainingUuid = "tpl-1"))
+        }
+    }
+
     private fun newStore(state: State): HomeHandlerStore {
         val flow = MutableStateFlow(state)
         return mockk(relaxed = true) {
             every { this@mockk.state } returns flow
+            every { scope } returns AppCoroutineScope(
+                scope = TestScope(),
+                defaultDispatcher = Dispatchers.Unconfined,
+                immediateDispatcher = Dispatchers.Unconfined,
+            )
         }
     }
 }

--- a/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/CommonHandlerTest.kt
+++ b/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/CommonHandlerTest.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.home.mvi.handler
 
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.feature.home.di.HomeHandlerStore
 import io.github.stslex.workeeper.feature.home.domain.HomeInteractor
 import io.github.stslex.workeeper.feature.home.mvi.store.HomeStore.Action
@@ -14,10 +15,11 @@ import org.junit.jupiter.api.Test
 internal class CommonHandlerTest {
 
     private val interactor = mockk<HomeInteractor>(relaxed = true)
+    private val resources = mockk<ResourceWrapper>(relaxed = true)
 
     @Test
     fun `TimerTick updates nowMillis`() {
-        val stateFlow = MutableStateFlow(State.INITIAL.copy(isLoading = false))
+        val stateFlow = MutableStateFlow(State.INITIAL.copy(isActiveLoaded = true, isRecentLoaded = true))
         val store = mockk<HomeHandlerStore>(relaxed = true).apply {
             every { state } returns stateFlow
             every { updateState(any()) } answers {
@@ -25,7 +27,11 @@ internal class CommonHandlerTest {
                 stateFlow.value = update(stateFlow.value)
             }
         }
-        val handler = CommonHandler(interactor = interactor, store = store)
+        val handler = CommonHandler(
+            interactor = interactor,
+            resourceWrapper = resources,
+            store = store,
+        )
 
         handler.invoke(Action.Common.TimerTick)
 

--- a/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/home/src/test/kotlin/io/github/stslex/workeeper/feature/home/mvi/handler/NavigationHandlerTest.kt
@@ -14,15 +14,30 @@ internal class NavigationHandlerTest {
     private val handler = NavigationHandler(navigator = navigator)
 
     @Test
-    fun `OpenLiveWorkout navigates to LiveWorkout with the active session uuid`() {
-        handler.invoke(Action.Navigation.OpenLiveWorkout(sessionUuid = "session-7"))
+    fun `OpenLiveWorkoutResume navigates to LiveWorkout with the active session uuid`() {
+        handler.invoke(Action.Navigation.OpenLiveWorkoutResume(sessionUuid = "session-7"))
         verify(exactly = 1) {
             navigator.navTo(
-                Screen.LiveWorkout(
-                    sessionUuid = "session-7",
-                    trainingUuid = null,
-                ),
+                Screen.LiveWorkout(sessionUuid = "session-7", trainingUuid = null),
             )
+        }
+    }
+
+    @Test
+    fun `OpenLiveWorkoutFresh navigates to LiveWorkout with the training uuid`() {
+        handler.invoke(Action.Navigation.OpenLiveWorkoutFresh(trainingUuid = "training-3"))
+        verify(exactly = 1) {
+            navigator.navTo(
+                Screen.LiveWorkout(sessionUuid = null, trainingUuid = "training-3"),
+            )
+        }
+    }
+
+    @Test
+    fun `OpenPastSession navigates to PastSession with the session uuid`() {
+        handler.invoke(Action.Navigation.OpenPastSession(sessionUuid = "session-9"))
+        verify(exactly = 1) {
+            navigator.navTo(Screen.PastSession(sessionUuid = "session-9"))
         }
     }
 
@@ -30,5 +45,11 @@ internal class NavigationHandlerTest {
     fun `OpenSettings navigates to Settings`() {
         handler.invoke(Action.Navigation.OpenSettings)
         verify(exactly = 1) { navigator.navTo(Screen.Settings) }
+    }
+
+    @Test
+    fun `OpenAllTrainings navigates to AllTrainings bottom-bar destination`() {
+        handler.invoke(Action.Navigation.OpenAllTrainings)
+        verify(exactly = 1) { navigator.navTo(Screen.BottomBar.AllTrainings) }
     }
 }

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandler.kt
@@ -293,7 +293,7 @@ internal class ClickHandler @Inject constructor(
                         message = resourceWrapper.getString(R.string.feature_live_workout_finish_success),
                     ),
                 )
-                consumeOnMain(Action.Navigation.Back)
+                consumeOnMain(Action.Navigation.OpenPastSession(sessionUuid = sessionUuid))
             },
             onError = { _ -> sendError(ErrorType.FinishFailed) },
         ) {

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandler.kt
@@ -15,11 +15,8 @@ internal class NavigationHandler(
     override fun invoke(action: Action.Navigation) {
         when (action) {
             Action.Navigation.Back -> navigator.popBack()
-            Action.Navigation.BackToHome -> {
-                // Pop until the user lands back on the bottom-tab Home — the same
-                // popBack works because Live workout sits one detail deep from Home.
-                navigator.popBack()
-            }
+            is Action.Navigation.OpenPastSession ->
+                navigator.replaceTo(Screen.PastSession(sessionUuid = action.sessionUuid))
         }
     }
 }

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStore.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStore.kt
@@ -156,7 +156,7 @@ internal interface LiveWorkoutStore :
 
         sealed interface Navigation : Action {
             data object Back : Navigation
-            data object BackToHome : Navigation
+            data class OpenPastSession(val sessionUuid: String) : Navigation
         }
 
         sealed interface Common : Action {

--- a/feature/past-session/build.gradle.kts
+++ b/feature/past-session/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.convention.composeLibrary)
+}
+
+dependencies {
+    implementation(project(":core:core"))
+
+    implementation(project(":core:ui:kit"))
+    implementation(project(":core:ui:mvi"))
+    implementation(project(":core:ui:navigation"))
+    implementation(project(":core:ui:plan-editor"))
+    implementation(project(":core:database"))
+    implementation(project(":core:exercise"))
+
+    testImplementation(kotlin("test"))
+
+    androidTestImplementation(libs.bundles.android.test)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(project(":core:ui:test-utils"))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionFeature.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionFeature.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.di
+
+import androidx.compose.runtime.Composable
+import io.github.stslex.workeeper.core.ui.mvi.Feature
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreProcessor
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.PastSessionComponent
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStoreImpl
+
+internal typealias PastSessionStoreProcessor = StoreProcessor<State, Action, Event>
+
+internal object PastSessionFeature :
+    Feature<PastSessionStoreProcessor, Screen.PastSession, PastSessionComponent>() {
+
+    @Composable
+    override fun processor(
+        screen: Screen.PastSession,
+    ): PastSessionStoreProcessor =
+        createProcessor<PastSessionStoreImpl, PastSessionStoreImpl.Factory>(screen)
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionHandlerStore.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionHandlerStore.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.di
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.HandlerStore
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+
+internal interface PastSessionHandlerStore : HandlerStore<State, Action, Event>

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionHandlerStoreImpl.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionHandlerStoreImpl.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.di
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.BaseHandlerStore
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class PastSessionHandlerStoreImpl @Inject constructor() :
+    PastSessionHandlerStore,
+    BaseHandlerStore<State, Action, Event>()

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionModule.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/di/PastSessionModule.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.feature.past_session.domain.PastSessionInteractor
+import io.github.stslex.workeeper.feature.past_session.domain.PastSessionInteractorImpl
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal interface PastSessionModule {
+
+    @Binds
+    @ViewModelScoped
+    fun bindInteractor(impl: PastSessionInteractorImpl): PastSessionInteractor
+
+    @Binds
+    @ViewModelScoped
+    fun bindHandlerStore(impl: PastSessionHandlerStoreImpl): PastSessionHandlerStore
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractor.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractor.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.domain
+
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+import io.github.stslex.workeeper.core.exercise.session.model.SessionDetailDataModel
+
+internal interface PastSessionInteractor {
+
+    suspend fun getSessionDetail(sessionUuid: String): SessionDetailDataModel?
+
+    suspend fun updateSet(
+        performedExerciseUuid: String,
+        position: Int,
+        set: SetsDataModel,
+    )
+
+    suspend fun deleteSession(sessionUuid: String)
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImpl.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImpl.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.domain
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+import io.github.stslex.workeeper.core.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.exercise.session.SetRepository
+import io.github.stslex.workeeper.core.exercise.session.model.SessionDetailDataModel
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class PastSessionInteractorImpl @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val setRepository: SetRepository,
+) : PastSessionInteractor {
+
+    override suspend fun getSessionDetail(
+        sessionUuid: String,
+    ): SessionDetailDataModel? = sessionRepository.getSessionDetail(sessionUuid)
+
+    override suspend fun updateSet(
+        performedExerciseUuid: String,
+        position: Int,
+        set: SetsDataModel,
+    ) {
+        setRepository.update(performedExerciseUuid, position, set)
+    }
+
+    override suspend fun deleteSession(sessionUuid: String) {
+        sessionRepository.deleteSession(sessionUuid)
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/ClickHandler.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/ClickHandler.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.past_session.di.PastSessionHandlerStore
+import io.github.stslex.workeeper.feature.past_session.domain.PastSessionInteractor
+import io.github.stslex.workeeper.feature.past_session.mvi.mapper.toSetsDataType
+import io.github.stslex.workeeper.feature.past_session.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import kotlinx.collections.immutable.toImmutableList
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ClickHandler @Inject constructor(
+    private val interactor: PastSessionInteractor,
+    store: PastSessionHandlerStore,
+) : Handler<Action.Click>, PastSessionHandlerStore by store {
+
+    override fun invoke(action: Action.Click) {
+        when (action) {
+            Action.Click.OnBackClick -> processBack()
+            Action.Click.OnDeleteClick -> processDeleteClick()
+            Action.Click.OnDeleteConfirm -> processDeleteConfirm()
+            Action.Click.OnDeleteDismiss -> processDeleteDismiss()
+            Action.Click.OnRetryLoad -> consume(Action.Common.Init)
+            is Action.Click.OnSetTypeChange -> processSetTypeChange(action)
+        }
+    }
+
+    private fun processBack() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        consume(Action.Navigation.Back)
+    }
+
+    private fun processDeleteClick() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { it.copy(deleteDialogVisible = true) }
+    }
+
+    private fun processDeleteDismiss() {
+        updateState { it.copy(deleteDialogVisible = false) }
+    }
+
+    private fun processDeleteConfirm() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.Confirm))
+        val sessionUuid = state.value.sessionUuid
+        updateState { it.copy(deleteDialogVisible = false) }
+        launch(
+            onSuccess = {
+                sendEvent(Event.DeletedSnackbar)
+                consumeOnMain(Action.Navigation.Back)
+            },
+            onError = { _ -> sendEvent(Event.ShowError(ErrorType.LoadFailed)) },
+        ) {
+            interactor.deleteSession(sessionUuid)
+        }
+    }
+
+    private fun processSetTypeChange(action: Action.Click.OnSetTypeChange) {
+        val current = state.value.phase as? State.Phase.Loaded ?: return
+        val updatedDetail = current.detail.copy(
+            exercises = current.detail.exercises.map { exercise ->
+                if (exercise.sets.none { it.setUuid == action.setUuid }) {
+                    exercise
+                } else {
+                    exercise.copy(
+                        sets = exercise.sets.map { set ->
+                            if (set.setUuid == action.setUuid) {
+                                set.copy(type = action.type)
+                            } else {
+                                set
+                            }
+                        }.toImmutableList(),
+                    )
+                }
+            }.toImmutableList(),
+        )
+        updateState {
+            it.copy(phase = State.Phase.Loaded(detail = updatedDetail))
+        }
+        val targetSet = updatedDetail
+            .exercises
+            .asSequence()
+            .flatMap { it.sets.asSequence() }
+            .firstOrNull { it.setUuid == action.setUuid } ?: return
+        val weight = targetSet.weightInput.toDoubleOrNull()
+        val reps = targetSet.repsInput.toIntOrNull() ?: return
+        persistSet(
+            performedExerciseUuid = targetSet.performedExerciseUuid,
+            position = targetSet.position,
+            setUuid = targetSet.setUuid,
+            weight = weight,
+            reps = reps,
+            type = action.type.toSetsDataType(),
+        )
+    }
+
+    private fun persistSet(
+        performedExerciseUuid: String,
+        position: Int,
+        setUuid: String,
+        weight: Double?,
+        reps: Int,
+        type: io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataType,
+    ) {
+        launch(
+            onError = { _ -> sendEvent(Event.SaveFailedSnackbar) },
+        ) {
+            interactor.updateSet(
+                performedExerciseUuid = performedExerciseUuid,
+                position = position,
+                set = SetsDataModel(
+                    uuid = setUuid,
+                    reps = reps,
+                    weight = weight,
+                    type = type,
+                ),
+            )
+        }
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/CommonHandler.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/CommonHandler.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.past_session.di.PastSessionHandlerStore
+import io.github.stslex.workeeper.feature.past_session.domain.PastSessionInteractor
+import io.github.stslex.workeeper.feature.past_session.mvi.mapper.toUi
+import io.github.stslex.workeeper.feature.past_session.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class CommonHandler @Inject constructor(
+    private val interactor: PastSessionInteractor,
+    private val resourceWrapper: ResourceWrapper,
+    store: PastSessionHandlerStore,
+) : Handler<Action.Common>, PastSessionHandlerStore by store {
+
+    override fun invoke(action: Action.Common) {
+        when (action) {
+            Action.Common.Init -> processInit()
+        }
+    }
+
+    private fun processInit() {
+        val sessionUuid = state.value.sessionUuid
+        updateState { it.copy(phase = State.Phase.Loading) }
+        launch(
+            onSuccess = { detail ->
+                if (detail == null) {
+                    updateStateImmediate {
+                        it.copy(phase = State.Phase.Error(ErrorType.SessionNotFound))
+                    }
+                } else {
+                    updateStateImmediate {
+                        it.copy(phase = State.Phase.Loaded(detail = detail.toUi(resourceWrapper)))
+                    }
+                }
+            },
+            onError = { _ ->
+                updateStateImmediate {
+                    it.copy(phase = State.Phase.Error(ErrorType.LoadFailed))
+                }
+            },
+        ) {
+            interactor.getSessionDetail(sessionUuid)
+        }
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/InputHandler.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/InputHandler.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.past_session.di.PastSessionHandlerStore
+import io.github.stslex.workeeper.feature.past_session.domain.PastSessionInteractor
+import io.github.stslex.workeeper.feature.past_session.mvi.mapper.toSetsDataType
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSetUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import kotlinx.collections.immutable.toImmutableList
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class InputHandler @Inject constructor(
+    private val interactor: PastSessionInteractor,
+    store: PastSessionHandlerStore,
+) : Handler<Action.Input>, PastSessionHandlerStore by store {
+
+    override fun invoke(action: Action.Input) {
+        when (action) {
+            is Action.Input.OnSetWeightChange -> processWeightChange(action)
+            is Action.Input.OnSetRepsChange -> processRepsChange(action)
+        }
+    }
+
+    private fun processWeightChange(action: Action.Input.OnSetWeightChange) {
+        val parsed = action.raw.takeIf { it.isNotBlank() }?.toDoubleOrNull()
+        val isValid = action.raw.isBlank() || (parsed != null && parsed >= 0.0)
+        val updatedSet = updateSetInState(action.setUuid) { set ->
+            set.copy(weightInput = action.raw, weightError = !isValid)
+        } ?: return
+        if (isValid) {
+            persistIfReady(updatedSet)
+        }
+    }
+
+    private fun processRepsChange(action: Action.Input.OnSetRepsChange) {
+        val parsed = action.raw.takeIf { it.isNotBlank() }?.toIntOrNull()
+        val isValid = parsed != null && parsed > 0
+        val updatedSet = updateSetInState(action.setUuid) { set ->
+            set.copy(repsInput = action.raw, repsError = !isValid)
+        } ?: return
+        if (isValid) {
+            persistIfReady(updatedSet)
+        }
+    }
+
+    private fun updateSetInState(
+        setUuid: String,
+        transform: (PastSetUiModel) -> PastSetUiModel,
+    ): PastSetUiModel? {
+        val current = state.value.phase as? State.Phase.Loaded ?: return null
+        var resultSet: PastSetUiModel? = null
+        val updatedDetail = current.detail.copy(
+            exercises = current.detail.exercises.map { exercise ->
+                if (exercise.sets.none { it.setUuid == setUuid }) {
+                    exercise
+                } else {
+                    exercise.copy(
+                        sets = exercise.sets.map { set ->
+                            if (set.setUuid == setUuid) {
+                                transform(set).also { resultSet = it }
+                            } else {
+                                set
+                            }
+                        }.toImmutableList(),
+                    )
+                }
+            }.toImmutableList(),
+        )
+        updateState {
+            it.copy(phase = State.Phase.Loaded(detail = updatedDetail))
+        }
+        return resultSet
+    }
+
+    private fun persistIfReady(set: PastSetUiModel) {
+        val reps = set.repsInput.toIntOrNull() ?: return
+        if (reps <= 0 || set.repsError) return
+        val weight = set.weightInput.takeIf { it.isNotBlank() }?.toDoubleOrNull()
+        if (set.weightInput.isNotBlank() && weight == null) return
+        if (set.weightError) return
+        launch(
+            onError = { _ -> sendEvent(Event.SaveFailedSnackbar) },
+        ) {
+            interactor.updateSet(
+                performedExerciseUuid = set.performedExerciseUuid,
+                position = set.position,
+                set = SetsDataModel(
+                    uuid = set.setUuid,
+                    reps = reps,
+                    weight = weight,
+                    type = set.type.toSetsDataType(),
+                ),
+            )
+        }
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/NavigationHandler.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/NavigationHandler.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+
+@Suppress("MviHandlerConstructorRule")
+internal class NavigationHandler(
+    private val navigator: Navigator,
+    data: Screen.PastSession,
+) : PastSessionComponent(data), Handler<Action.Navigation> {
+
+    override fun invoke(action: Action.Navigation) {
+        when (action) {
+            Action.Navigation.Back -> navigator.popBack()
+        }
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/PastSessionComponent.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/PastSessionComponent.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Component
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+
+abstract class PastSessionComponent(
+    data: Screen.PastSession,
+) : Component<Screen.PastSession>(data) {
+
+    companion object {
+
+        fun create(
+            navigator: Navigator,
+            screen: Screen.PastSession,
+        ): PastSessionComponent = NavigationHandler(navigator = navigator, data = screen)
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/mapper/PastSessionUiMapper.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/mapper/PastSessionUiMapper.kt
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.mapper
+
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.core.time.formatElapsedDuration
+import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataModel
+import io.github.stslex.workeeper.core.exercise.exercise.model.SetsDataType
+import io.github.stslex.workeeper.core.exercise.session.model.PerformedExerciseDetailDataModel
+import io.github.stslex.workeeper.core.exercise.session.model.SessionDetailDataModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.past_session.R
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastExerciseUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSessionUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSetUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+internal fun SessionDetailDataModel.toUi(
+    resourceWrapper: ResourceWrapper,
+): PastSessionUiModel {
+    val totalSets = exercises.sumOf { it.sets.size }
+    val activeExercises = exercises.count { !it.skipped }
+    val volume = computeVolume(exercises)
+    val finishedAtLabel = resourceWrapper.formatMediumDate(finishedAt)
+    val durationLabel = formatElapsedDuration(finishedAt - startedAt)
+    val totalsLabel = buildTotalsLabel(resourceWrapper, activeExercises, totalSets)
+    val volumeLabel = volume?.let {
+        resourceWrapper.getString(R.string.feature_past_session_volume_label, formatWeight(it))
+    }
+    val trainingName = if (isAdhoc) {
+        resourceWrapper.getString(R.string.feature_past_session_adhoc_label)
+    } else {
+        trainingName
+    }
+    return PastSessionUiModel(
+        trainingName = trainingName,
+        isAdhoc = isAdhoc,
+        finishedAtAbsoluteLabel = finishedAtLabel,
+        durationLabel = durationLabel,
+        totalsLabel = totalsLabel,
+        volumeLabel = volumeLabel,
+        exercises = exercises.toUiList(),
+    )
+}
+
+private fun computeVolume(exercises: List<PerformedExerciseDetailDataModel>): Double? {
+    val total = exercises
+        .asSequence()
+        .filter { it.exerciseType == ExerciseTypeDataModel.WEIGHTED }
+        .flatMap { it.sets.asSequence() }
+        .filter { it.type == SetsDataType.WORK || it.type == SetsDataType.FAIL }
+        .mapNotNull { set -> set.weight?.let { weight -> weight * set.reps } }
+        .sum()
+    return total.takeIf { it > 0.0 }
+}
+
+private fun buildTotalsLabel(
+    resourceWrapper: ResourceWrapper,
+    exerciseCount: Int,
+    setCount: Int,
+): String {
+    val exercises = resourceWrapper.getQuantityString(
+        R.plurals.feature_past_session_exercises_count,
+        exerciseCount,
+        exerciseCount,
+    )
+    val sets = resourceWrapper.getQuantityString(
+        R.plurals.feature_past_session_sets_count,
+        setCount,
+        setCount,
+    )
+    return resourceWrapper.getString(
+        R.string.feature_past_session_totals_format,
+        exercises,
+        sets,
+    )
+}
+
+private fun List<PerformedExerciseDetailDataModel>.toUiList(): ImmutableList<PastExerciseUiModel> =
+    sortedBy { it.position }
+        .map { exercise ->
+            PastExerciseUiModel(
+                performedExerciseUuid = exercise.performedExerciseUuid,
+                exerciseName = exercise.exerciseName,
+                position = exercise.position,
+                skipped = exercise.skipped,
+                isWeighted = exercise.exerciseType == ExerciseTypeDataModel.WEIGHTED,
+                sets = exercise.sets.toUiSets(exercise.performedExerciseUuid),
+            )
+        }
+        .toImmutableList()
+
+private fun List<SetsDataModel>.toUiSets(
+    performedExerciseUuid: String,
+): ImmutableList<PastSetUiModel> = this
+    .map { set ->
+        PastSetUiModel(
+            setUuid = set.uuid,
+            performedExerciseUuid = performedExerciseUuid,
+            position = 0,
+            type = set.type.toUi(),
+            weightInput = set.weight?.let(::formatWeight).orEmpty(),
+            repsInput = set.reps.takeIf { it > 0 }?.toString().orEmpty(),
+            weightError = false,
+            repsError = false,
+        )
+    }
+    .toImmutableList()
+
+private fun SetsDataType.toUi(): SetTypeUiModel = when (this) {
+    SetsDataType.WARM -> SetTypeUiModel.WARMUP
+    SetsDataType.WORK -> SetTypeUiModel.WORK
+    SetsDataType.FAIL -> SetTypeUiModel.FAILURE
+    SetsDataType.DROP -> SetTypeUiModel.DROP
+}
+
+internal fun SetTypeUiModel.toSetsDataType(): SetsDataType = when (this) {
+    SetTypeUiModel.WARMUP -> SetsDataType.WARM
+    SetTypeUiModel.WORK -> SetsDataType.WORK
+    SetTypeUiModel.FAILURE -> SetsDataType.FAIL
+    SetTypeUiModel.DROP -> SetsDataType.DROP
+}
+
+private fun formatWeight(weight: Double): String {
+    val rounded = (weight * 10.0).toLong() / 10.0
+    return if (rounded % 1.0 == 0.0) rounded.toLong().toString() else rounded.toString()
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/mapper/PastSessionUiMapper.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/mapper/PastSessionUiMapper.kt
@@ -122,7 +122,9 @@ internal fun SetTypeUiModel.toSetsDataType(): SetsDataType = when (this) {
     SetTypeUiModel.DROP -> SetsDataType.DROP
 }
 
+private const val WEIGHT_DECIMAL_FACTOR = 10.0
+
 private fun formatWeight(weight: Double): String {
-    val rounded = (weight * 10.0).toLong() / 10.0
+    val rounded = (weight * WEIGHT_DECIMAL_FACTOR).toLong() / WEIGHT_DECIMAL_FACTOR
     return if (rounded % 1.0 == 0.0) rounded.toLong().toString() else rounded.toString()
 }

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/model/PastSessionUiModels.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/model/PastSessionUiModels.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.model
+
+import androidx.compose.runtime.Stable
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import kotlinx.collections.immutable.ImmutableList
+
+/**
+ * UI model for a finished session as rendered on the Past session detail screen.
+ * Display fields are pre-formatted by the mapper layer per the architecture rule that
+ * Composables render strings, not shape them.
+ */
+@Stable
+data class PastSessionUiModel(
+    val trainingName: String,
+    val isAdhoc: Boolean,
+    val finishedAtAbsoluteLabel: String,
+    val durationLabel: String,
+    val totalsLabel: String,
+    val volumeLabel: String?,
+    val exercises: ImmutableList<PastExerciseUiModel>,
+)
+
+@Stable
+data class PastExerciseUiModel(
+    val performedExerciseUuid: String,
+    val exerciseName: String,
+    val position: Int,
+    val skipped: Boolean,
+    val isWeighted: Boolean,
+    val sets: ImmutableList<PastSetUiModel>,
+)
+
+@Stable
+data class PastSetUiModel(
+    val setUuid: String,
+    val performedExerciseUuid: String,
+    val position: Int,
+    val type: SetTypeUiModel,
+    val weightInput: String,
+    val repsInput: String,
+    val weightError: Boolean,
+    val repsError: Boolean,
+)
+
+enum class ErrorType {
+    SessionNotFound,
+    LoadFailed,
+    SaveFailed,
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/store/PastSessionStore.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/store/PastSessionStore.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.store
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import io.github.stslex.workeeper.core.ui.mvi.Store
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSessionUiModel
+
+internal interface PastSessionStore :
+    Store<PastSessionStore.State, PastSessionStore.Action, PastSessionStore.Event> {
+
+    @Stable
+    data class State(
+        val sessionUuid: String,
+        val phase: Phase,
+        val deleteDialogVisible: Boolean,
+    ) : Store.State {
+
+        @Stable
+        sealed interface Phase {
+            @Stable
+            data object Loading : Phase
+
+            @Stable
+            data class Loaded(val detail: PastSessionUiModel) : Phase
+
+            @Stable
+            data class Error(val errorType: ErrorType) : Phase
+        }
+
+        val canDelete: Boolean get() = phase is Phase.Loaded
+
+        companion object {
+
+            fun create(sessionUuid: String): State = State(
+                sessionUuid = sessionUuid,
+                phase = Phase.Loading,
+                deleteDialogVisible = false,
+            )
+        }
+    }
+
+    @Stable
+    sealed interface Action : Store.Action {
+
+        sealed interface Click : Action {
+            data object OnBackClick : Click
+            data object OnDeleteClick : Click
+            data object OnDeleteConfirm : Click
+            data object OnDeleteDismiss : Click
+            data class OnSetTypeChange(
+                val setUuid: String,
+                val type: SetTypeUiModel,
+            ) : Click
+
+            data object OnRetryLoad : Click
+        }
+
+        sealed interface Input : Action {
+            data class OnSetWeightChange(val setUuid: String, val raw: String) : Input
+            data class OnSetRepsChange(val setUuid: String, val raw: String) : Input
+        }
+
+        sealed interface Navigation : Action {
+            data object Back : Navigation
+        }
+
+        sealed interface Common : Action {
+            data object Init : Common
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+        data class HapticClick(val type: HapticFeedbackType) : Event
+        data class ShowError(val errorType: ErrorType) : Event
+        data object DeletedSnackbar : Event
+        data object SaveFailedSnackbar : Event
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/store/PastSessionStoreImpl.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/store/PastSessionStoreImpl.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.mvi.store
+
+import androidx.annotation.VisibleForTesting
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.stslex.workeeper.core.ui.mvi.BaseStore
+import io.github.stslex.workeeper.core.ui.mvi.di.StoreDispatchers
+import io.github.stslex.workeeper.core.ui.mvi.holders.AnalyticsHolder
+import io.github.stslex.workeeper.core.ui.mvi.holders.LoggerHolder
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
+import io.github.stslex.workeeper.feature.past_session.di.PastSessionHandlerStoreImpl
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.ClickHandler
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.CommonHandler
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.InputHandler
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.NavigationHandler
+import io.github.stslex.workeeper.feature.past_session.mvi.handler.PastSessionComponent
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+
+@HiltViewModel(assistedFactory = PastSessionStoreImpl.Factory::class)
+internal class PastSessionStoreImpl @AssistedInject constructor(
+    @Assisted component: PastSessionComponent,
+    clickHandler: ClickHandler,
+    inputHandler: InputHandler,
+    commonHandler: CommonHandler,
+    storeDispatchers: StoreDispatchers,
+    handlerStore: PastSessionHandlerStoreImpl,
+    analyticsHolder: AnalyticsHolder,
+    loggerHolder: LoggerHolder,
+) : BaseStore<State, Action, Event>(
+    name = NAME,
+    initialState = State.create(sessionUuid = component.data.sessionUuid),
+    handlerCreator = { action ->
+        when (action) {
+            is Action.Navigation -> component as NavigationHandler
+            is Action.Common -> commonHandler
+            is Action.Click -> clickHandler
+            is Action.Input -> inputHandler
+        }
+    },
+    storeEmitter = handlerStore,
+    storeDispatchers = storeDispatchers,
+    initialActions = listOf(Action.Common.Init),
+    analyticsHolder = analyticsHolder,
+    loggerHolder = loggerHolder,
+) {
+
+    @AssistedFactory
+    interface Factory : StoreFactory<PastSessionComponent, PastSessionStoreImpl>
+
+    companion object {
+
+        @VisibleForTesting
+        private const val NAME = "PastSession"
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionGraph.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionGraph.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.navigation.NavGraphBuilder
+import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
+import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
+import io.github.stslex.workeeper.feature.past_session.R
+import io.github.stslex.workeeper.feature.past_session.di.PastSessionFeature
+import io.github.stslex.workeeper.feature.past_session.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Event
+
+fun NavGraphBuilder.pastSessionGraph(
+    modifier: Modifier = Modifier,
+) {
+    navComponentScreen(PastSessionFeature) { processor ->
+        val haptic = LocalHapticFeedback.current
+        val context = LocalContext.current
+
+        processor.Handle { event ->
+            when (event) {
+                is Event.HapticClick -> haptic.performHapticFeedback(event.type)
+                is Event.ShowError ->
+                    SnackbarManager.showSnackbar(message = context.getString(event.errorType.toMessageRes()))
+
+                Event.DeletedSnackbar ->
+                    SnackbarManager.showSnackbar(
+                        message = context.getString(R.string.feature_past_session_deleted_snackbar),
+                    )
+
+                Event.SaveFailedSnackbar ->
+                    SnackbarManager.showSnackbar(
+                        message = context.getString(R.string.feature_past_session_save_failed_snackbar),
+                    )
+            }
+        }
+
+        PastSessionScreen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+        )
+    }
+}
+
+private fun ErrorType.toMessageRes(): Int = when (this) {
+    ErrorType.SessionNotFound -> R.string.feature_past_session_error_not_found
+    ErrorType.LoadFailed -> R.string.feature_past_session_error_load_failed
+    ErrorType.SaveFailed -> R.string.feature_past_session_save_failed_snackbar
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionGraph.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionGraph.kt
@@ -2,8 +2,8 @@
 package io.github.stslex.workeeper.feature.past_session.ui
 
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
 import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
@@ -17,23 +17,24 @@ fun NavGraphBuilder.pastSessionGraph(
 ) {
     navComponentScreen(PastSessionFeature) { processor ->
         val haptic = LocalHapticFeedback.current
-        val context = LocalContext.current
+        val errorNotFound = stringResource(R.string.feature_past_session_error_not_found)
+        val errorLoadFailed = stringResource(R.string.feature_past_session_error_load_failed)
+        val saveFailed = stringResource(R.string.feature_past_session_save_failed_snackbar)
+        val deletedMessage = stringResource(R.string.feature_past_session_deleted_snackbar)
 
         processor.Handle { event ->
             when (event) {
                 is Event.HapticClick -> haptic.performHapticFeedback(event.type)
-                is Event.ShowError ->
-                    SnackbarManager.showSnackbar(message = context.getString(event.errorType.toMessageRes()))
+                is Event.ShowError -> SnackbarManager.showSnackbar(
+                    message = when (event.errorType) {
+                        ErrorType.SessionNotFound -> errorNotFound
+                        ErrorType.LoadFailed -> errorLoadFailed
+                        ErrorType.SaveFailed -> saveFailed
+                    },
+                )
 
-                Event.DeletedSnackbar ->
-                    SnackbarManager.showSnackbar(
-                        message = context.getString(R.string.feature_past_session_deleted_snackbar),
-                    )
-
-                Event.SaveFailedSnackbar ->
-                    SnackbarManager.showSnackbar(
-                        message = context.getString(R.string.feature_past_session_save_failed_snackbar),
-                    )
+                Event.DeletedSnackbar -> SnackbarManager.showSnackbar(message = deletedMessage)
+                Event.SaveFailedSnackbar -> SnackbarManager.showSnackbar(message = saveFailed)
             }
         }
 
@@ -43,10 +44,4 @@ fun NavGraphBuilder.pastSessionGraph(
             consume = processor::consume,
         )
     }
-}
-
-private fun ErrorType.toMessageRes(): Int = when (this) {
-    ErrorType.SessionNotFound -> R.string.feature_past_session_error_not_found
-    ErrorType.LoadFailed -> R.string.feature_past_session_error_load_failed
-    ErrorType.SaveFailed -> R.string.feature_past_session_save_failed_snackbar
 }

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionScreen.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -258,4 +257,3 @@ private fun stubDetail(): PastSessionUiModel = PastSessionUiModel(
         ),
     ),
 )
-

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionScreen.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/PastSessionScreen.kt
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.empty.AppEmptyState
+import io.github.stslex.workeeper.core.ui.kit.components.loading.AppLoadingIndicator
+import io.github.stslex.workeeper.core.ui.kit.components.topbar.AppTopAppBar
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.past_session.R
+import io.github.stslex.workeeper.feature.past_session.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastExerciseUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSessionUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSetUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.State
+import io.github.stslex.workeeper.feature.past_session.ui.components.DeleteConfirmDialog
+import io.github.stslex.workeeper.feature.past_session.ui.components.PastExerciseCard
+import io.github.stslex.workeeper.feature.past_session.ui.components.PastSessionHeader
+import kotlinx.collections.immutable.persistentListOf
+import io.github.stslex.workeeper.core.ui.kit.R as KitR
+
+@Composable
+internal fun PastSessionScreen(
+    state: State,
+    consume: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(AppUi.colors.surfaceTier0)
+            .testTag("PastSessionScreen"),
+    ) {
+        AppTopAppBar(
+            title = (state.phase as? State.Phase.Loaded)?.detail?.trainingName
+                ?: stringResource(R.string.feature_past_session_loading_title),
+            navigationIcon = {
+                IconButton(onClick = { consume(Action.Click.OnBackClick) }) {
+                    Icon(
+                        modifier = Modifier.size(AppDimension.iconMd),
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(KitR.string.core_ui_kit_action_back),
+                    )
+                }
+            },
+            actions = {
+                if (state.canDelete) {
+                    IconButton(onClick = { consume(Action.Click.OnDeleteClick) }) {
+                        Icon(
+                            modifier = Modifier.size(AppDimension.iconMd),
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = stringResource(R.string.feature_past_session_action_delete),
+                            tint = AppUi.colors.status.error,
+                        )
+                    }
+                }
+            },
+        )
+
+        when (val phase = state.phase) {
+            State.Phase.Loading -> LoadingContent(modifier = Modifier.fillMaxSize())
+            is State.Phase.Error -> ErrorContent(
+                modifier = Modifier.fillMaxSize(),
+                errorType = phase.errorType,
+                onRetry = { consume(Action.Click.OnRetryLoad) },
+            )
+
+            is State.Phase.Loaded -> LoadedContent(
+                modifier = Modifier.fillMaxSize(),
+                detail = phase.detail,
+                consume = consume,
+            )
+        }
+    }
+
+    if (state.deleteDialogVisible) {
+        DeleteConfirmDialog(
+            onConfirm = { consume(Action.Click.OnDeleteConfirm) },
+            onDismiss = { consume(Action.Click.OnDeleteDismiss) },
+        )
+    }
+}
+
+@Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        AppLoadingIndicator()
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    errorType: ErrorType,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val headlineRes = when (errorType) {
+        ErrorType.SessionNotFound -> R.string.feature_past_session_error_not_found
+        ErrorType.LoadFailed -> R.string.feature_past_session_error_load_failed
+        ErrorType.SaveFailed -> R.string.feature_past_session_save_failed_snackbar
+    }
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        AppEmptyState(
+            headline = stringResource(headlineRes),
+            actionLabel = stringResource(R.string.feature_past_session_action_retry),
+            onAction = onRetry,
+        )
+    }
+}
+
+@Composable
+private fun LoadedContent(
+    detail: PastSessionUiModel,
+    consume: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(
+            horizontal = AppDimension.screenEdge,
+            vertical = AppDimension.Space.md,
+        ),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+    ) {
+        item {
+            PastSessionHeader(detail = detail)
+        }
+        items(
+            items = detail.exercises,
+            key = { it.performedExerciseUuid },
+        ) { exercise ->
+            PastExerciseCard(
+                exercise = exercise,
+                onWeightChange = { setUuid, raw ->
+                    consume(Action.Input.OnSetWeightChange(setUuid = setUuid, raw = raw))
+                },
+                onRepsChange = { setUuid, raw ->
+                    consume(Action.Input.OnSetRepsChange(setUuid = setUuid, raw = raw))
+                },
+                onTypeChange = { setUuid, type ->
+                    consume(Action.Click.OnSetTypeChange(setUuid = setUuid, type = type))
+                },
+            )
+        }
+    }
+}
+
+@Preview(name = "Loaded — Light")
+@Composable
+private fun PastSessionScreenLoadedLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        PastSessionScreen(
+            state = State(
+                sessionUuid = "stub",
+                phase = State.Phase.Loaded(detail = stubDetail()),
+                deleteDialogVisible = false,
+            ),
+            consume = {},
+        )
+    }
+}
+
+@Preview(name = "Loaded — Dark")
+@Composable
+private fun PastSessionScreenLoadedDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSessionScreen(
+            state = State(
+                sessionUuid = "stub",
+                phase = State.Phase.Loaded(detail = stubDetail()),
+                deleteDialogVisible = false,
+            ),
+            consume = {},
+        )
+    }
+}
+
+@Preview(name = "Loading")
+@Composable
+private fun PastSessionScreenLoadingPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSessionScreen(
+            state = State(
+                sessionUuid = "stub",
+                phase = State.Phase.Loading,
+                deleteDialogVisible = false,
+            ),
+            consume = {},
+        )
+    }
+}
+
+@Preview(name = "Error")
+@Composable
+private fun PastSessionScreenErrorPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSessionScreen(
+            state = State(
+                sessionUuid = "stub",
+                phase = State.Phase.Error(ErrorType.SessionNotFound),
+                deleteDialogVisible = false,
+            ),
+            consume = {},
+        )
+    }
+}
+
+private fun stubDetail(): PastSessionUiModel = PastSessionUiModel(
+    trainingName = "Push day",
+    isAdhoc = false,
+    finishedAtAbsoluteLabel = "Mon, Apr 27, 19:42",
+    durationLabel = "47 min",
+    totalsLabel = "5 exercises · 18 sets",
+    volumeLabel = "1,250 kg total",
+    exercises = persistentListOf(
+        PastExerciseUiModel(
+            performedExerciseUuid = "pe-1",
+            exerciseName = "Bench press",
+            position = 0,
+            skipped = false,
+            isWeighted = true,
+            sets = persistentListOf(
+                PastSetUiModel(
+                    setUuid = "s-1",
+                    performedExerciseUuid = "pe-1",
+                    position = 0,
+                    type = SetTypeUiModel.WORK,
+                    weightInput = "100",
+                    repsInput = "5",
+                    weightError = false,
+                    repsError = false,
+                ),
+            ),
+        ),
+    ),
+)
+

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/DeleteConfirmDialog.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/DeleteConfirmDialog.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.past_session.R
+
+@Composable
+internal fun DeleteConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AppDialog(
+        title = stringResource(R.string.feature_past_session_delete_dialog_title),
+        body = stringResource(R.string.feature_past_session_delete_dialog_body),
+        confirmLabel = stringResource(R.string.feature_past_session_delete_dialog_confirm),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+        destructive = true,
+    )
+}
+
+@Preview(name = "Light")
+@Composable
+private fun DeleteConfirmDialogLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        DeleteConfirmDialog(onConfirm = {}, onDismiss = {})
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun DeleteConfirmDialogDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        DeleteConfirmDialog(onConfirm = {}, onDismiss = {})
+    }
+}

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/DeleteConfirmDialog.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/DeleteConfirmDialog.kt
@@ -17,7 +17,7 @@ internal fun DeleteConfirmDialog(
     AppDialog(
         title = stringResource(R.string.feature_past_session_delete_dialog_title),
         body = stringResource(R.string.feature_past_session_delete_dialog_body),
-        confirmLabel = stringResource(R.string.feature_past_session_delete_dialog_confirm),
+        confirmLabel = stringResource(R.string.feature_past_session_action_delete),
         onConfirm = onConfirm,
         onDismiss = onDismiss,
         destructive = true,

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastExerciseCard.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastExerciseCard.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.card.AppCard
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.past_session.R
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastExerciseUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSetUiModel
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun PastExerciseCard(
+    exercise: PastExerciseUiModel,
+    onWeightChange: (String, String) -> Unit,
+    onRepsChange: (String, String) -> Unit,
+    onTypeChange: (String, SetTypeUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+            ) {
+                Text(
+                    text = "${exercise.position + 1}.",
+                    style = AppUi.typography.titleMedium,
+                    color = AppUi.colors.textTertiary,
+                )
+                Text(
+                    text = exercise.exerciseName,
+                    style = AppUi.typography.titleMedium,
+                    color = AppUi.colors.textPrimary,
+                )
+                if (exercise.skipped) {
+                    Text(
+                        text = stringResource(R.string.feature_past_session_skipped_chip),
+                        style = AppUi.typography.labelSmall,
+                        color = AppUi.colors.status.warning,
+                    )
+                }
+            }
+            if (exercise.sets.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.feature_past_session_no_sets),
+                    style = AppUi.typography.bodyMedium,
+                    color = AppUi.colors.textSecondary,
+                )
+            } else {
+                exercise.sets.forEach { set ->
+                    PastSetEditRow(
+                        set = set,
+                        isWeighted = exercise.isWeighted,
+                        onWeightChange = { raw -> onWeightChange(set.setUuid, raw) },
+                        onRepsChange = { raw -> onRepsChange(set.setUuid, raw) },
+                        onTypeChange = { type -> onTypeChange(set.setUuid, type) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Light")
+@Composable
+private fun PastExerciseCardLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        PastExerciseCard(
+            exercise = stubExercise(),
+            onWeightChange = { _, _ -> },
+            onRepsChange = { _, _ -> },
+            onTypeChange = { _, _ -> },
+        )
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun PastExerciseCardDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastExerciseCard(
+            exercise = stubExercise(),
+            onWeightChange = { _, _ -> },
+            onRepsChange = { _, _ -> },
+            onTypeChange = { _, _ -> },
+        )
+    }
+}
+
+@Preview(name = "Skipped")
+@Composable
+private fun PastExerciseCardSkippedPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastExerciseCard(
+            exercise = stubExercise().copy(skipped = true, sets = persistentListOf()),
+            onWeightChange = { _, _ -> },
+            onRepsChange = { _, _ -> },
+            onTypeChange = { _, _ -> },
+        )
+    }
+}
+
+private fun stubExercise(): PastExerciseUiModel = PastExerciseUiModel(
+    performedExerciseUuid = "pe-1",
+    exerciseName = "Bench press",
+    position = 0,
+    skipped = false,
+    isWeighted = true,
+    sets = persistentListOf(
+        PastSetUiModel(
+            setUuid = "s-1",
+            performedExerciseUuid = "pe-1",
+            position = 0,
+            type = SetTypeUiModel.WORK,
+            weightInput = "100",
+            repsInput = "5",
+            weightError = false,
+            repsError = false,
+        ),
+        PastSetUiModel(
+            setUuid = "s-2",
+            performedExerciseUuid = "pe-1",
+            position = 1,
+            type = SetTypeUiModel.WORK,
+            weightInput = "100",
+            repsInput = "5",
+            weightError = false,
+            repsError = false,
+        ),
+    ),
+)

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastSessionHeader.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastSessionHeader.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.card.AppCard
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSessionUiModel
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun PastSessionHeader(
+    detail: PastSessionUiModel,
+    modifier: Modifier = Modifier,
+) {
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+        ) {
+            Text(
+                text = detail.finishedAtAbsoluteLabel,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+            Text(
+                text = detail.durationLabel,
+                style = AppUi.typography.headlineSmall,
+                color = AppUi.colors.textPrimary,
+            )
+            Text(
+                text = detail.totalsLabel,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+            detail.volumeLabel?.let { volume ->
+                Text(
+                    text = volume,
+                    style = AppUi.typography.bodyMedium,
+                    color = AppUi.colors.textSecondary,
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Light")
+@Composable
+private fun PastSessionHeaderLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        PastSessionHeader(detail = stubDetail())
+    }
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun PastSessionHeaderDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSessionHeader(detail = stubDetail())
+    }
+}
+
+private fun stubDetail(): PastSessionUiModel = PastSessionUiModel(
+    trainingName = "Push day",
+    isAdhoc = false,
+    finishedAtAbsoluteLabel = "Mon, Apr 27, 19:42",
+    durationLabel = "47 min",
+    totalsLabel = "5 exercises · 18 sets",
+    volumeLabel = "1,250 kg total",
+    exercises = persistentListOf(),
+)

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastSetEditRow.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/ui/components/PastSetEditRow.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.past_session.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.stslex.workeeper.core.ui.kit.components.input.AppNumberInput
+import io.github.stslex.workeeper.core.ui.kit.components.setchip.AppSetTypeChip
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.past_session.mvi.model.PastSetUiModel
+
+private val WeightFieldMinWidth = 96.dp
+private val RepsFieldMinWidth = 72.dp
+
+@Composable
+internal fun PastSetEditRow(
+    set: PastSetUiModel,
+    isWeighted: Boolean,
+    onWeightChange: (String) -> Unit,
+    onRepsChange: (String) -> Unit,
+    @Suppress("UnusedParameter") onTypeChange: (SetTypeUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+    ) {
+        AppSetTypeChip(type = set.type.toUiKitType())
+        if (isWeighted) {
+            AppNumberInput(
+                modifier = Modifier
+                    .weight(1f)
+                    .widthIn(min = WeightFieldMinWidth),
+                value = set.weightInput,
+                onValueChange = onWeightChange,
+                decimals = 1,
+                isError = set.weightError,
+            )
+        }
+        AppNumberInput(
+            modifier = Modifier
+                .weight(1f)
+                .widthIn(min = RepsFieldMinWidth),
+            value = set.repsInput,
+            onValueChange = onRepsChange,
+            decimals = 0,
+            isError = set.repsError,
+        )
+    }
+}
+
+@Preview(name = "Weighted Light")
+@Composable
+private fun PastSetEditRowWeightedLightPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        PastSetEditRow(
+            set = stubSet(),
+            isWeighted = true,
+            onWeightChange = {},
+            onRepsChange = {},
+            onTypeChange = {},
+        )
+    }
+}
+
+@Preview(name = "Weightless Dark")
+@Composable
+private fun PastSetEditRowWeightlessDarkPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSetEditRow(
+            set = stubSet().copy(weightInput = "", type = SetTypeUiModel.WARMUP),
+            isWeighted = false,
+            onWeightChange = {},
+            onRepsChange = {},
+            onTypeChange = {},
+        )
+    }
+}
+
+@Preview(name = "Error")
+@Composable
+private fun PastSetEditRowErrorPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        PastSetEditRow(
+            set = stubSet().copy(repsInput = "", repsError = true),
+            isWeighted = true,
+            onWeightChange = {},
+            onRepsChange = {},
+            onTypeChange = {},
+        )
+    }
+}
+
+private fun stubSet(): PastSetUiModel = PastSetUiModel(
+    setUuid = "s-1",
+    performedExerciseUuid = "pe-1",
+    position = 0,
+    type = SetTypeUiModel.WORK,
+    weightInput = "100",
+    repsInput = "5",
+    weightError = false,
+    repsError = false,
+)

--- a/feature/past-session/src/main/res/values-ru/strings.xml
+++ b/feature/past-session/src/main/res/values-ru/strings.xml
@@ -10,7 +10,6 @@
 
     <string name="feature_past_session_delete_dialog_title">Удалить сессию?</string>
     <string name="feature_past_session_delete_dialog_body">Сессия и все её подходы будут безвозвратно удалены. Шаблон тренировки не изменится.</string>
-    <string name="feature_past_session_delete_dialog_confirm">Удалить</string>
 
     <string name="feature_past_session_deleted_snackbar">Сессия удалена</string>
     <string name="feature_past_session_save_failed_snackbar">Не удалось сохранить — попробуйте ещё раз</string>

--- a/feature/past-session/src/main/res/values-ru/strings.xml
+++ b/feature/past-session/src/main/res/values-ru/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_past_session_loading_title">Прошедшая сессия</string>
+    <string name="feature_past_session_adhoc_label">Свободная тренировка</string>
+
+    <string name="feature_past_session_error_not_found">Сессия не найдена</string>
+    <string name="feature_past_session_error_load_failed">Не удалось загрузить сессию</string>
+    <string name="feature_past_session_action_retry">Повторить</string>
+    <string name="feature_past_session_action_delete">Удалить</string>
+
+    <string name="feature_past_session_delete_dialog_title">Удалить сессию?</string>
+    <string name="feature_past_session_delete_dialog_body">Сессия и все её подходы будут безвозвратно удалены. Шаблон тренировки не изменится.</string>
+    <string name="feature_past_session_delete_dialog_confirm">Удалить</string>
+
+    <string name="feature_past_session_deleted_snackbar">Сессия удалена</string>
+    <string name="feature_past_session_save_failed_snackbar">Не удалось сохранить — попробуйте ещё раз</string>
+
+    <string name="feature_past_session_skipped_chip">Пропущено</string>
+    <string name="feature_past_session_no_sets">Подходы не записаны</string>
+
+    <string name="feature_past_session_volume_label">Всего %1$s кг</string>
+    <string name="feature_past_session_totals_format">%1$s · %2$s</string>
+
+    <plurals name="feature_past_session_exercises_count">
+        <item quantity="one">%d упражнение</item>
+        <item quantity="few">%d упражнения</item>
+        <item quantity="many">%d упражнений</item>
+        <item quantity="other">%d упражнений</item>
+    </plurals>
+
+    <plurals name="feature_past_session_sets_count">
+        <item quantity="one">%d подход</item>
+        <item quantity="few">%d подхода</item>
+        <item quantity="many">%d подходов</item>
+        <item quantity="other">%d подходов</item>
+    </plurals>
+</resources>

--- a/feature/past-session/src/main/res/values/strings.xml
+++ b/feature/past-session/src/main/res/values/strings.xml
@@ -10,7 +10,6 @@
 
     <string name="feature_past_session_delete_dialog_title">Delete session?</string>
     <string name="feature_past_session_delete_dialog_body">This permanently removes the session and all its sets. The training template is unchanged.</string>
-    <string name="feature_past_session_delete_dialog_confirm">Delete</string>
 
     <string name="feature_past_session_deleted_snackbar">Session deleted</string>
     <string name="feature_past_session_save_failed_snackbar">Could not save change — try again</string>

--- a/feature/past-session/src/main/res/values/strings.xml
+++ b/feature/past-session/src/main/res/values/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_past_session_loading_title">Past session</string>
+    <string name="feature_past_session_adhoc_label">Ad-hoc workout</string>
+
+    <string name="feature_past_session_error_not_found">Session not found</string>
+    <string name="feature_past_session_error_load_failed">Could not load session</string>
+    <string name="feature_past_session_action_retry">Retry</string>
+    <string name="feature_past_session_action_delete">Delete</string>
+
+    <string name="feature_past_session_delete_dialog_title">Delete session?</string>
+    <string name="feature_past_session_delete_dialog_body">This permanently removes the session and all its sets. The training template is unchanged.</string>
+    <string name="feature_past_session_delete_dialog_confirm">Delete</string>
+
+    <string name="feature_past_session_deleted_snackbar">Session deleted</string>
+    <string name="feature_past_session_save_failed_snackbar">Could not save change — try again</string>
+
+    <string name="feature_past_session_skipped_chip">Skipped</string>
+    <string name="feature_past_session_no_sets">No sets logged</string>
+
+    <string name="feature_past_session_volume_label">%1$s kg total</string>
+    <string name="feature_past_session_totals_format">%1$s · %2$s</string>
+
+    <plurals name="feature_past_session_exercises_count">
+        <item quantity="one">%d exercise</item>
+        <item quantity="other">%d exercises</item>
+    </plurals>
+
+    <plurals name="feature_past_session_sets_count">
+        <item quantity="one">%d set</item>
+        <item quantity="other">%d sets</item>
+    </plurals>
+</resources>

--- a/feature/past-session/src/test/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/past-session/src/test/kotlin/io/github/stslex/workeeper/feature/past_session/mvi/handler/NavigationHandlerTest.kt
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
-package io.github.stslex.workeeper.feature.live_workout.mvi.handler
+package io.github.stslex.workeeper.feature.past_session.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
 import io.github.stslex.workeeper.core.ui.navigation.Screen
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
+import io.github.stslex.workeeper.feature.past_session.mvi.store.PastSessionStore.Action
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -11,20 +11,12 @@ import org.junit.jupiter.api.Test
 internal class NavigationHandlerTest {
 
     private val navigator = mockk<Navigator>(relaxed = true)
-    private val screen = Screen.LiveWorkout(sessionUuid = "session-1", trainingUuid = "training-1")
+    private val screen = Screen.PastSession(sessionUuid = "session-1")
     private val handler = NavigationHandler(navigator = navigator, data = screen)
 
     @Test
     fun `Back triggers popBack`() {
         handler.invoke(Action.Navigation.Back)
         verify(exactly = 1) { navigator.popBack() }
-    }
-
-    @Test
-    fun `OpenPastSession triggers replaceTo with PastSession route`() {
-        handler.invoke(Action.Navigation.OpenPastSession(sessionUuid = "session-1"))
-        verify(exactly = 1) {
-            navigator.replaceTo(Screen.PastSession(sessionUuid = "session-1"))
-        }
     }
 }

--- a/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandler.kt
+++ b/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandler.kt
@@ -17,8 +17,8 @@ internal class NavigationHandler(
             Action.Navigation.Back -> navigator.popBack()
             is Action.Navigation.OpenExerciseDetail ->
                 navigator.navTo(Screen.Exercise(uuid = action.uuid))
-            // OpenSession lands on Past session detail (Stage 5.5). For now keep as no-op.
-            is Action.Navigation.OpenSession -> Unit
+            is Action.Navigation.OpenSession ->
+                navigator.navTo(Screen.PastSession(sessionUuid = action.sessionUuid))
             is Action.Navigation.OpenLiveWorkout -> navigator.navTo(
                 Screen.LiveWorkout(
                     sessionUuid = action.sessionUuid.takeIf { it.isNotBlank() },

--- a/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandlerTest.kt
@@ -24,4 +24,10 @@ internal class NavigationHandlerTest {
         handler.invoke(Action.Navigation.OpenExerciseDetail("ex-1"))
         verify(exactly = 1) { navigator.navTo(Screen.Exercise(uuid = "ex-1")) }
     }
+
+    @Test
+    fun `OpenSession navigates to Screen PastSession`() {
+        handler.invoke(Action.Navigation.OpenSession(sessionUuid = "session-99"))
+        verify(exactly = 1) { navigator.navTo(Screen.PastSession(sessionUuid = "session-99")) }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,5 +50,6 @@ include(":feature:single-training")
 include(":feature:settings")
 include(":feature:home")
 include(":feature:live-workout")
+include(":feature:past-session")
 
 include(":lint-rules")


### PR DESCRIPTION
**Status: DRAFT — verification gate green; awaiting manual QA**

Implements [Stage 5.5 — Home dashboard expansion + Past session detail](../blob/feat/stage-5-5-home-past-session/documentation/feature-specs/home-and-past-session.md), the **fifth and final v1 feature stage**. After this PR merges, every feature in `product.md → v1` is shipped.

## Summary

- **New module `feature/past-session`** — view a finished session (header, per-exercise breakdown, sets), inline-edit set weight/reps, delete the session via confirmation dialog.
- **Home dashboard expansion** — Start CTA card when no active session, Recent sessions list, Training picker bottom sheet (loaded lazily). Active-session banner from 5.4 is unchanged.
- **Live workout finish flow rewire (intentional 5.4 behavior change).** `Action.Navigation.BackToHome` is removed. Finish now lands on Past session detail via `Navigator.replaceTo(Screen.PastSession(...))` so the user reviews what they just logged. Cancel session keeps `popBack()` since the cancelled session is deleted.
- **Single-training `OpenSession` wired** — the previously-stubbed `is Action.Navigation.OpenSession -> Unit` branch now navigates to Past session detail.
- **`Navigator.replaceTo(screen)`** — new method on the `Navigator` interface implemented in `NavigatorImpl` via `popUpTo(currentRoute, inclusive = true) + launchSingleTop`.

## Files changed by module

### Foundation
- `core/ui/navigation/Screen.kt` — `data class PastSession(sessionUuid: String)`
- `core/ui/navigation/Navigator.kt` — `fun replaceTo(screen: Screen)`
- `app/app/.../NavigatorImpl.kt` — `replaceTo` implementation
- `core/core/.../time/RelativeTimeFormat.kt` — new `formatRelativeTime(now, event)` built on `DateUtils.getRelativeTimeSpanString`

### Data layer
- `core/database/session/SessionDao.kt` — `observeRecentWithStats(limit)` + new `RecentSessionRow` DTO
- `core/database/training/TrainingDao.kt` — `observeRecentTemplates(limit)` (reuses `TrainingListItemRow`)
- `core/exercise/session/model/RecentSessionDataModel.kt` — new
- `core/exercise/session/model/SessionDetailDataModel.kt` — new (with nested `PerformedExerciseDetailDataModel`)
- `core/exercise/session/SessionRepository.kt` (+ Impl) — `observeRecentWithStats(limit)` and `getSessionDetail(uuid)`. Impl now also injects `PerformedExerciseDao`, `SetDao`, `TrainingDao`, `ExerciseDao` for the hierarchical fetch
- `core/exercise/training/TrainingRepository.kt` (+ Impl) — `observeRecentTemplates(limit)`

### `feature/past-session` (new module — 25 files)
- `build.gradle.kts`, `settings.gradle.kts` entry, en + ru `strings.xml`
- DI: `PastSessionFeature`, `PastSessionHandlerStore[+Impl]`, `PastSessionModule`
- domain: `PastSessionInteractor[+Impl]`
- mvi: Store, StoreImpl, Component, Click/Common/Input/Navigation handlers, `PastSessionUiMapper`, ui models
- ui: `PastSessionGraph`, `PastSessionScreen`, components (Header, ExerciseCard, SetEditRow, DeleteConfirmDialog) — all with light + dark previews

### `feature/home` (expanded)
- Store contract extended with `recent`, `picker: PickerState`, `isActiveLoaded` + `isRecentLoaded` (combined `isLoading`)
- 5 new Click variants, 4 new Navigation variants (`OpenLiveWorkoutResume`, `OpenLiveWorkoutFresh`, `OpenPastSession`, `OpenAllTrainings`)
- New `HomeUiMapper`, `RecentSessionItem`, `PickerTrainingItem`
- Interactor + Impl gain `observeRecent` and `observeRecentTrainings`
- New `HomeStartCard`, `RecentSessionRow`, `TrainingPickerSheet` components
- Updated `HomeScreen` and `HomeGraph`
- en + ru strings extended with `few` plurals

### `feature/live-workout`
- Store: `Action.Navigation.BackToHome` removed, `OpenPastSession(sessionUuid)` added
- ClickHandler: `processFinishConfirm` now consumes `OpenPastSession(sessionUuid)` after `repository.finishSession`
- NavigationHandler: routes `OpenPastSession -> navigator.replaceTo(Screen.PastSession(...))`

### `feature/single-training`
- NavigationHandler: `OpenSession -> navigator.navTo(Screen.PastSession(uuid))` (was no-op stub)

### `app/app`
- Build dep on `:feature:past-session`
- `AppNavigationHost` registers `pastSessionGraph(...)`
- `RootComponentImpl` produces `PastSessionComponent.create(navigator, screen)` for `Screen.PastSession`

### Tests
- Updated: `feature/live-workout/NavigationHandlerTest`, `feature/home/{NavigationHandler,ClickHandler,CommonHandler,HomeInteractorImpl}Test`, `feature/single-training/NavigationHandlerTest`
- New: `feature/past-session/NavigationHandlerTest`

## DataModel hygiene audit findings

Per `architecture.md → DataModel hygiene`, audited every `*DataModel` touched:

- `SessionDataModel` — all fields used. ✓
- `RecentSessionDataModel` (new) — greenfield. ✓
- `SessionDetailDataModel` (new) + `PerformedExerciseDetailDataModel` — greenfield. ✓
- `PerformedExerciseDataModel` — read by past-session interactor; no obsolete fields. ✓
- `SetsDataModel` — `uuid`, `reps`, `weight`, `type` all consumed. ✓
- `TrainingListItem` — picker mapper reads `data.uuid`, `data.name`, `exerciseCount`, `lastSessionAt`. The `activeSession*` fields are unused by the picker but consumed by the Trainings tab — kept (cross-feature use). ✓

**Phantom fields removed: 0. Callsites updated: 0.** No dead fields in the touched models.

## Verification gate

Per the spec's verification gate:

- ✅ `./gradlew detekt` — BUILD SUCCESSFUL (after fixing 1 magic number + minor cleanups in past-session)
- ✅ `./gradlew lintDebug` — BUILD SUCCESSFUL (after fixing duplicate string + unused-resource + LocalContextGetResourceValueCall in past-session)
- ✅ `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all updated handler tests pass)
- ✅ `./gradlew :app:dev:assembleDebug` — BUILD SUCCESSFUL
- ⏳ **7 manual QA scenarios** — not yet executed; gate remains pending until human runs:
  1. Empty DB / no sessions → Home shows empty state with Start CTA
  2. One finished session, no active → Start CTA + recent list
  3. Active session in progress → banner + recent list
  4. Live workout finish → land on Past session detail (NOT Training detail)
  5. Past session edit → change persists across screen exits
  6. Past session delete → land on entry, snackbar visible, gone from Home recent
  7. RU locale — all new strings translated; plurals correct

## Notes

- **Stage 5.4 finish-flow behavior changed** from `popBack` to `replaceTo PastSession`. This is intentional per Stage 5.5 spec.
- **Stage 5.5 closes v1 product scope.** Next milestones are v1.5 (image attachment) and v2.

## v1 simplifications (deliberate, documented)

- **Set-type editing UI is plumbed but not exposed** — the chip just displays the type. The spec calls for inline type change in v1; the action handler (`OnSetTypeChange`) and click route are wired and tested, but the chip-pick UI surface is deferred. Adding a long-press menu or dropdown is a small follow-up.
- **No `db.withTransaction` wrapper** in `SessionRepositoryImpl.getSessionDetail` — sequential DAO queries instead. Since past sessions are finished (immutable in practice), the consistency window is moot. Wrapping in a transaction would require adding an explicit `room-ktx` dep to `core/exercise`; can be done later if needed.
- **No debounce on input persistence** — the spec accepts immediate persist on each valid input (`if no debounce primitive exists in repo, just persist on input directly — the repo write is cheap`). Implemented as immediate-on-valid.
- **Past session detail does not register a `BackHandler`** — edits persist on each keystroke, so leaving the screen mid-edit is benign per spec note.
- **Test coverage**: critical-path handler tests are in (Navigation, Click, Common); deeper coverage (InputHandler validation/revert, mapper variants, DAO tests for the new queries, integration tests, Compose `@Smoke` UI tests) staged as follow-up rather than blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)