### PR TITLE
feat(exercise): image attachment (v1.5)

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":feature:home"))
     implementation(project(":feature:live-workout"))
     implementation(project(":feature:past-session"))
+    implementation(project(":feature:image-viewer"))
 
     implementation(platform(libs.google.firebase.bom))
     implementation(libs.google.firebase.analytics)

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <application
         android:name="io.github.stslex.workeeper.BaseApplication"
         android:allowBackup="true"
@@ -24,6 +29,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/app/src/main/java/io/github/stslex/workeeper/BaseApplication.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/BaseApplication.kt
@@ -1,8 +1,17 @@
 package io.github.stslex.workeeper
 
 import android.app.Application
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.core.logger.FirebaseCrashlyticsHolder
 import io.github.stslex.workeeper.core.core.logger.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 abstract class BaseApplication : Application() {
 
@@ -12,5 +21,24 @@ abstract class BaseApplication : Application() {
         super.onCreate()
         FirebaseCrashlyticsHolder.initialize()
         Log.isLogging = isDebugLoggingAllow
+        cleanupOrphanedImageTempFiles()
+    }
+
+    private fun cleanupOrphanedImageTempFiles() {
+        val imageStorage = EntryPointAccessors.fromApplication(
+            this,
+            ImageStorageEntryPoint::class.java,
+        ).imageStorage()
+        // Fire-and-forget on a one-shot IO coroutine — clearing temp files left
+        // behind by killed camera-capture flows is best-effort.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            imageStorage.cleanupTempFiles()
+        }
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    internal interface ImageStorageEntryPoint {
+        fun imageStorage(): ImageStorage
     }
 }

--- a/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/host/AppNavigationHost.kt
@@ -18,6 +18,7 @@ import io.github.stslex.workeeper.feature.all_exercises.ui.allExercisesGraph
 import io.github.stslex.workeeper.feature.all_trainings.ui.allTrainingsGraph
 import io.github.stslex.workeeper.feature.exercise.ui.exerciseGraph
 import io.github.stslex.workeeper.feature.home.ui.homeGraph
+import io.github.stslex.workeeper.feature.image_viewer.ui.imageViewerGraph
 import io.github.stslex.workeeper.feature.live_workout.ui.liveWorkoutGraph
 import io.github.stslex.workeeper.feature.past_session.ui.pastSessionGraph
 import io.github.stslex.workeeper.feature.settings.ui.archiveGraph
@@ -72,6 +73,9 @@ internal fun AppNavigationHost(
             )
             pastSessionGraph(
                 modifier = Modifier.testTag("PastSessionGraph"),
+            )
+            imageViewerGraph(
+                modifier = Modifier.testTag("ImageViewerGraph"),
             )
             settingsGraph(
                 modifier = Modifier.testTag("SettingsGraph"),

--- a/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/navigation/RootComponentImpl.kt
@@ -8,6 +8,7 @@ import io.github.stslex.workeeper.feature.all_exercises.mvi.handler.AllExercises
 import io.github.stslex.workeeper.feature.all_trainings.mvi.handler.AllTrainingsComponent
 import io.github.stslex.workeeper.feature.exercise.mvi.handler.ExerciseComponent
 import io.github.stslex.workeeper.feature.home.mvi.handler.HomeComponent
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.ImageViewerComponent
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.LiveWorkoutComponent
 import io.github.stslex.workeeper.feature.past_session.mvi.handler.PastSessionComponent
 import io.github.stslex.workeeper.feature.settings.mvi.handler.ArchiveComponent
@@ -30,5 +31,6 @@ class RootComponentImpl(
         Screen.Settings -> SettingsComponent.create(navigator)
         Screen.Archive -> ArchiveComponent.create(navigator)
         is Screen.PastSession -> PastSessionComponent.create(navigator, screen)
+        is Screen.ExerciseImage -> ImageViewerComponent.create(navigator, screen)
     }
 }

--- a/app/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="exercise_images"
+        path="exercise_images/" />
+</paths>

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorage.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorage.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images
+
+import android.net.Uri
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
+
+interface ImageStorage {
+
+    /**
+     * Reads the image at [sourceUri], decodes it, downsamples to fit within
+     * [MAX_EDGE]x[MAX_EDGE], compresses as JPEG quality [QUALITY], and writes
+     * it atomically to filesDir/exercise_images/<exerciseUuid>.jpg.
+     *
+     * If a file already exists at the destination, it is overwritten (atomic
+     * via temp file + rename — old file remains intact if the process dies).
+     *
+     * Caller is responsible for invoking deleteImage() on any *previous* path
+     * that this exercise had — saveImage does not track that.
+     *
+     * @return [ImageSaveResult.Success] on success, or [ImageSaveResult.Failure]
+     *         on failure. Never throws.
+     */
+    suspend fun saveImage(sourceUri: Uri, exerciseUuid: String): ImageSaveResult
+
+    /**
+     * Returns a temporary file URI suitable for handing to
+     * ActivityResultContracts.TakePicture. The caller passes this URI to the
+     * camera launcher; on success, the camera writes the captured image there.
+     * The caller is then expected to call saveImage(tempUri, exerciseUuid) to
+     * downsample + persist to the canonical location.
+     *
+     * Temp files live in filesDir/exercise_images/.tmp/ and are cleaned up by
+     * cleanupTempFiles() on next app start.
+     */
+    suspend fun createTempCaptureUri(): Uri
+
+    /**
+     * Deletes the file at [path]. No-op if absent. Returns true if a file
+     * was actually deleted.
+     */
+    suspend fun deleteImage(path: String): Boolean
+
+    /**
+     * Removes any temp capture files left behind by killed processes.
+     * Called once at app startup.
+     */
+    suspend fun cleanupTempFiles()
+
+    companion object {
+        const val MAX_EDGE: Int = 1280
+        const val QUALITY: Int = 85
+        const val DIRECTORY: String = "exercise_images"
+        const val TEMP_SUBDIRECTORY: String = ".tmp"
+        const val FILE_EXTENSION: String = ".jpg"
+    }
+}

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageImpl.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageImpl.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.DIRECTORY
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.FILE_EXTENSION
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.MAX_EDGE
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.QUALITY
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.TEMP_SUBDIRECTORY
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveError
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
+import io.github.stslex.workeeper.core.core.logger.Log
+import io.github.stslex.workeeper.core.core.logger.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class ImageStorageImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ImageStorage {
+
+    private val logger: Logger = Log.tag("ImageStorage")
+
+    private val rootDir: File
+        get() = File(context.filesDir, DIRECTORY).apply { mkdirs() }
+
+    private val tempDir: File
+        get() = File(rootDir, TEMP_SUBDIRECTORY).apply { mkdirs() }
+
+    private val fileProviderAuthority: String
+        get() = "${context.packageName}.fileprovider"
+
+    override suspend fun saveImage(
+        sourceUri: Uri,
+        exerciseUuid: String,
+    ): ImageSaveResult = withContext(ioDispatcher) {
+        val destFile = File(rootDir, "$exerciseUuid$FILE_EXTENSION")
+        val tempFile = File(rootDir, "$exerciseUuid$FILE_EXTENSION.tmp")
+        try {
+            val bitmap = decodeDownsampled(sourceUri)
+                ?: return@withContext ImageSaveResult.Failure(ImageSaveError.SourceUnreadable)
+            try {
+                writeJpeg(bitmap, tempFile)
+            } finally {
+                bitmap.recycle()
+            }
+            if (!tempFile.renameTo(destFile)) {
+                tempFile.delete()
+                return@withContext ImageSaveResult.Failure(ImageSaveError.IoFailure)
+            }
+            ImageSaveResult.Success(destFile.absolutePath)
+        } catch (cause: FileNotFoundException) {
+            logger.e(cause, "Source not found: $sourceUri")
+            tempFile.delete()
+            ImageSaveResult.Failure(ImageSaveError.SourceUnreadable)
+        } catch (cause: ImageDecoder.DecodeException) {
+            logger.e(cause, "Failed to decode $sourceUri")
+            tempFile.delete()
+            ImageSaveResult.Failure(ImageSaveError.SourceUnreadable)
+        } catch (cause: IOException) {
+            logger.e(cause, "IO failure saving $sourceUri")
+            tempFile.delete()
+            ImageSaveResult.Failure(diagnoseIoError(cause))
+        } catch (cause: SecurityException) {
+            logger.e(cause, "Security failure reading $sourceUri")
+            tempFile.delete()
+            ImageSaveResult.Failure(ImageSaveError.SourceUnreadable)
+        }
+    }
+
+    override suspend fun createTempCaptureUri(): Uri = withContext(ioDispatcher) {
+        val tempFile = File.createTempFile("capture_", FILE_EXTENSION, tempDir)
+        FileProvider.getUriForFile(context, fileProviderAuthority, tempFile)
+    }
+
+    override suspend fun deleteImage(path: String): Boolean = withContext(ioDispatcher) {
+        if (path.isBlank()) return@withContext false
+        val file = File(path)
+        file.exists() && file.delete()
+    }
+
+    override suspend fun cleanupTempFiles() {
+        withContext(ioDispatcher) {
+            tempDir.listFiles()?.forEach(File::delete)
+        }
+    }
+
+    private fun decodeDownsampled(sourceUri: Uri): Bitmap? {
+        val source = ImageDecoder.createSource(context.contentResolver, sourceUri)
+        return ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+            decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+            decoder.isMutableRequired = false
+            val width = info.size.width
+            val height = info.size.height
+            val longestEdge = maxOf(width, height)
+            if (longestEdge > MAX_EDGE) {
+                val scale = MAX_EDGE.toFloat() / longestEdge
+                val targetWidth = (width * scale).toInt().coerceAtLeast(1)
+                val targetHeight = (height * scale).toInt().coerceAtLeast(1)
+                decoder.setTargetSize(targetWidth, targetHeight)
+            }
+        }
+    }
+
+    private fun writeJpeg(bitmap: Bitmap, destination: File) {
+        destination.outputStream().use { out ->
+            val ok = bitmap.compress(Bitmap.CompressFormat.JPEG, QUALITY, out)
+            if (!ok) throw IOException("Bitmap.compress returned false for ${destination.absolutePath}")
+            out.flush()
+        }
+    }
+
+    private fun diagnoseIoError(cause: IOException): ImageSaveError {
+        val message = cause.message.orEmpty().lowercase()
+        return if ("space" in message || "enospc" in message) {
+            ImageSaveError.OutOfSpace
+        } else {
+            ImageSaveError.IoFailure
+        }
+    }
+}

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageModule.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageModule.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ImageStorageModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindImageStorage(impl: ImageStorageImpl): ImageStorage
+}

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/model/ImageSaveError.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/model/ImageSaveError.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images.model
+
+enum class ImageSaveError {
+    SourceUnreadable,
+    OutOfSpace,
+    IoFailure,
+}

--- a/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/model/ImageSaveResult.kt
+++ b/core/core/src/main/kotlin/io/github/stslex/workeeper/core/core/images/model/ImageSaveResult.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images.model
+
+sealed interface ImageSaveResult {
+
+    data class Success(val absolutePath: String) : ImageSaveResult
+
+    data class Failure(val error: ImageSaveError) : ImageSaveResult
+}

--- a/core/core/src/test/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageImplTest.kt
+++ b/core/core/src/test/kotlin/io/github/stslex/workeeper/core/core/images/ImageStorageImplTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.core.images
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.DIRECTORY
+import io.github.stslex.workeeper.core.core.images.ImageStorage.Companion.TEMP_SUBDIRECTORY
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.io.File
+
+@ExtendWith(RobolectricExtension::class)
+@Config(application = ImageStorageImplTest.TestApplication::class, sdk = [33])
+internal class ImageStorageImplTest {
+
+    private lateinit var context: Context
+    private lateinit var storage: ImageStorageImpl
+
+    private val rootDir: File
+        get() = File(context.filesDir, DIRECTORY)
+
+    private val tempDir: File
+        get() = File(rootDir, TEMP_SUBDIRECTORY)
+
+    @BeforeEach
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        storage = ImageStorageImpl(
+            context = context,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+        rootDir.deleteRecursively()
+        rootDir.mkdirs()
+        tempDir.mkdirs()
+    }
+
+    @AfterEach
+    fun teardown() {
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun `deleteImage returns true and removes existing file`() = runTest {
+        val target = File(rootDir, "alpha.jpg").apply { writeBytes(byteArrayOf(0x1, 0x2)) }
+
+        val deleted = storage.deleteImage(target.absolutePath)
+
+        assertTrue(deleted)
+        assertFalse(target.exists())
+    }
+
+    @Test
+    fun `deleteImage returns false when path is absent`() = runTest {
+        val target = File(rootDir, "missing.jpg")
+
+        val deleted = storage.deleteImage(target.absolutePath)
+
+        assertFalse(deleted)
+    }
+
+    @Test
+    fun `deleteImage returns false on blank path`() = runTest {
+        assertFalse(storage.deleteImage(""))
+    }
+
+    @Test
+    fun `cleanupTempFiles removes everything in the temp subdirectory`() = runTest {
+        File(tempDir, "leftover-1.jpg").writeBytes(byteArrayOf(0x1))
+        File(tempDir, "leftover-2.jpg").writeBytes(byteArrayOf(0x2))
+
+        storage.cleanupTempFiles()
+
+        assertEquals(0, tempDir.listFiles()?.size ?: 0)
+    }
+
+    @Test
+    fun `cleanupTempFiles does not delete files outside the temp subdirectory`() = runTest {
+        val canonical = File(rootDir, "keep.jpg").apply { writeBytes(byteArrayOf(0x9)) }
+        File(tempDir, "leftover.jpg").writeBytes(byteArrayOf(0x1))
+
+        storage.cleanupTempFiles()
+
+        assertTrue(canonical.exists())
+    }
+
+    class TestApplication : Application()
+}

--- a/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepositoryImpl.kt
+++ b/core/exercise/src/main/kotlin/io/github/stslex/workeeper/core/exercise/exercise/ExerciseRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.database.converters.PlanSetsConverter
 import io.github.stslex.workeeper.core.database.exercise.ExerciseDao
 import io.github.stslex.workeeper.core.database.session.SessionDao
@@ -42,6 +43,7 @@ internal class ExerciseRepositoryImpl @Inject constructor(
     private val trainingExerciseDao: TrainingExerciseDao,
     private val sessionDao: SessionDao,
     private val setDao: SetDao,
+    private val imageStorage: ImageStorage,
     @IODispatcher private val bgDispatcher: CoroutineDispatcher,
 ) : ExerciseRepository {
 
@@ -153,7 +155,10 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun deleteItem(uuid: String) {
         withContext(bgDispatcher) {
+            // Read imagePath BEFORE delete — once the row is gone, we lose the path.
+            val imagePath = dao.getById(Uuid.parse(uuid))?.imagePath
             dao.permanentDelete(Uuid.parse(uuid))
+            imagePath?.let { imageStorage.deleteImage(it) }
         }
     }
 
@@ -175,7 +180,10 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun deleteAllItems(uuids: List<Uuid>) {
         withContext(bgDispatcher) {
+            // Snapshot paths before deleting rows so we can clean image files after.
+            val paths = uuids.mapNotNull { dao.getById(it)?.imagePath }
             uuids.forEach { dao.permanentDelete(it) }
+            paths.forEach { imageStorage.deleteImage(it) }
         }
     }
 
@@ -193,7 +201,9 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun permanentDelete(uuid: String) {
         withContext(bgDispatcher) {
+            val imagePath = dao.getById(Uuid.parse(uuid))?.imagePath
             dao.permanentDelete(Uuid.parse(uuid))
+            imagePath?.let { imageStorage.deleteImage(it) }
         }
     }
 
@@ -288,7 +298,10 @@ internal class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun bulkPermanentDelete(uuids: Set<String>) {
         withContext(bgDispatcher) {
-            uuids.forEach { dao.permanentDelete(Uuid.parse(it)) }
+            val parsed = uuids.map(Uuid::parse)
+            val paths = parsed.mapNotNull { dao.getById(it)?.imagePath }
+            parsed.forEach { dao.permanentDelete(it) }
+            paths.forEach { imageStorage.deleteImage(it) }
         }
     }
 

--- a/core/exercise/src/test/kotlin/io/github/stslex/workeeper/core/exercise/ExerciseRepositoryImplTest.kt
+++ b/core/exercise/src/test/kotlin/io/github/stslex/workeeper/core/exercise/ExerciseRepositoryImplTest.kt
@@ -2,7 +2,10 @@
 package io.github.stslex.workeeper.core.exercise
 
 import android.database.sqlite.SQLiteConstraintException
+import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.database.exercise.ExerciseDao
+import io.github.stslex.workeeper.core.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.database.exercise.ExerciseTypeEntity
 import io.github.stslex.workeeper.core.database.session.SessionDao
 import io.github.stslex.workeeper.core.database.session.SetDao
 import io.github.stslex.workeeper.core.database.tag.ExerciseTagDao
@@ -31,6 +34,7 @@ internal class ExerciseRepositoryImplTest {
     private val trainingExerciseDao = mockk<TrainingExerciseDao>(relaxed = true)
     private val sessionDao = mockk<SessionDao>(relaxed = true)
     private val setDao = mockk<SetDao>(relaxed = true)
+    private val imageStorage = mockk<ImageStorage>(relaxed = true)
 
     private val repository: ExerciseRepository = ExerciseRepositoryImpl(
         dao = exerciseDao,
@@ -39,7 +43,23 @@ internal class ExerciseRepositoryImplTest {
         trainingExerciseDao = trainingExerciseDao,
         sessionDao = sessionDao,
         setDao = setDao,
+        imageStorage = imageStorage,
         bgDispatcher = testDispatcher,
+    )
+
+    private fun exerciseEntity(
+        uuid: Uuid,
+        imagePath: String? = null,
+    ): ExerciseEntity = ExerciseEntity(
+        uuid = uuid,
+        name = "name-$uuid",
+        type = ExerciseTypeEntity.WEIGHTED,
+        description = null,
+        imagePath = imagePath,
+        archived = false,
+        createdAt = 0L,
+        archivedAt = null,
+        lastAdhocSets = null,
     )
 
     @Test
@@ -90,5 +110,80 @@ internal class ExerciseRepositoryImplTest {
         )
 
         assertEquals(SaveResult.Success, result)
+    }
+
+    @Test
+    fun `deleteItem removes the row and the image file when imagePath set`() = runTest(testDispatcher) {
+        val uuid = Uuid.random()
+        val path = "/data/user/0/app/files/exercise_images/$uuid.jpg"
+        coEvery { exerciseDao.getById(uuid) } returns exerciseEntity(uuid, imagePath = path)
+
+        repository.deleteItem(uuid.toString())
+
+        coVerify { exerciseDao.permanentDelete(uuid) }
+        coVerify { imageStorage.deleteImage(path) }
+    }
+
+    @Test
+    fun `deleteItem skips imageStorage when imagePath is null`() = runTest(testDispatcher) {
+        val uuid = Uuid.random()
+        coEvery { exerciseDao.getById(uuid) } returns exerciseEntity(uuid, imagePath = null)
+
+        repository.deleteItem(uuid.toString())
+
+        coVerify { exerciseDao.permanentDelete(uuid) }
+        coVerify(exactly = 0) { imageStorage.deleteImage(any()) }
+    }
+
+    @Test
+    fun `deleteAllItems removes rows and image files`() = runTest(testDispatcher) {
+        val uuidA = Uuid.random()
+        val uuidB = Uuid.random()
+        val pathA = "/files/$uuidA.jpg"
+        coEvery { exerciseDao.getById(uuidA) } returns exerciseEntity(uuidA, imagePath = pathA)
+        coEvery { exerciseDao.getById(uuidB) } returns exerciseEntity(uuidB, imagePath = null)
+
+        repository.deleteAllItems(listOf(uuidA, uuidB))
+
+        coVerify { exerciseDao.permanentDelete(uuidA) }
+        coVerify { exerciseDao.permanentDelete(uuidB) }
+        coVerify(exactly = 1) { imageStorage.deleteImage(pathA) }
+    }
+
+    @Test
+    fun `archive does not delete the image file`() = runTest(testDispatcher) {
+        val uuid = Uuid.random()
+
+        repository.archive(uuid.toString())
+
+        coVerify { exerciseDao.archive(uuid, any()) }
+        coVerify(exactly = 0) { imageStorage.deleteImage(any()) }
+    }
+
+    @Test
+    fun `permanentDelete removes the image file`() = runTest(testDispatcher) {
+        val uuid = Uuid.random()
+        val path = "/files/$uuid.jpg"
+        coEvery { exerciseDao.getById(uuid) } returns exerciseEntity(uuid, imagePath = path)
+
+        repository.permanentDelete(uuid.toString())
+
+        coVerify { exerciseDao.permanentDelete(uuid) }
+        coVerify { imageStorage.deleteImage(path) }
+    }
+
+    @Test
+    fun `bulkPermanentDelete removes image files for all rows`() = runTest(testDispatcher) {
+        val uuidA = Uuid.random()
+        val uuidB = Uuid.random()
+        val pathA = "/files/$uuidA.jpg"
+        coEvery { exerciseDao.getById(uuidA) } returns exerciseEntity(uuidA, imagePath = pathA)
+        coEvery { exerciseDao.getById(uuidB) } returns exerciseEntity(uuidB, imagePath = null)
+
+        repository.bulkPermanentDelete(setOf(uuidA.toString(), uuidB.toString()))
+
+        coVerify { exerciseDao.permanentDelete(uuidA) }
+        coVerify { exerciseDao.permanentDelete(uuidB) }
+        coVerify(exactly = 1) { imageStorage.deleteImage(pathA) }
     }
 }

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
@@ -66,6 +66,16 @@ sealed interface Screen {
         val sessionUuid: String,
     ) : Screen
 
+    /**
+     * Full-screen image viewer. [model] is either an absolute file path
+     * (`filesDir/exercise_images/<uuid>.jpg`) or a content URI string
+     * (e.g. from `PickVisualMedia`); Coil resolves both transparently.
+     */
+    @Serializable
+    data class ExerciseImage(
+        val model: String,
+    ) : Screen
+
     companion object {
 
         @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)

--- a/documentation/feature-specs/exercise-image.md
+++ b/documentation/feature-specs/exercise-image.md
@@ -1,0 +1,635 @@
+# Feature spec — Exercise image attachment (v1.5)
+
+This is the v1.5 spec — a fast follow-up after v1 closure. The first feature outside the v1 bottom-bar shape: Exercise image attachment. References:
+
+- [product.md](../product.md) — `v1.5` feature 14 (Exercise image attachment) + Open questions section ("Image storage strategy")
+- [ux-architecture.md](../ux-architecture.md) — Exercise detail (Hero image), Edit exercise (Image picker), Exercises tab (thumbnail row)
+- [data-needs.md](../data-needs.md) — `exercise.image_path: String?` reserved field
+- [architecture.md](../architecture.md) — Permission handling, Compose launchers, file IO conventions
+- [feature-specs/exercises.md](exercises.md) — patterns to mirror in feature/exercise + feature/all-exercises
+
+## Scope
+
+Three deliverables:
+
+- **ImageStorage utility** in a shared core module — handles compress + save + delete + path generation. Single source of truth for the file lifecycle.
+- **Picker flow in Edit exercise** — camera capture + gallery selection, with permission handling, optimistic UI updates, and "save on commit" semantics so cancelled edits leave no orphan files.
+- **Read-only surfaces in Exercise detail + Exercises tab row** — replace the existing icon placeholder with the actual image when `imagePath != null`, retain the placeholder otherwise.
+
+## Out of scope
+
+- Image cropping / rotation / filters in-app — accept what the picker / camera returns, only resize.
+- Multiple images per exercise — single hero image only (per product.md).
+- Cloud sync / remote storage — local only (per product.md: "Stored locally on the device; no cloud upload.").
+- Image attachment on `training`, `session`, or `set` — exercise-only.
+- Server-uploaded thumbnails — single source file, downsampled on load by Coil.
+- Sharing / exporting an exercise image — v2.
+- ExifInterface orientation correction beyond what `ImageDecoder` does for free.
+- Migration of `imagePath` for existing exercises — they all stay `null` until the user explicitly attaches; no batch import.
+
+## Design decisions (locked)
+
+These were "open questions" in product.md. Locking them now.
+
+| Question | Decision | Reasoning |
+|---|---|---|
+| Format | **JPEG quality 85** | Universal decoder support, ~70% size reduction vs PNG for photo content, quality loss imperceptible at this level. WebP would save ~25% more but complicates debug viewing of files. |
+| Max dimensions | **1280×1280**, longest edge | Hero image renders at ~120-180dp on phones; 1280px gives 4-5x oversample for clarity on dense screens. Above this is wasted bytes. |
+| Thumbnail strategy | **None — single file**, Coil downsamples on load | Coil 3 has `Size`-aware decoding. Separate thumbnail file = 2x the file management complexity for negligible gain. |
+| Storage location | **`context.filesDir/exercise_images/<exerciseUuid>.jpg`** | Internal storage = no external permission needed, no MediaStore visibility leak, auto-cleanup on uninstall. NOT `cacheDir` (system can wipe), NOT `externalFilesDir` (worse for private data). |
+| Camera capture | **`ActivityResultContracts.TakePicture`** | Modern API, returns Boolean success, writes to a `FileProvider` URI we control. |
+| Gallery picker | **`ActivityResultContracts.PickVisualMedia`** with `ImageOnly`. AndroidX backport handles API < 33 transparently. | No `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE` permission needed on any supported SDK. |
+| Permissions | **`CAMERA` only** (runtime). Gallery needs none. | Photo Picker is the official privacy-preserving path; no permission required on the supported SDK range (28+). |
+| Edit commit semantics | **"Save on commit"** — keep `pendingImage` in State, write to disk only on Save. Old file deleted only after new file successfully written. | Eliminates orphan files from cancelled edits. Cost: image bytes held in memory during edit (acceptable — single image, max ~500KB). |
+| File replace | **Atomic via temp file + rename** within `saveImage`. | If process is killed mid-write, old file remains intact. |
+| Lifecycle | **Delete file only on `deleteItem` (permanent)**. Archive does NOT delete the file. | Per product.md: archive preserves history. If unarchived later, image must still be there. |
+| Coil cache invalidation | **Append `?v=<lastModifiedMs>` to the image model** when displaying. | Coil keys cache by URI string. Without versioning, replacing a file at the same path shows the old cached image. |
+
+If any of these need to change, surface it in PR review — but the spec assumes them.
+
+## Module structure
+
+```
+core/
+├── core/                          # MODIFIED — new utility added
+│   └── src/main/kotlin/.../core/core/
+│       └── images/                # NEW package
+│           ├── ImageStorage.kt              # interface
+│           ├── ImageStorageImpl.kt          # impl: save / delete / paths
+│           ├── ImageStorageModule.kt        # Hilt @Module @Binds
+│           └── model/
+│               ├── ImageSaveResult.kt       # sealed: Success(path) | Failure(reason)
+│               └── ImageSaveError.kt        # enum: SourceUnreadable, OutOfSpace, IoFailure
+│
+└── exercise/                      # MODIFIED — repo hooks file deletion
+    └── src/main/kotlin/.../core/exercise/exercise/
+        └── ExerciseRepositoryImpl.kt        # +ImageStorage dependency; deleteItem/deleteAllItems remove files
+
+feature/
+├── exercise/                      # MODIFIED — picker + state + hero
+│   └── src/main/kotlin/.../feature/exercise/
+│       ├── domain/
+│       │   ├── ExerciseInteractor.kt        # +saveImage(uri), +deleteImage(path) passthroughs
+│       │   └── ExerciseInteractorImpl.kt
+│       ├── mvi/
+│       │   ├── handler/
+│       │   │   ├── ClickHandler.kt          # MODIFIED — picker open/source-select/remove
+│       │   │   ├── CommonHandler.kt         # MODIFIED — image result events
+│       │   │   ├── InputHandler.kt          # MODIFIED — pendingImage state mgmt
+│       │   │   └── PlanEditActionHandler.kt # MODIFIED — Save flow commits image
+│       │   ├── mapper/
+│       │   │   └── ExerciseUiMapper.kt      # MODIFIED — surfaces effective imagePath (committed or pending)
+│       │   ├── model/                       # NEW models
+│       │   │   ├── PendingImage.kt          # sealed: NewFromUri(uri) | RemoveExisting | Unchanged
+│       │   │   └── ImageSourceUiModel.kt    # enum: Camera | Gallery (for source picker dialog)
+│       │   └── store/
+│       │       └── ExerciseStore.kt         # MODIFIED — +pendingImage, +sourceDialogVisible, +permissionDeniedDialogVisible
+│       └── ui/
+│           ├── ExerciseEditScreen.kt        # MODIFIED — wires picker launchers + image edit row
+│           └── components/
+│               ├── ExerciseHero.kt          # MODIFIED — conditional AsyncImage when path != null
+│               ├── ImageEditRow.kt          # NEW — current thumbnail + Edit/Remove buttons (in edit screen)
+│               ├── ImageSourceDialog.kt     # NEW — Camera / Gallery / Cancel choice
+│               └── PermissionDeniedDialog.kt# NEW — fallback when CAMERA permission denied
+│
+└── all-exercises/                 # MODIFIED — row thumbnail
+    └── src/main/kotlin/.../feature/all_exercises/
+        ├── mvi/
+        │   ├── mapper/
+        │   │   └── AllExercisesUiMapper.kt  # MODIFIED — passes imagePath into ExerciseUiModel
+        │   └── model/
+        │       └── ExerciseUiModel.kt       # MODIFIED — +imagePath: String?
+        └── ui/components/
+            └── ExerciseRow.kt               # MODIFIED — AsyncImage when path != null, else ExerciseTypeIcon
+
+app/app/                           # MODIFIED
+├── src/main/AndroidManifest.xml             # +CAMERA permission, +FileProvider authority
+├── src/main/res/xml/
+│   └── file_provider_paths.xml              # NEW — exposes filesDir/exercise_images for camera capture URI
+└── src/main/res/values/strings.xml          # NEW image-related strings (mirrored in values-ru)
+```
+
+## Data layer
+
+**No schema migration.** `ExerciseEntity.imagePath: String?`, `ExerciseDataModel.imagePath`, `ExerciseChangeDataModel.imagePath` already in place from earlier stages — verified end-to-end. Pipeline already carries the field; today it's always `null`. v1.5 simply starts populating it.
+
+## Storage layer — `core/core/images`
+
+### `ImageStorage` interface
+
+```kotlin
+interface ImageStorage {
+
+    /**
+     * Reads the image at [sourceUri], decodes it, downsamples to fit within
+     * [MAX_EDGE]x[MAX_EDGE], compresses as JPEG quality [QUALITY], and writes
+     * it atomically to filesDir/exercise_images/<exerciseUuid>.jpg.
+     *
+     * If a file already exists at the destination, it is overwritten (atomic
+     * via temp file + rename — old file remains intact if the process dies).
+     *
+     * Caller is responsible for invoking deleteImage() on any *previous* path
+     * that this exercise had — saveImage does not track that.
+     *
+     * @return ImageSaveResult.Success(absolutePath) on success, or
+     *         ImageSaveResult.Failure(error) on failure.
+     *         Never throws.
+     */
+    suspend fun saveImage(sourceUri: Uri, exerciseUuid: String): ImageSaveResult
+
+    /**
+     * Returns a temporary file URI suitable for handing to
+     * ActivityResultContracts.TakePicture. The caller passes this URI to the
+     * camera launcher; on success, the camera writes the captured image there.
+     * The caller is then expected to call saveImage(tempUri, exerciseUuid) to
+     * downsample + persist to the canonical location.
+     *
+     * Temp files live in filesDir/exercise_images/.tmp/ and are cleaned up by
+     * cleanupTempFiles() on next app start.
+     */
+    suspend fun createTempCaptureUri(): Uri
+
+    /**
+     * Deletes the file at [path]. No-op if absent. Returns true if a file
+     * was actually deleted.
+     */
+    suspend fun deleteImage(path: String): Boolean
+
+    /**
+     * Removes any temp capture files left behind by killed processes.
+     * Called once at app startup.
+     */
+    suspend fun cleanupTempFiles()
+
+    companion object {
+        const val MAX_EDGE = 1280
+        const val QUALITY = 85
+        const val DIRECTORY = "exercise_images"
+        const val TEMP_SUBDIRECTORY = ".tmp"
+    }
+}
+```
+
+### `ImageStorageImpl` notes
+
+- Decode source: `ImageDecoder.createSource(contentResolver, sourceUri).decodeBitmap { info, _ -> info.setTargetSampleSize(...) }` — built-in downsample at decode time, avoids loading full bitmap into memory.
+- Write: `BitmapFactory` for fallback on weird sources; primary path is `ImageDecoder` (API 28+, matches our minSdk).
+- Atomic rename: write to `<dest>.tmp`, then `File.renameTo(<dest>)`. On Linux/Android this is atomic for same-filesystem moves.
+- Wrap all IO in `withContext(bgDispatcher)`. Use the existing `bgDispatcher` qualifier from core/core DI.
+- Return `ImageSaveResult` rather than throwing — caller (UI) needs structured failure to show appropriate error message.
+- `cleanupTempFiles` runs at app start. Trigger from `WorkeeperApp.onCreate` via Hilt-injected `AppStartupTask` if such a hook exists; otherwise launch from `WorkeeperApp.onCreate` in a `GlobalScope.launch(Dispatchers.IO)` (one-shot, fire-and-forget; not ideal but acceptable for cleanup).
+
+### Hilt module
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ImageStorageModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindImageStorage(impl: ImageStorageImpl): ImageStorage
+}
+```
+
+`ImageStorageImpl` constructor injects `@ApplicationContext context: Context` and `@BgDispatcher dispatcher: CoroutineDispatcher`.
+
+### `ExerciseRepositoryImpl` hook
+
+Inject `ImageStorage`. Modify two methods:
+
+```kotlin
+override suspend fun deleteItem(uuid: String) {
+    withContext(bgDispatcher) {
+        // Read imagePath BEFORE delete — once row is gone, we lose the path.
+        val imagePath = dao.getById(Uuid.parse(uuid))?.imagePath
+        dao.permanentDelete(Uuid.parse(uuid))
+        imagePath?.let { imageStorage.deleteImage(it) }
+    }
+}
+
+override suspend fun deleteAllItems(uuids: List<Uuid>) {
+    withContext(bgDispatcher) {
+        // Snapshot paths before deleting rows.
+        val paths = uuids.mapNotNull { dao.getById(it)?.imagePath }
+        uuids.forEach { dao.permanentDelete(it) }
+        paths.forEach { imageStorage.deleteImage(it) }
+    }
+}
+```
+
+Note: archive flow does NOT touch the file. Verified by inspecting current `archiveItem` / `unarchiveItem` impls — they only flip the `archived` flag. Image survives archive/unarchive cycles, as it should.
+
+## Permission flow
+
+`CAMERA` is the only runtime permission needed. Add to `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-feature android:name="android.hardware.camera" android:required="false" />
+```
+
+`required="false"` keeps the app installable on devices without camera hardware (rare, but tablets sometimes).
+
+The flow:
+
+```
+User taps "Edit image" in Edit exercise
+                ↓
+       ImageSourceDialog shown
+                ↓
+       ┌────────┴────────┐
+       │                 │
+   Camera             Gallery
+       ↓                 │
+  Check CAMERA           │
+  permission             │
+       │                 │
+   ┌───┴───┐             │
+ granted  denied         │
+   │       │             │
+   │   request           │
+   │   permission        │
+   │       │             │
+   │   ┌───┴───┐         │
+   │ granted denied      │
+   │   │     │           │
+   │   │  PermissionDeniedDialog
+   │   │  (offer Settings deeplink)
+   │   │                 │
+   ▼   ▼                 ▼
+ TakePicture launcher  PickVisualMedia launcher
+       │                 │
+   tempUri          contentUri
+       │                 │
+       └────────┬────────┘
+                ▼
+       Action.Common.ImagePicked(uri)
+                ↓
+       Update State.pendingImage = NewFromUri(uri)
+       (no disk write yet)
+                ↓
+       Hero re-renders showing the new image
+       (Coil reads from URI directly — content://
+        works the same as file://)
+```
+
+Permission rationale string (for the system dialog, when applicable): "Workeeper uses the camera so you can attach a photo of the exercise machine or movement, helping you identify it later in the gym." Localized string in values + values-ru.
+
+## Compose launcher wiring
+
+Picker launchers live in `ExerciseEditScreen` (the only place that picks). Use `rememberLauncherForActivityResult` for both, plus `rememberLauncherForActivityResult(RequestPermission)` for the camera-permission flow.
+
+Pseudocode in the screen body:
+
+```kotlin
+val context = LocalContext.current
+val cameraTempUriState = remember { mutableStateOf<Uri?>(null) }
+
+val cameraLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.TakePicture(),
+) { success ->
+    val uri = cameraTempUriState.value
+    if (success && uri != null) {
+        consume(Action.Common.ImagePicked(uri))
+    } else {
+        consume(Action.Common.ImagePickCancelled)
+    }
+    cameraTempUriState.value = null
+}
+
+val galleryLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.PickVisualMedia(),
+) { uri ->
+    if (uri != null) consume(Action.Common.ImagePicked(uri))
+    else consume(Action.Common.ImagePickCancelled)
+}
+
+val cameraPermissionLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.RequestPermission(),
+) { granted ->
+    if (granted) {
+        consume(Action.Click.RequestCameraCapture)
+    } else {
+        consume(Action.Click.OnCameraPermissionDenied)
+    }
+}
+
+// When ClickHandler emits a "launch camera" event, the screen handles it via:
+LaunchedEffect(Unit) {
+    events.collect { event ->
+        when (event) {
+            is Event.LaunchCamera -> {
+                val tempUri = event.tempUri
+                cameraTempUriState.value = tempUri
+                cameraLauncher.launch(tempUri)
+            }
+            is Event.LaunchGallery -> {
+                galleryLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                )
+            }
+            is Event.RequestCameraPermission -> {
+                cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+            }
+        }
+    }
+}
+```
+
+The `tempUri` for camera capture comes from the Store, which calls `imageStorage.createTempCaptureUri()` and emits `Event.LaunchCamera(tempUri)`. The screen does NOT call ImageStorage directly.
+
+## MVI surface — `feature/exercise` deltas
+
+### State additions
+
+```kotlin
+data class State(
+    // ... existing fields
+    val imagePath: String?,                  // committed value from DB; what's in ExerciseDataModel today
+    val pendingImage: PendingImage,           // edit-time staging
+    val sourceDialogVisible: Boolean,
+    val permissionDeniedDialogVisible: Boolean,
+) : Store.State {
+
+    /** What the UI should display right now — pending overrides committed. */
+    val effectiveImageDisplay: ImageDisplay
+        get() = when (pendingImage) {
+            is PendingImage.NewFromUri -> ImageDisplay.FromUri(pendingImage.uri)
+            PendingImage.RemoveExisting -> ImageDisplay.None
+            PendingImage.Unchanged -> when (imagePath) {
+                null -> ImageDisplay.None
+                else -> ImageDisplay.FromPath(imagePath, lastModified = imageLastModified)
+            }
+        }
+
+    val isImageDirty: Boolean get() = pendingImage != PendingImage.Unchanged
+    val canSave: Boolean get() = nameValid /* &&  ... existing checks */ // unchanged structurally
+}
+
+@Stable
+sealed interface ImageDisplay {
+    data object None : ImageDisplay
+    data class FromPath(val path: String, val lastModified: Long) : ImageDisplay
+    data class FromUri(val uri: Uri) : ImageDisplay
+}
+
+@Stable
+sealed interface PendingImage {
+    data object Unchanged : PendingImage
+    data class NewFromUri(val uri: Uri) : PendingImage
+    data object RemoveExisting : PendingImage
+}
+```
+
+`imageLastModified` is captured at exercise-load time (from `File(imagePath).lastModified()` if the path exists) and stored in State. Used to bust Coil's cache when a different revision lands.
+
+### Action additions
+
+```kotlin
+sealed interface Click : Action {
+    // ... existing
+    data object OnEditImageClick : Click           // opens source dialog
+    data class OnImageSourceSelected(val source: ImageSourceUiModel) : Click
+    data object OnRemoveImageClick : Click
+    data object OnImageSourceDialogDismiss : Click
+    data object OnPermissionDeniedDialogDismiss : Click
+    data object OnPermissionDeniedSettingsClick : Click   // open app settings
+    data object RequestCameraCapture : Click       // internal: emitted by permission launcher result
+    data object OnCameraPermissionDenied : Click   // internal: emitted by permission launcher result
+}
+
+sealed interface Common : Action {
+    // ... existing
+    data class ImagePicked(val uri: Uri) : Common
+    data object ImagePickCancelled : Common
+}
+```
+
+### Event additions
+
+```kotlin
+sealed interface Event : Store.Event {
+    // ... existing
+    data class LaunchCamera(val tempUri: Uri) : Event
+    data object LaunchGallery : Event
+    data object RequestCameraPermission : Event
+    data class OpenAppSettings(val packageName: String) : Event
+    data class ShowImageError(val errorType: ImageErrorType) : Event
+}
+
+enum class ImageErrorType {
+    SaveFailed,
+    LoadFailed,
+    DecodeFailed,
+}
+```
+
+### Handler responsibilities
+
+- **`ClickHandler`**:
+  - `OnEditImageClick` → emit `Event.HapticClick`, `updateState { sourceDialogVisible = true }`.
+  - `OnImageSourceSelected(Camera)` → check permission via `context.checkSelfPermission(CAMERA)`. If granted, call `interactor.createTempCaptureUri()` → emit `Event.LaunchCamera(uri)`. If not granted, emit `Event.RequestCameraPermission`.
+  - `OnImageSourceSelected(Gallery)` → emit `Event.LaunchGallery`. Close source dialog.
+  - `OnRemoveImageClick` → `updateState { pendingImage = PendingImage.RemoveExisting }`. (Source dialog implicitly hidden — show only when no image, but allow remove from row.)
+  - `RequestCameraCapture` → re-run the camera path from the source-selected case, now that permission is granted.
+  - `OnCameraPermissionDenied` → `updateState { permissionDeniedDialogVisible = true }`.
+  - `OnPermissionDeniedSettingsClick` → emit `Event.OpenAppSettings(context.packageName)`.
+
+- **`CommonHandler`**:
+  - `ImagePicked(uri)` → `updateState { pendingImage = PendingImage.NewFromUri(uri) }`. Source dialog gets hidden.
+  - `ImagePickCancelled` → no state change beyond hiding source dialog if visible.
+
+- **`PlanEditActionHandler`** (or whichever handler owns the Save click):
+  - On Save: build `ExerciseChangeDataModel` based on current State + `pendingImage`:
+    - If `pendingImage = NewFromUri(uri)`:
+      - Capture `oldPath = state.imagePath`.
+      - Call `interactor.saveImage(uri, exerciseUuid)`.
+      - On `ImageSaveResult.Success(newPath)`: set `imagePath = newPath` in the change model. After successful repo update, fire-and-forget `interactor.deleteImage(oldPath)` if `oldPath != null && oldPath != newPath`.
+      - On `ImageSaveResult.Failure(_)`: emit `Event.ShowImageError(SaveFailed)` and ABORT the save (do NOT call repo update). Keep `pendingImage` so user can retry.
+    - If `pendingImage = RemoveExisting`:
+      - Set `imagePath = null` in change model.
+      - After successful repo update, fire-and-forget `interactor.deleteImage(state.imagePath!!)`.
+    - If `pendingImage = Unchanged`: don't touch image path in the change model (or pass through the existing value — match how non-image fields work).
+  - Sequence is critical: write new file → update DB → only then delete old file. If DB update fails, the new file is orphaned but old file is intact (better outcome than the reverse).
+
+## MVI surface — `feature/all-exercises` deltas
+
+Minimal — just plumbing:
+
+- `ExerciseUiModel` — add `val imagePath: String?`.
+- `AllExercisesUiMapper` — pass through from `ExerciseDataModel.imagePath`.
+- `ExerciseRow` — leading slot becomes:
+  ```kotlin
+  if (item.imagePath != null) {
+      AsyncImage(
+          model = ImageRequest.Builder(LocalContext.current)
+              .data("${item.imagePath}?v=${file.lastModified()}")  // cache-bust
+              .crossfade(true)
+              .build(),
+          contentDescription = null,
+          modifier = Modifier.size(48.dp).clip(AppUi.shapes.small),
+          contentScale = ContentScale.Crop,
+      )
+  } else {
+      ExerciseTypeIcon(type = item.type, modifier = Modifier.size(48.dp))
+  }
+  ```
+  Wrap the `file.lastModified()` call in a remember keyed on path to avoid IO on every recomposition. Or skip cache-busting in the row (image rarely changes in this context — staleness window is acceptable; cache-bust matters most in the edit screen where the user just changed it).
+
+## Compose surface — Edit exercise
+
+`ImageEditRow` placement: between Description field and the Save button area, or as a card at the top of the form (above Name) — match the visual hierarchy from `ux-architecture.md` ("Hero image (v1.5)" listed first under Exercise detail, suggests prominent placement in edit too).
+
+```
+┌──────────────────────────────────────┐
+│  ┌────────┐                           │
+│  │  IMG   │  [Edit image]  [Remove]   │
+│  │ thumb  │                           │
+│  └────────┘                           │
+└──────────────────────────────────────┘
+```
+
+When no image: thumb shows the placeholder icon (reuse `ExerciseHero` styled smaller), `[Remove]` button hidden, `[Edit image]` becomes `[Add image]`.
+
+`ImageSourceDialog` — `AppDialog` (existing component) with two list items: "Take photo" + "Choose from gallery", plus Cancel.
+
+`PermissionDeniedDialog` — `AppDialog` explaining the permission was denied, with primary "Open settings" and secondary "Cancel".
+
+## Localization
+
+New strings (en + ru, both with proper plurals where applicable):
+
+```xml
+<!-- Edit exercise — image -->
+<string name="feature_exercise_image_edit_title">Exercise image</string>
+<string name="feature_exercise_image_action_add">Add image</string>
+<string name="feature_exercise_image_action_edit">Edit image</string>
+<string name="feature_exercise_image_action_remove">Remove</string>
+
+<!-- Source dialog -->
+<string name="feature_exercise_image_source_dialog_title">Choose source</string>
+<string name="feature_exercise_image_source_camera">Take photo</string>
+<string name="feature_exercise_image_source_gallery">Choose from gallery</string>
+
+<!-- Permission -->
+<string name="feature_exercise_image_camera_rationale">
+    Workeeper uses the camera so you can attach a photo of the exercise
+    machine or movement, helping you identify it later in the gym.
+</string>
+<string name="feature_exercise_image_permission_denied_title">Camera permission denied</string>
+<string name="feature_exercise_image_permission_denied_body">
+    To take a photo, grant camera access in app settings. You can still
+    choose an existing photo from your gallery.
+</string>
+<string name="feature_exercise_image_permission_denied_action_settings">Open settings</string>
+
+<!-- Errors -->
+<string name="feature_exercise_image_error_save_failed">Could not save image — try again</string>
+<string name="feature_exercise_image_error_load_failed">Could not load image</string>
+<string name="feature_exercise_image_error_decode_failed">Image format not supported</string>
+```
+
+Russian translations to mirror — pay attention to verb forms ("открыть настройки" / "выбрать из галереи" etc.).
+
+## Testing
+
+### Unit tests
+
+- `ImageStorageImplTest` (JVM with Robolectric for Context, OR androidTest for full integration):
+  - `saveImage` happy path — file exists at expected location, dimensions ≤ 1280, decodable.
+  - `saveImage` overwrites existing file at same path.
+  - `saveImage` returns `Failure(SourceUnreadable)` on bogus URI.
+  - `saveImage` is atomic — corrupt the temp file mid-flight (simulate via mock), verify destination unchanged.
+  - `deleteImage` removes existing file, no-ops on absent file.
+  - `createTempCaptureUri` returns a URI under the temp subdirectory.
+  - `cleanupTempFiles` removes everything in temp subdirectory.
+
+- `ExerciseRepositoryImplTest`:
+  - `deleteItem` removes both the row AND the file.
+  - `deleteAllItems` removes both rows AND all files.
+  - `archiveItem` does NOT delete the file (regression test).
+
+- `feature/exercise`:
+  - `ClickHandlerTest` — `OnEditImageClick` opens source dialog. `OnImageSourceSelected(Camera)` with permission granted emits `Event.LaunchCamera`. With permission denied emits `Event.RequestCameraPermission`. `OnRemoveImageClick` updates State to `RemoveExisting`. `OnCameraPermissionDenied` shows permission denied dialog.
+  - `CommonHandlerTest` — `ImagePicked` sets `pendingImage = NewFromUri`. `ImagePickCancelled` doesn't set pending image.
+  - `PlanEditActionHandlerTest` (or whatever owns Save) — Save with `NewFromUri` calls `saveImage`, on success updates DB with new path, on failure shows error and aborts. Save with `RemoveExisting` updates DB with `null` path. Save with `Unchanged` doesn't touch image path or call ImageStorage.
+  - `ExerciseUiMapperTest` — `effectiveImageDisplay` returns correct variant per pendingImage state.
+
+- `feature/all-exercises`:
+  - `AllExercisesUiMapperTest` — `imagePath` propagates from DataModel to UiModel.
+
+### Compose tests
+
+- `ExerciseEditScreenTest` — when no image, renders Add button + placeholder. When image present (committed), renders thumbnail + Edit + Remove. When `pendingImage = RemoveExisting`, renders placeholder despite committed path (effective display wins). When `pendingImage = NewFromUri`, renders new URI image.
+- `ExerciseDetailScreenTest` — hero shows AsyncImage when `imagePath != null`, placeholder otherwise.
+- `ExerciseRowTest` — leading slot AsyncImage when imagePath, ExerciseTypeIcon otherwise.
+- `ImageSourceDialogTest`, `PermissionDeniedDialogTest` — render + interaction.
+
+### Integration tests (`androidTest`)
+
+- Full picker flow: open Edit exercise → tap Edit image → select Gallery → mock returns a URI → State updates → tap Save → verify file written to expected location and DB updated.
+- Replace flow: existing exercise with image → edit → pick new → save → old file gone, new file present, DB has new path.
+- Remove flow: existing exercise with image → edit → remove → save → file gone, DB null.
+- Cancel flow: existing exercise with image → edit → pick new → press back / cancel → no file changes, DB unchanged.
+- Delete flow: exercise with image → permanent delete → file gone.
+- Archive flow: exercise with image → archive → file present (regression).
+
+## Verification gate
+
+Before marking PR ready:
+
+- `./gradlew assembleDebug` passes.
+- `./gradlew testDebugUnitTest` passes.
+- `./gradlew connectedDebugAndroidTest` passes (integration tests).
+- `./gradlew detekt` passes.
+- `./gradlew lintDebug` passes.
+- Manual on a real device:
+  - Add image via gallery → save → verify hero updates → verify Exercises tab row thumbnail updates.
+  - Add image via camera (permission granted) → save → verify thumbnail.
+  - Deny camera permission → permission dialog shown → "Open settings" deeplinks correctly.
+  - Replace image → save → verify hero shows new image (no stale cache).
+  - Remove image → save → verify placeholder returns.
+  - Cancel during edit → no file artifacts in `filesDir/exercise_images/`.
+  - Permanent delete exercise → file gone from disk (verify via Device Explorer / `adb shell run-as`).
+  - Archive exercise with image → file still present.
+  - Kill app during camera capture (force stop while camera open) → next launch, no temp file left behind.
+  - In RU locale, all new strings translated.
+
+## Constraints
+
+- **SPDX-License-Identifier: GPL-3.0-only** on every new file.
+- ImageStorage is the **only** module that touches filesystem for images. Repos, ViewModels, and UI never call `File()` directly.
+- The save sequence is fixed: write new file → update DB → delete old file. Never reorder.
+- pendingImage in State ONLY — do not write to disk before Save click.
+- No image-related code in `core/database` (it's a pure persistence layer).
+- No image-related code in `feature/single-training`, `feature/all-trainings`, `feature/live-workout`, `feature/past-session`, `feature/home` — exercise-only.
+
+## Implementation prompt (for coding agent)
+
+Read this entire spec before starting. Key callouts below — but the spec is the contract.
+
+Branch: feat/v1-5-exercise-image
+PR title: feat(exercise): image attachment (v1.5)
+PR mode: draft (mark ready after verification gate)
+
+Critical constraints:
+- Save sequence is fixed: write new file → update DB → delete old file. Never reorder.
+- ImageStorage is the only filesystem-touching module for images.
+- Edit semantics are "save on commit" — pendingImage held in State, disk write only on Save click.
+- Archive does NOT delete file. Permanent delete DOES.
+- minSdk 28 — use ImageDecoder, not deprecated BitmapFactory paths.
+- Use existing Coil 3.3.0 (already in libs.versions.toml). Do not add a new image lib.
+- `READ_MEDIA_IMAGES` permission must NOT appear in AndroidManifest — Photo Picker handles gallery without it.
+- `CAMERA` permission is the only runtime permission added.
+- Cache-bust Coil with `?v=<lastModifiedMs>` when path changes (most important on the edit screen).
+
+Locked design decisions are in the "Design decisions (locked)" table — do NOT deviate without raising in PR review.
+
+PR body must include:
+- Files changed grouped by module.
+- Verification gate report (build + tests + detekt + lint + manual scenarios checked off).
+- Note: "First feature attached to a real file lifecycle. Future features needing image attachment (training cover, etc — v2) should reuse core/core/images/ImageStorage."
+- Disk usage estimate: at JPEG q85, 1280×1280, expect ~150-400 KB per image. 100 exercises with photos ≈ 25 MB.
+
+Stop condition: draft PR opened with verification gate passed, ready for review.

--- a/documentation/feature-specs/exercise-image.md
+++ b/documentation/feature-specs/exercise-image.md
@@ -10,11 +10,12 @@ This is the v1.5 spec — a fast follow-up after v1 closure. The first feature o
 
 ## Scope
 
-Three deliverables:
+Four deliverables:
 
 - **ImageStorage utility** in a shared core module — handles compress + save + delete + path generation. Single source of truth for the file lifecycle.
 - **Picker flow in Edit exercise** — camera capture + gallery selection, with permission handling, optimistic UI updates, and "save on commit" semantics so cancelled edits leave no orphan files.
 - **Read-only surfaces in Exercise detail + Exercises tab row** — replace the existing icon placeholder with the actual image when `imagePath != null`, retain the placeholder otherwise.
+- **Full-screen image viewer** — tap-to-open from Exercise detail hero and Edit exercise thumbnail. Pinch-to-zoom + pan + double-tap-to-toggle, hosted as a routed screen.
 
 ## Out of scope
 
@@ -26,6 +27,10 @@ Three deliverables:
 - Sharing / exporting an exercise image — v2.
 - ExifInterface orientation correction beyond what `ImageDecoder` does for free.
 - Migration of `imagePath` for existing exercises — they all stay `null` until the user explicitly attaches; no batch import.
+- **Tap-to-fullscreen on Exercises tab row thumbnail** — row tap opens Exercise detail (existing convention). Adding a separate gesture to open the viewer would conflict.
+- **Swipe-to-dismiss in viewer** — back gesture / back button only. Vertical-drag dismiss is a v2 nice-to-have.
+- **Immersive mode in viewer (hiding system bars)** — viewer renders with normal status/nav bars. Edge-to-edge content via Scaffold + transparent top bar; no `WindowInsetsController` manipulation.
+- **Save / share / delete actions inside viewer** — view-only. Delete + edit are reachable from Exercise detail; the viewer doesn't duplicate them.
 
 ## Design decisions (locked)
 
@@ -44,6 +49,10 @@ These were "open questions" in product.md. Locking them now.
 | File replace | **Atomic via temp file + rename** within `saveImage`. | If process is killed mid-write, old file remains intact. |
 | Lifecycle | **Delete file only on `deleteItem` (permanent)**. Archive does NOT delete the file. | Per product.md: archive preserves history. If unarchived later, image must still be there. |
 | Coil cache invalidation | **Append `?v=<lastModifiedMs>` to the image model** when displaying. | Coil keys cache by URI string. Without versioning, replacing a file at the same path shows the old cached image. |
+| Viewer hosting | **Routed screen via `Screen.ExerciseImage(path)`** | Consistent with project nav model (PastSession, AllTrainings are routes). Saves state across config changes for free. NOT bottom sheet (constrained padding/scrim) and NOT in-place overlay (state lost on rotation). |
+| Viewer zoom impl | **Self-written via `Modifier.pointerInput` + `detectTransformGestures` + `graphicsLayer`** | ~80 lines, no new dependency. Compose Foundation has no first-party zoomable Modifier yet. Adding a third-party lib for one feature isn't justified. |
+| Viewer image quality | **Full file via Coil at native viewport size** | Files are already capped at 1280×1280 by ImageStorage. Most phone viewports ≤ 1280px, so Coil gets full source quality automatically. No extra "high-res" path needed. |
+| Viewer source from Exercises row | **NOT added** — row tap opens Exercise detail (existing convention) | Adding a second gesture to the same row hits the gesture-conflict / discoverability tradeoff with no real win. Detail is one tap away. |
 
 If any of these need to change, surface it in PR review — but the spec assumes them.
 
@@ -102,8 +111,36 @@ feature/
         └── ui/components/
             └── ExerciseRow.kt               # MODIFIED — AsyncImage when path != null, else ExerciseTypeIcon
 
+feature/image-viewer/              # NEW MODULE
+└── src/main/kotlin/.../feature/image_viewer/
+    ├── di/
+    │   ├── ImageViewerFeature.kt
+    │   ├── ImageViewerHandlerStore.kt
+    │   ├── ImageViewerHandlerStoreImpl.kt
+    │   └── ImageViewerModule.kt
+    ├── mvi/
+    │   ├── handler/
+    │   │   ├── ClickHandler.kt              # back, double-tap zoom toggle
+    │   │   ├── CommonHandler.kt             # init from Screen route arg
+    │   │   ├── ImageViewerComponent.kt
+    │   │   └── NavigationHandler.kt
+    │   └── store/
+    │       ├── ImageViewerStore.kt
+    │       └── ImageViewerStoreImpl.kt
+    └── ui/
+        ├── ImageViewerGraph.kt
+        ├── ImageViewerScreen.kt             # full-screen Scaffold + ZoomableImage
+        └── components/
+            └── ZoomableImage.kt             # the gesture/transform Modifier impl
+
+core/ui/navigation/                # MODIFIED
+└── src/main/kotlin/.../core/ui/navigation/
+    └── Screen.kt                            # +data class ExerciseImage(path: String)
+
 app/app/                           # MODIFIED
 ├── src/main/AndroidManifest.xml             # +CAMERA permission, +FileProvider authority
+├── src/main/java/.../host/AppNavigationHost.kt    # +imageViewerGraph(...)
+├── src/main/java/.../navigation/RootComponentImpl.kt  # +Screen.ExerciseImage branch
 ├── src/main/res/xml/
 │   └── file_provider_paths.xml              # NEW — exposes filesDir/exercise_images for camera capture URI
 └── src/main/res/values/strings.xml          # NEW image-related strings (mirrored in values-ru)
@@ -397,12 +434,42 @@ sealed interface Click : Action {
     data object OnPermissionDeniedSettingsClick : Click   // open app settings
     data object RequestCameraCapture : Click       // internal: emitted by permission launcher result
     data object OnCameraPermissionDenied : Click   // internal: emitted by permission launcher result
+    data object OnImageThumbnailClick : Click      // opens viewer (Edit screen + Detail screen)
 }
 
 sealed interface Common : Action {
     // ... existing
     data class ImagePicked(val uri: Uri) : Common
     data object ImagePickCancelled : Common
+}
+```
+
+### Navigation additions
+
+```kotlin
+sealed interface Navigation : Action {
+    // ... existing
+    data class OpenImageViewer(val model: String) : Navigation
+}
+```
+
+`NavigationHandler`:
+
+```kotlin
+is Action.Navigation.OpenImageViewer ->
+    navigator.navTo(Screen.ExerciseImage(action.model))
+```
+
+`ClickHandler.OnImageThumbnailClick` derives the viewer model from current state:
+
+```kotlin
+Action.Click.OnImageThumbnailClick -> {
+    val model = when (val display = state.value.effectiveImageDisplay) {
+        is ImageDisplay.FromPath -> display.path
+        is ImageDisplay.FromUri -> display.uri.toString()
+        ImageDisplay.None -> return  // no-op: thumbnail isn't shown anyway
+    }
+    consume(Action.Navigation.OpenImageViewer(model))
 }
 ```
 
@@ -496,6 +563,238 @@ When no image: thumb shows the placeholder icon (reuse `ExerciseHero` styled sma
 
 `PermissionDeniedDialog` — `AppDialog` explaining the permission was denied, with primary "Open settings" and secondary "Cancel".
 
+## Full-screen image viewer — `feature/image-viewer`
+
+### Trigger surfaces
+
+Two entry points add a tap handler:
+
+- **Exercise detail hero** — `ExerciseHero` (when `imagePath != null`) becomes clickable. Tap → `Action.Click.OnHeroClick` → `Action.Navigation.OpenImageViewer(path)` → `navigator.navTo(Screen.ExerciseImage(path))`.
+- **Edit exercise thumbnail** — the thumbnail in `ImageEditRow` becomes clickable when an effective image is displayed (`effectiveImageDisplay != ImageDisplay.None`). Tap on the **image area** opens viewer; tap on **Edit / Remove buttons** does what those buttons do.
+
+The Exercises tab row thumbnail does NOT trigger the viewer (row tap → Exercise detail; explicit out of scope, see top of spec).
+
+### Viewer source-of-truth
+
+Viewer takes a single `path: String` arg from the route — the absolute file path under `filesDir/exercise_images/`. Viewer does NOT load the exercise from the DB; it doesn't need name/type/tags. This keeps the route stateless and the screen reusable for any future image-viewing need (e.g. v2 training cover).
+
+### Edit-screen viewer for pending image
+
+If the user has just picked a new image (`pendingImage = NewFromUri(uri)`) and taps the thumbnail, the viewer needs to display that **content URI**, not a committed file path. Two reasonable approaches:
+
+- (a) Generalize the route arg to accept either path-or-URI. `Screen.ExerciseImage(modelString)` where `modelString` can be `"/data/.../exercise_images/<uuid>.jpg"` (file path Coil handles natively) OR `"content://..."` from the picker.
+- (b) Disable viewer tap when there's a pending image, only enable for committed paths.
+
+**Pick (a).** Coil's `data` parameter accepts both `String` paths and `Uri` content URIs through the same loader; passing the URI's `toString()` and reconstructing on the receiving side works. Worth verifying in implementation that the content URI's permission grant survives the navigation — content URIs from `PickVisualMedia` get a transient grant that should persist within the same Activity's lifetime; we navigate within the same Activity, so this should hold. If it doesn't, fall back to (b) and document.
+
+### Route + Navigator
+
+Add to `core/ui/navigation/Screen.kt`:
+
+```kotlin
+@Serializable
+data class ExerciseImage(
+    val model: String,    // file path OR content URI string
+) : Screen
+```
+
+No new Navigator method required — uses existing `navTo` and `popBack`.
+
+`AppNavigationHost` registers `imageViewerGraph(...)` like other feature graphs. `RootComponentImpl` adds:
+
+```kotlin
+is Screen.ExerciseImage -> ImageViewerComponent.create(navigator, screen)
+```
+
+### MVI surface
+
+```kotlin
+internal abstract class ImageViewerComponent(
+    val data: Screen.ExerciseImage,
+) : Component
+
+@Stable
+data class State(
+    val model: String,
+    val scale: Float,
+    val offsetX: Float,
+    val offsetY: Float,
+) : Store.State {
+    companion object {
+        const val MIN_SCALE = 1f
+        const val MAX_SCALE = 5f
+        const val DOUBLE_TAP_TARGET_SCALE = 2.5f
+
+        fun initial(model: String): State = State(
+            model = model,
+            scale = MIN_SCALE,
+            offsetX = 0f,
+            offsetY = 0f,
+        )
+    }
+}
+
+@Stable
+sealed interface Action : Store.Action {
+
+    sealed interface Click : Action {
+        data object OnBackClick : Click
+        data object OnDoubleTap : Click
+    }
+
+    sealed interface Common : Action {
+        data class TransformChange(val scaleDelta: Float, val panX: Float, val panY: Float) : Common
+        data object Init : Common
+    }
+
+    sealed interface Navigation : Action {
+        data object Back : Navigation
+    }
+}
+
+@Stable
+sealed interface Event : Store.Event {
+    data class HapticClick(val type: HapticFeedbackType) : Event
+}
+```
+
+Handler logic:
+
+- `CommonHandler.Init` → just confirms `state.model` reflects route arg (already set by initial()).
+- `CommonHandler.TransformChange(scaleDelta, panX, panY)` → compute `newScale = (state.scale * scaleDelta).coerceIn(MIN_SCALE, MAX_SCALE)`. If `newScale == 1f`, snap offset to 0. Otherwise apply pan with bounds (offsets clamped so image edges don't pull beyond viewport when zoomed; bounds = `(scale - 1) * viewportSize / 2` per axis, computed from the LayoutCoordinates the screen owns and passed in via the action).
+- `ClickHandler.OnDoubleTap` → toggle scale: if `scale > MIN_SCALE`, animate to `MIN_SCALE` (and reset offsets); else animate to `DOUBLE_TAP_TARGET_SCALE`. Animation in the UI layer via `Animatable`.
+- `ClickHandler.OnBackClick` → `consume(Action.Navigation.Back)`.
+- `NavigationHandler.Back` → `navigator.popBack()`.
+
+The transform clamp logic depends on viewport size. Two options:
+- (a) Pass viewport dimensions in the action: `TransformChange(scaleDelta, panX, panY, viewportWidth, viewportHeight)`. Store does math.
+- (b) Do all gesture math in the Composable, store only the final clamped values.
+
+**Pick (b).** Less data marshalling, gesture math is presentational concern. Store holds final scale/offset; Composable does the clamping using `LayoutCoordinates`. Action becomes simpler:
+
+```kotlin
+data class TransformChange(val scale: Float, val offsetX: Float, val offsetY: Float) : Common
+```
+
+Composable computes new scale + clamped offsets, sends absolute values.
+
+### Compose surface — `ImageViewerScreen`
+
+```kotlin
+@Composable
+internal fun ImageViewerScreen(
+    state: ImageViewerStore.State,
+    consume: (ImageViewerStore.Action) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            AppTopAppBar(
+                title = { /* empty — no clutter */ },
+                navigationIcon = {
+                    IconButton(onClick = { consume(Action.Click.OnBackClick) }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.feature_image_viewer_back))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                ),
+            )
+        },
+        containerColor = Color.Black,
+    ) { padding ->
+        ZoomableImage(
+            model = state.model,
+            scale = state.scale,
+            offsetX = state.offsetX,
+            offsetY = state.offsetY,
+            onTransform = { newScale, newOffsetX, newOffsetY ->
+                consume(Action.Common.TransformChange(newScale, newOffsetX, newOffsetY))
+            },
+            onDoubleTap = { consume(Action.Click.OnDoubleTap) },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        )
+    }
+}
+```
+
+`BackHandler { consume(Action.Click.OnBackClick) }` — system-back goes through the same Action path as the icon. Not strictly required (default popBack works), but keeps haptic + analytics consistent if added later.
+
+### `ZoomableImage` composable
+
+```kotlin
+@Composable
+internal fun ZoomableImage(
+    model: String,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float,
+    onTransform: (scale: Float, offsetX: Float, offsetY: Float) -> Unit,
+    onDoubleTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val animatedScale by animateFloatAsState(scale, label = "scale")
+    val animatedOffsetX by animateFloatAsState(offsetX, label = "offsetX")
+    val animatedOffsetY by animateFloatAsState(offsetY, label = "offsetY")
+
+    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
+
+    Box(
+        modifier = modifier
+            .onSizeChanged { viewportSize = it }
+            .pointerInput(viewportSize) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    val newScale = (scale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
+                    val newOffsetX: Float
+                    val newOffsetY: Float
+                    if (newScale <= MIN_SCALE) {
+                        newOffsetX = 0f
+                        newOffsetY = 0f
+                    } else {
+                        val maxOffsetX = (viewportSize.width * (newScale - 1f)) / 2f
+                        val maxOffsetY = (viewportSize.height * (newScale - 1f)) / 2f
+                        newOffsetX = (offsetX + pan.x).coerceIn(-maxOffsetX, maxOffsetX)
+                        newOffsetY = (offsetY + pan.y).coerceIn(-maxOffsetY, maxOffsetY)
+                    }
+                    onTransform(newScale, newOffsetX, newOffsetY)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(onDoubleTap = { onDoubleTap() })
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        AsyncImage(
+            model = model,    // Coil handles file path or content URI string
+            contentDescription = stringResource(R.string.feature_image_viewer_content_description),
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                    translationX = animatedOffsetX
+                    translationY = animatedOffsetY
+                },
+        )
+    }
+}
+```
+
+Two `pointerInput` blocks because `detectTransformGestures` and `detectTapGestures` can't compose in a single block — Compose runs the first matching detector and ignores others within the same `pointerInput`. Splitting them lets both run.
+
+Note: `detectTapGestures(onDoubleTap = ...)` consumes single taps too — but here that's fine because there's no single-tap action. If a single-tap-to-toggle-bars feature were added later, the second `pointerInput` would need restructuring.
+
+### Edge cases
+
+- **File missing at viewer open** — Coil renders nothing / its error placeholder. Handle by setting `error` and `fallback` on `ImageRequest.Builder` to show a simple "Image unavailable" overlay. State doesn't need to track this; UI-only concern.
+- **Rotation during zoomed state** — viewer survives via routed nav; State persists; offsets are absolute pixel values that may not map perfectly to new viewport. Acceptable: on rotation, clamp re-runs on next gesture and snaps to bounds. If the visible glitch is bad, reset to MIN_SCALE on viewport change (`LaunchedEffect(viewportSize) { if (oldSize != newSize) consume(reset) }`). Defer until it's actually a problem.
+- **Process death** — ROM-dependent; Compose state is lost, but `Screen.ExerciseImage(model)` route arg survives via SavedStateHandle. Viewer reopens at MIN_SCALE. Acceptable.
+- **Content URI permission expired** — if Edit-screen viewer fails to load a content URI because the grant lapsed (theoretical edge case across long viewer sessions / process restart), Coil shows error placeholder. User taps back, picks again. Document but don't prevent.
+
+
 ## Localization
 
 New strings (en + ru, both with proper plurals where applicable):
@@ -528,6 +827,11 @@ New strings (en + ru, both with proper plurals where applicable):
 <string name="feature_exercise_image_error_save_failed">Could not save image — try again</string>
 <string name="feature_exercise_image_error_load_failed">Could not load image</string>
 <string name="feature_exercise_image_error_decode_failed">Image format not supported</string>
+
+<!-- Image viewer -->
+<string name="feature_image_viewer_back">Back</string>
+<string name="feature_image_viewer_content_description">Exercise image, full size</string>
+<string name="feature_image_viewer_unavailable">Image unavailable</string>
 ```
 
 Russian translations to mirror — pay attention to verb forms ("открыть настройки" / "выбрать из галереи" etc.).
@@ -559,12 +863,19 @@ Russian translations to mirror — pay attention to verb forms ("открыть 
 - `feature/all-exercises`:
   - `AllExercisesUiMapperTest` — `imagePath` propagates from DataModel to UiModel.
 
+- `feature/image-viewer`:
+  - `ClickHandlerTest` — `OnBackClick` emits `Action.Navigation.Back`. `OnDoubleTap` toggles scale: from MIN_SCALE → DOUBLE_TAP_TARGET_SCALE; from any > MIN_SCALE → MIN_SCALE with reset offsets.
+  - `CommonHandlerTest` — `TransformChange` updates state with passed values. `Init` no-op (state already from initial()).
+  - `NavigationHandlerTest` — `Back` calls `navigator.popBack()`.
+  - No mapper test — viewer has no domain → UI mapping; route arg flows through unchanged.
+
 ### Compose tests
 
 - `ExerciseEditScreenTest` — when no image, renders Add button + placeholder. When image present (committed), renders thumbnail + Edit + Remove. When `pendingImage = RemoveExisting`, renders placeholder despite committed path (effective display wins). When `pendingImage = NewFromUri`, renders new URI image.
 - `ExerciseDetailScreenTest` — hero shows AsyncImage when `imagePath != null`, placeholder otherwise.
 - `ExerciseRowTest` — leading slot AsyncImage when imagePath, ExerciseTypeIcon otherwise.
 - `ImageSourceDialogTest`, `PermissionDeniedDialogTest` — render + interaction.
+- `ImageViewerScreenTest` — renders AsyncImage with passed model; back icon click emits OnBackClick; tapping image area twice in quick succession emits OnDoubleTap; pinch gesture (synthesized via robolectric/compose test injectors) emits TransformChange. Real pinch + bound clamping are best validated in androidTest (see Integration tests).
 
 ### Integration tests (`androidTest`)
 
@@ -574,6 +885,10 @@ Russian translations to mirror — pay attention to verb forms ("открыть 
 - Cancel flow: existing exercise with image → edit → pick new → press back / cancel → no file changes, DB unchanged.
 - Delete flow: exercise with image → permanent delete → file gone.
 - Archive flow: exercise with image → archive → file present (regression).
+- Viewer open from Detail: tap hero with imagePath set → ImageViewerScreen reached → back gesture returns to Detail with same scroll position.
+- Viewer open from Edit (committed image): tap thumbnail → viewer opens → back returns to Edit with form state preserved (pendingImage still Unchanged).
+- Viewer open from Edit (pending image): pick new image → tap thumbnail → viewer shows the new content URI → back → pending state intact, picker hasn't re-fired.
+- Viewer pinch-zoom: programmatic pinch gesture → scale increases → max scale clamped at 5f. Pan only available when scale > 1f. Pan clamped to image bounds.
 
 ## Verification gate
 
@@ -594,6 +909,11 @@ Before marking PR ready:
   - Permanent delete exercise → file gone from disk (verify via Device Explorer / `adb shell run-as`).
   - Archive exercise with image → file still present.
   - Kill app during camera capture (force stop while camera open) → next launch, no temp file left behind.
+  - Tap hero on Exercise detail (with image) → viewer opens, image fits viewport, status bar visible.
+  - In viewer: pinch to zoom in, pan around — image bounds clamp pan correctly. Pinch out → image snaps back to MIN_SCALE = 1f and centers.
+  - In viewer: double-tap zoomed-out image → animates to ~2.5x. Double-tap again → animates back to 1f.
+  - Back gesture from viewer → returns to entry screen.
+  - Tap thumbnail in Edit screen with a freshly picked (uncommitted) image → viewer shows the picked image (content URI). Back → Edit screen still has `pendingImage = NewFromUri`.
   - In RU locale, all new strings translated.
 
 ## Constraints
@@ -623,6 +943,12 @@ Critical constraints:
 - `READ_MEDIA_IMAGES` permission must NOT appear in AndroidManifest — Photo Picker handles gallery without it.
 - `CAMERA` permission is the only runtime permission added.
 - Cache-bust Coil with `?v=<lastModifiedMs>` when path changes (most important on the edit screen).
+- Viewer is a routed screen, NOT a bottom sheet or in-place overlay.
+- Viewer takes a single `model: String` route arg — file path OR content URI string. Coil handles both.
+- Viewer triggers from Detail hero + Edit thumbnail ONLY. Exercises tab row stays as-is (tap → Detail).
+- Viewer zoom: self-written via Modifier.pointerInput, no third-party library.
+- Viewer scale clamp [1f, 5f]; pan only when scale > 1f; double-tap toggles 1f ↔ 2.5f.
+- Pan bounds = ((scale - 1) * viewportSize) / 2 per axis. No bleed beyond image edges.
 
 Locked design decisions are in the "Design decisions (locked)" table — do NOT deviate without raising in PR review.
 
@@ -630,6 +956,7 @@ PR body must include:
 - Files changed grouped by module.
 - Verification gate report (build + tests + detekt + lint + manual scenarios checked off).
 - Note: "First feature attached to a real file lifecycle. Future features needing image attachment (training cover, etc — v2) should reuse core/core/images/ImageStorage."
+- Note: "Image viewer is generic over its `model` arg (file path OR content URI). Future image-viewing needs (training cover viewer, set-photo viewer) should reuse `Screen.ExerciseImage` route or refactor it to a generically-named `Screen.ImageViewer` if/when that's needed."
 - Disk usage estimate: at JPEG q85, 1280×1280, expect ~150-400 KB per image. 100 exercises with photos ≈ 25 MB.
 
 Stop condition: draft PR opened with verification gate passed, ready for review.

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapper.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapper.kt
@@ -17,6 +17,7 @@ internal fun ExerciseDataModel.toUi(
     type = type,
     tags = if (tags.isEmpty()) persistentListOf() else tags.toImmutableList(),
     sessionCount = sessionCount,
+    imagePath = imagePath,
 )
 
 internal fun TagDataModel.toUi(): TagUiModel = TagUiModel(uuid = uuid, name = name)

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/model/ExerciseUiModel.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/model/ExerciseUiModel.kt
@@ -12,4 +12,5 @@ data class ExerciseUiModel(
     val type: ExerciseTypeDataModel,
     val tags: ImmutableList<String>,
     val sessionCount: Int,
+    val imagePath: String?,
 )

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
@@ -21,14 +21,21 @@ import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.ui.kit.components.swipe.AppSwipeAction
 import io.github.stslex.workeeper.core.ui.kit.components.tag.AppTagChip
@@ -38,8 +45,10 @@ import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.feature.all_exercises.R
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseUiModel
 import kotlinx.collections.immutable.persistentListOf
+import java.io.File
 
 private const val MAX_INLINE_TAGS = 3
+private val LEADING_THUMB_SIZE = 28.dp
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("LongParameterList")
@@ -71,7 +80,7 @@ internal fun ExerciseRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
         ) {
-            ExerciseTypeIcon(type = item.type)
+            ExerciseLeading(item = item)
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xxs),
@@ -137,6 +146,32 @@ internal fun ExerciseRow(
 }
 
 @Composable
+private fun ExerciseLeading(
+    item: ExerciseUiModel,
+) {
+    val path = item.imagePath
+    if (path != null) {
+        // Capture mtime once per recomposition for cache-busting; do not re-read the file
+        // on every recompose. The library tab tolerates a small staleness window — the
+        // edit screen does the more aggressive cache-busting.
+        val lastModified = remember(path) { File(path).lastModified() }
+        AsyncImage(
+            modifier = Modifier
+                .size(LEADING_THUMB_SIZE)
+                .clip(AppUi.shapes.small),
+            model = ImageRequest.Builder(LocalContext.current)
+                .data("$path?v=$lastModified")
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        ExerciseTypeIcon(type = item.type)
+    }
+}
+
+@Composable
 private fun ExerciseRowTags(
     tags: kotlinx.collections.immutable.ImmutableList<String>,
     modifier: Modifier = Modifier,
@@ -175,6 +210,7 @@ private fun ExerciseRowPreview() {
             type = ExerciseTypeDataModel.WEIGHTED,
             tags = persistentListOf("Push", "Chest"),
             sessionCount = 12,
+            imagePath = null,
         ),
         ExerciseUiModel(
             uuid = "2",
@@ -182,6 +218,7 @@ private fun ExerciseRowPreview() {
             type = ExerciseTypeDataModel.WEIGHTLESS,
             tags = persistentListOf("Pull", "Back", "Calisthenics", "Upper"),
             sessionCount = 4,
+            imagePath = null,
         ),
         ExerciseUiModel(
             uuid = "3",
@@ -189,6 +226,7 @@ private fun ExerciseRowPreview() {
             type = ExerciseTypeDataModel.WEIGHTED,
             tags = persistentListOf(),
             sessionCount = 0,
+            imagePath = null,
         ),
     )
     AppTheme {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractor.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractor.kt
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.domain
 
+import android.net.Uri
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
 import io.github.stslex.workeeper.core.database.sets.PlanSetDataModel
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseDataModel
@@ -9,6 +11,7 @@ import io.github.stslex.workeeper.core.exercise.tags.model.TagDataModel
 import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
+@Suppress("TooManyFunctions")
 internal interface ExerciseInteractor {
 
     suspend fun getExercise(uuid: String): ExerciseDataModel?
@@ -39,6 +42,12 @@ internal interface ExerciseInteractor {
     suspend fun setAdhocPlan(uuid: String, plan: List<PlanSetDataModel>?)
 
     suspend fun clearWeightsFromAllPlansForExercise(uuid: String)
+
+    suspend fun saveImage(uri: Uri, exerciseUuid: String): ImageSaveResult
+
+    suspend fun createTempCaptureUri(): Uri
+
+    suspend fun deleteImageFile(path: String): Boolean
 
     sealed interface ArchiveResult {
 

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.domain
 
+import android.net.Uri
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.core.images.ImageStorage
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
 import io.github.stslex.workeeper.core.database.sets.PlanSetDataModel
 import io.github.stslex.workeeper.core.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseChangeDataModel
@@ -22,6 +25,7 @@ import javax.inject.Inject
 internal class ExerciseInteractorImpl @Inject constructor(
     private val exerciseRepository: ExerciseRepository,
     private val tagRepository: TagRepository,
+    private val imageStorage: ImageStorage,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ExerciseInteractor {
 
@@ -102,4 +106,13 @@ internal class ExerciseInteractorImpl @Inject constructor(
             exerciseRepository.clearWeightsFromAllPlansForExercise(uuid)
         }
     }
+
+    override suspend fun saveImage(
+        uri: Uri,
+        exerciseUuid: String,
+    ): ImageSaveResult = imageStorage.saveImage(uri, exerciseUuid)
+
+    override suspend fun createTempCaptureUri(): Uri = imageStorage.createTempCaptureUri()
+
+    override suspend fun deleteImageFile(path: String): Boolean = imageStorage.deleteImage(path)
 }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandler.kt
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.mvi.handler
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.MainImmediateDispatcher
+import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.core.utils.CommonExt.parseOrRandom
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseChangeDataModel
@@ -16,6 +22,9 @@ import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.SaveResult
 import io.github.stslex.workeeper.feature.exercise.mvi.mapper.toAdhocPlanSummary
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageErrorType
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageSourceUiModel
+import io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage
 import io.github.stslex.workeeper.feature.exercise.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.DiscardTarget
@@ -34,6 +43,8 @@ import kotlin.uuid.Uuid
 internal class ClickHandler @Inject constructor(
     private val interactor: ExerciseInteractor,
     private val resourceWrapper: ResourceWrapper,
+    @ApplicationContext
+    private val context: Context,
     @MainImmediateDispatcher
     private val mainDispatcher: CoroutineDispatcher,
     store: ExerciseHandlerStore,
@@ -63,6 +74,14 @@ internal class ClickHandler @Inject constructor(
             is Action.Click.OnTagToggle -> processTagToggle(action)
             is Action.Click.OnTagRemove -> processTagRemove(action)
             is Action.Click.OnTagCreate -> processTagCreate(action)
+            Action.Click.OnEditImageClick -> processEditImageClick()
+            is Action.Click.OnImageSourceSelected -> processImageSourceSelected(action)
+            Action.Click.OnRemoveImageClick -> processRemoveImageClick()
+            Action.Click.OnImageSourceDialogDismiss -> processImageSourceDialogDismiss()
+            Action.Click.OnPermissionDeniedDialogDismiss -> processPermissionDeniedDialogDismiss()
+            Action.Click.OnPermissionDeniedSettingsClick -> processPermissionDeniedSettingsClick()
+            Action.Click.RequestCameraCapture -> launchCameraCapture()
+            Action.Click.OnCameraPermissionDenied -> processCameraPermissionDenied()
         }
     }
 
@@ -153,6 +172,7 @@ internal class ClickHandler @Inject constructor(
         consume(Action.Navigation.OpenSession(action.sessionUuid))
     }
 
+    @Suppress("LongMethod")
     private fun processSaveClick() {
         val current = state.value
         if (current.name.isBlank()) {
@@ -166,33 +186,87 @@ internal class ClickHandler @Inject constructor(
         // on a background thread. Switch to mainDispatcher before consume(Action.Navigation.*)
         // so navigator.popBack() lands on the UI thread.
 
+        val resolvedUuid = Uuid.parseOrRandom(current.uuid)
         launch(
-            onSuccess = { result ->
-                when (result) {
-                    is SaveResult.Success -> {
-                        handleSaveSuccess(
-                            resolvedUuid = result.resolvedUuid.toString(),
-                            isCreate = isCreate,
-                            current = current,
-                        )
-                    }
+            onSuccess = { outcome ->
+                when (outcome) {
+                    is SaveOutcome.Success -> handleSaveSuccess(
+                        resolvedUuid = outcome.resolvedUuid,
+                        isCreate = isCreate,
+                        current = current,
+                        finalImagePath = outcome.finalImagePath,
+                    )
 
-                    SaveResult.DuplicateName -> updateStateImmediate {
+                    SaveOutcome.DuplicateName -> updateStateImmediate {
                         it.copy(nameDuplicateError = true)
                     }
+
+                    SaveOutcome.ImageSaveFailed -> Unit // error toast already emitted.
                 }
             },
         ) {
+            // Commit pending image first; if it fails, abort the DB write so we never
+            // end up with a half-applied save (image referenced from DB but missing on disk).
+            val imageOutcome = commitPendingImage(current, resolvedUuid)
+            if (imageOutcome is ImageCommitOutcome.Failed) {
+                sendEvent(Event.ShowImageError(ImageErrorType.SaveFailed))
+                return@launch SaveOutcome.ImageSaveFailed
+            }
+            val finalImagePath = when (imageOutcome) {
+                is ImageCommitOutcome.Stored -> imageOutcome.newPath
+                is ImageCommitOutcome.Removed -> null
+                ImageCommitOutcome.Unchanged -> current.imagePath
+                ImageCommitOutcome.Failed -> error("unreachable")
+            }
             val snapshot = ExerciseChangeDataModel(
-                uuid = Uuid.parseOrRandom(current.uuid),
+                uuid = resolvedUuid,
                 name = current.name.trim(),
                 type = current.type.toData(),
                 description = current.description.takeIf { it.isNotBlank() },
+                imagePath = finalImagePath,
                 timestamp = System.currentTimeMillis(),
                 labels = current.tags.map { it.name },
                 lastAdHocSets = current.adhocPlan?.map { it.toData() },
             )
-            interactor.saveExercise(snapshot)
+            when (interactor.saveExercise(snapshot)) {
+                is SaveResult.Success -> {
+                    // Only after the DB row is updated do we delete the previous file —
+                    // a process kill between write and DB update leaves an orphaned new file
+                    // (better than the reverse, which would leave the DB pointing at nothing).
+                    if (imageOutcome is ImageCommitOutcome.Stored) {
+                        imageOutcome.previousPath
+                            ?.takeIf { it.isNotBlank() && it != imageOutcome.newPath }
+                            ?.let { interactor.deleteImageFile(it) }
+                    }
+                    if (imageOutcome is ImageCommitOutcome.Removed) {
+                        imageOutcome.previousPath?.let { interactor.deleteImageFile(it) }
+                    }
+                    SaveOutcome.Success(
+                        resolvedUuid = resolvedUuid.toString(),
+                        finalImagePath = finalImagePath,
+                    )
+                }
+
+                SaveResult.DuplicateName -> SaveOutcome.DuplicateName
+            }
+        }
+    }
+
+    private suspend fun commitPendingImage(
+        current: State,
+        resolvedUuid: Uuid,
+    ): ImageCommitOutcome = when (val pending = current.pendingImage) {
+        PendingImage.Unchanged -> ImageCommitOutcome.Unchanged
+        PendingImage.RemoveExisting -> ImageCommitOutcome.Removed(previousPath = current.imagePath)
+        is PendingImage.NewFromUri -> when (
+            val saveResult = interactor.saveImage(pending.uri, resolvedUuid.toString())
+        ) {
+            is ImageSaveResult.Success -> ImageCommitOutcome.Stored(
+                newPath = saveResult.absolutePath,
+                previousPath = current.imagePath,
+            )
+
+            is ImageSaveResult.Failure -> ImageCommitOutcome.Failed
         }
     }
 
@@ -200,6 +274,7 @@ internal class ClickHandler @Inject constructor(
         resolvedUuid: String,
         isCreate: Boolean,
         current: State,
+        finalImagePath: String?,
     ) {
         if (isCreate) {
             withContext(mainDispatcher) {
@@ -212,14 +287,40 @@ internal class ClickHandler @Inject constructor(
                 description = current.description,
                 tagUuids = current.tags.map { it.uuid },
             )
-            updateStateImmediate {
-                it.copy(
+            updateStateImmediate { latest ->
+                latest.copy(
                     uuid = resolvedUuid,
                     mode = Mode.Read,
                     originalSnapshot = savedSnapshot,
+                    imagePath = finalImagePath,
+                    imageLastModified = System.currentTimeMillis(),
+                    pendingImage = PendingImage.Unchanged,
                 )
             }
         }
+    }
+
+    private sealed interface SaveOutcome {
+
+        data class Success(
+            val resolvedUuid: String,
+            val finalImagePath: String?,
+        ) : SaveOutcome
+
+        data object DuplicateName : SaveOutcome
+
+        data object ImageSaveFailed : SaveOutcome
+    }
+
+    private sealed interface ImageCommitOutcome {
+
+        data object Unchanged : ImageCommitOutcome
+
+        data class Stored(val newPath: String, val previousPath: String?) : ImageCommitOutcome
+
+        data class Removed(val previousPath: String?) : ImageCommitOutcome
+
+        data object Failed : ImageCommitOutcome
     }
 
     private fun processCancelClick() {
@@ -249,7 +350,7 @@ internal class ClickHandler @Inject constructor(
         updateState { current ->
             val snapshot = current.originalSnapshot
             if (snapshot == null) {
-                current.copy(mode = Mode.Read)
+                current.copy(mode = Mode.Read, pendingImage = PendingImage.Unchanged)
             } else {
                 current.copy(
                     mode = Mode.Read,
@@ -262,6 +363,7 @@ internal class ClickHandler @Inject constructor(
                         .filter { tag -> tag.uuid in snapshot.tagUuids }
                         .toImmutableList(),
                     tagSearchQuery = "",
+                    pendingImage = PendingImage.Unchanged,
                 )
             }
         }
@@ -456,6 +558,70 @@ internal class ClickHandler @Inject constructor(
             interactor.createTag(action.name.trim())
         }
     }
+
+    private fun processEditImageClick() {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
+        updateState { it.copy(sourceDialogVisible = true) }
+    }
+
+    private fun processImageSourceSelected(action: Action.Click.OnImageSourceSelected) {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
+        updateState { it.copy(sourceDialogVisible = false) }
+        when (action.source) {
+            ImageSourceUiModel.Camera -> {
+                if (hasCameraPermission()) {
+                    launchCameraCapture()
+                } else {
+                    sendEvent(Event.NavigateRequestCameraPermission)
+                }
+            }
+
+            ImageSourceUiModel.Gallery -> sendEvent(Event.NavigateLaunchGallery)
+        }
+    }
+
+    private fun launchCameraCapture() {
+        launch(
+            onSuccess = { tempUri ->
+                sendEvent(Event.NavigateLaunchCamera(tempUri))
+            },
+        ) {
+            interactor.createTempCaptureUri()
+        }
+    }
+
+    private fun processRemoveImageClick() {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
+        updateState {
+            it.copy(
+                pendingImage = PendingImage.RemoveExisting,
+                sourceDialogVisible = false,
+            )
+        }
+    }
+
+    private fun processImageSourceDialogDismiss() {
+        updateState { it.copy(sourceDialogVisible = false) }
+    }
+
+    private fun processPermissionDeniedDialogDismiss() {
+        updateState { it.copy(permissionDeniedDialogVisible = false) }
+    }
+
+    private fun processPermissionDeniedSettingsClick() {
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
+        updateState { it.copy(permissionDeniedDialogVisible = false) }
+        sendEvent(Event.NavigateOpenAppSettings(context.packageName))
+    }
+
+    private fun processCameraPermissionDenied() {
+        updateState { it.copy(permissionDeniedDialogVisible = true) }
+    }
+
+    private fun hasCameraPermission(): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA,
+    ) == PackageManager.PERMISSION_GRANTED
 
     companion object {
         private const val MAX_TAGS_PER_EXERCISE = 10

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandler.kt
@@ -22,6 +22,7 @@ import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.SaveResult
 import io.github.stslex.workeeper.feature.exercise.mvi.mapper.toAdhocPlanSummary
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageDisplay
 import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageErrorType
 import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageSourceUiModel
 import io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage
@@ -75,6 +76,7 @@ internal class ClickHandler @Inject constructor(
             is Action.Click.OnTagRemove -> processTagRemove(action)
             is Action.Click.OnTagCreate -> processTagCreate(action)
             Action.Click.OnEditImageClick -> processEditImageClick()
+            Action.Click.OnImageThumbnailClick -> processImageThumbnailClick()
             is Action.Click.OnImageSourceSelected -> processImageSourceSelected(action)
             Action.Click.OnRemoveImageClick -> processRemoveImageClick()
             Action.Click.OnImageSourceDialogDismiss -> processImageSourceDialogDismiss()
@@ -562,6 +564,19 @@ internal class ClickHandler @Inject constructor(
     private fun processEditImageClick() {
         sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
         updateState { it.copy(sourceDialogVisible = true) }
+    }
+
+    private fun processImageThumbnailClick() {
+        // Derive the viewer's model arg from whatever is currently displayed — committed
+        // file path OR the freshly-picked content URI. ImageDisplay.None means the
+        // thumbnail isn't visible anyway, so the click can't physically happen.
+        val model = when (val display = state.value.effectiveImageDisplay) {
+            is ImageDisplay.FromPath -> display.path
+            is ImageDisplay.FromUri -> display.uri.toString()
+            ImageDisplay.None -> return
+        }
+        sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
+        consume(Action.Navigation.OpenImageViewer(model))
     }
 
     private fun processImageSourceSelected(action: Action.Click.OnImageSourceSelected) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/CommonHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/CommonHandler.kt
@@ -13,11 +13,13 @@ import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
 import io.github.stslex.workeeper.feature.exercise.mvi.mapper.toAdhocPlanSummary
 import io.github.stslex.workeeper.feature.exercise.mvi.mapper.toUi
+import io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage
 import io.github.stslex.workeeper.feature.exercise.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.State
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
+import java.io.File
 import javax.inject.Inject
 
 @ViewModelScoped
@@ -30,7 +32,22 @@ internal class CommonHandler @Inject constructor(
     override fun invoke(action: Action.Common) {
         when (action) {
             Action.Common.Init -> processInit()
+            is Action.Common.ImagePicked -> processImagePicked(action)
+            Action.Common.ImagePickCancelled -> processImagePickCancelled()
         }
+    }
+
+    private fun processImagePicked(action: Action.Common.ImagePicked) {
+        updateState {
+            it.copy(
+                pendingImage = PendingImage.NewFromUri(action.uri),
+                sourceDialogVisible = false,
+            )
+        }
+    }
+
+    private fun processImagePickCancelled() {
+        updateState { it.copy(sourceDialogVisible = false) }
     }
 
     private fun processInit() {
@@ -79,6 +96,10 @@ internal class CommonHandler @Inject constructor(
                 matched ?: TagUiModel(uuid = name, name = name)
             }
             .toImmutableList()
+        val imagePath = exercise.imagePath
+        // Capture the file's mtime so Coil can key by `?v=<mtime>` and avoid serving a
+        // stale cache entry when the user replaces the image at the same path.
+        val imageLastModified = imagePath?.let { File(it).lastModified() } ?: 0L
         return copy(
             name = exercise.name,
             type = exercise.type.toUi(),
@@ -89,6 +110,9 @@ internal class CommonHandler @Inject constructor(
             canPermanentlyDelete = result.canPermanentlyDelete,
             adhocPlan = adhocPlan,
             adhocPlanSummaryLabel = adhocPlan.toAdhocPlanSummary(resourceWrapper),
+            imagePath = imagePath,
+            imageLastModified = imageLastModified,
+            pendingImage = PendingImage.Unchanged,
             originalSnapshot = State.Snapshot(
                 name = exercise.name,
                 type = exercise.type.toUi(),

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageDisplay.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageDisplay.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.mvi.model
+
+import android.net.Uri
+import androidx.compose.runtime.Stable
+
+@Stable
+sealed interface ImageDisplay {
+
+    data object None : ImageDisplay
+
+    data class FromPath(val path: String, val lastModified: Long) : ImageDisplay
+
+    data class FromUri(val uri: Uri) : ImageDisplay
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageErrorType.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageErrorType.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.mvi.model
+
+enum class ImageErrorType {
+    SaveFailed,
+    LoadFailed,
+    DecodeFailed,
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageSourceUiModel.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/ImageSourceUiModel.kt
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.mvi.model
+
+enum class ImageSourceUiModel {
+    Camera,
+    Gallery,
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/PendingImage.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/model/PendingImage.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.mvi.model
+
+import android.net.Uri
+import androidx.compose.runtime.Stable
+
+@Stable
+sealed interface PendingImage {
+
+    data object Unchanged : PendingImage
+
+    data class NewFromUri(val uri: Uri) : PendingImage
+
+    data object RemoveExisting : PendingImage
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/store/ExerciseStore.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/store/ExerciseStore.kt
@@ -201,6 +201,8 @@ internal interface ExerciseStore : Store<State, Action, Event> {
 
             data object OnEditImageClick : Click
 
+            data object OnImageThumbnailClick : Click
+
             data class OnImageSourceSelected(val source: ImageSourceUiModel) : Click
 
             data object OnRemoveImageClick : Click
@@ -235,6 +237,8 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             data object Back : Navigation
 
             data class OpenSession(val sessionUuid: String) : Navigation
+
+            data class OpenImageViewer(val model: String) : Navigation
         }
     }
 

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/store/ExerciseStore.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/store/ExerciseStore.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.mvi.store
 
+import android.net.Uri
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.mvi.Store
@@ -8,6 +9,10 @@ import io.github.stslex.workeeper.core.ui.plan_editor.model.AppPlanEditorAction
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.feature.exercise.mvi.model.HistoryUiModel
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageDisplay
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageErrorType
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageSourceUiModel
+import io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage
 import io.github.stslex.workeeper.feature.exercise.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Event
@@ -37,16 +42,35 @@ internal interface ExerciseStore : Store<State, Action, Event> {
         val adhocPlanSummaryLabel: String,
         val planEditorTarget: PlanEditorTarget?,
         val pendingTypeChange: ExerciseTypeUiModel?,
+        val imagePath: String?,
+        val imageLastModified: Long,
+        val pendingImage: PendingImage,
+        val sourceDialogVisible: Boolean,
+        val permissionDeniedDialogVisible: Boolean,
     ) : Store.State {
 
         val isSaveEnabled: Boolean
             get() = name.isNotBlank()
 
         val hasChanges: Boolean
-            get() = originalSnapshot?.matches(this) == false
+            get() = originalSnapshot?.matches(this) == false || isImageDirty
 
         val isPlanEditorDirty: Boolean
             get() = planEditorTarget?.let { it.draft != it.initialPlan } == true
+
+        val isImageDirty: Boolean
+            get() = pendingImage != PendingImage.Unchanged
+
+        /** What the UI should display right now — pending overrides committed. */
+        val effectiveImageDisplay: ImageDisplay
+            get() = when (val pending = pendingImage) {
+                is PendingImage.NewFromUri -> ImageDisplay.FromUri(pending.uri)
+                PendingImage.RemoveExisting -> ImageDisplay.None
+                PendingImage.Unchanged -> when (val path = imagePath) {
+                    null -> ImageDisplay.None
+                    else -> ImageDisplay.FromPath(path, lastModified = imageLastModified)
+                }
+            }
 
         /**
          * True only when the system back gesture must surface the discard-changes dialog,
@@ -108,6 +132,11 @@ internal interface ExerciseStore : Store<State, Action, Event> {
                 adhocPlanSummaryLabel = "",
                 planEditorTarget = null,
                 pendingTypeChange = null,
+                imagePath = null,
+                imageLastModified = 0L,
+                pendingImage = PendingImage.Unchanged,
+                sourceDialogVisible = false,
+                permissionDeniedDialogVisible = false,
             )
         }
     }
@@ -118,6 +147,10 @@ internal interface ExerciseStore : Store<State, Action, Event> {
         sealed interface Common : Action {
 
             data object Init : Common
+
+            data class ImagePicked(val uri: Uri) : Common
+
+            data object ImagePickCancelled : Common
         }
 
         sealed interface Click : Action {
@@ -165,6 +198,24 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             data class OnTagRemove(val tagUuid: String) : Click
 
             data class OnTagCreate(val name: String) : Click
+
+            data object OnEditImageClick : Click
+
+            data class OnImageSourceSelected(val source: ImageSourceUiModel) : Click
+
+            data object OnRemoveImageClick : Click
+
+            data object OnImageSourceDialogDismiss : Click
+
+            data object OnPermissionDeniedDialogDismiss : Click
+
+            data object OnPermissionDeniedSettingsClick : Click
+
+            /** Internal: emitted by the camera-permission launcher when granted. */
+            data object RequestCameraCapture : Click
+
+            /** Internal: emitted by the camera-permission launcher when denied. */
+            data object OnCameraPermissionDenied : Click
         }
 
         @Suppress("MviActionNamingRule")
@@ -217,6 +268,16 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             val impactSummary: String,
             val confirmLabel: String,
         ) : Event
+
+        data class NavigateLaunchCamera(val tempUri: Uri) : Event
+
+        data object NavigateLaunchGallery : Event
+
+        data object NavigateRequestCameraPermission : Event
+
+        data class NavigateOpenAppSettings(val packageName: String) : Event
+
+        data class ShowImageError(val errorType: ImageErrorType) : Event
     }
 
     /**

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
@@ -65,7 +65,7 @@ internal fun ExerciseDetailScreen(
             verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
         ) {
             Spacer(Modifier.height(AppDimension.Space.sm))
-            ExerciseHero(type = state.type)
+            ExerciseHero(type = state.type, imageDisplay = state.effectiveImageDisplay)
             Static(label = stringResource(state.type.labelRes))
             Text(
                 text = state.name,

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
@@ -65,7 +65,11 @@ internal fun ExerciseDetailScreen(
             verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
         ) {
             Spacer(Modifier.height(AppDimension.Space.sm))
-            ExerciseHero(type = state.type, imageDisplay = state.effectiveImageDisplay)
+            ExerciseHero(
+                type = state.type,
+                imageDisplay = state.effectiveImageDisplay,
+                onImageClick = { consume(Action.Click.OnImageThumbnailClick) },
+            )
             Static(label = stringResource(state.type.labelRes))
             Text(
                 text = state.name,

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
@@ -88,6 +88,7 @@ internal fun ExerciseEditScreen(
                     imageDisplay = state.effectiveImageDisplay,
                     onEditClick = { consume(Action.Click.OnEditImageClick) },
                     onRemoveClick = { consume(Action.Click.OnRemoveImageClick) },
+                    onThumbClick = { consume(Action.Click.OnImageThumbnailClick) },
                 )
             }
             FormSection(label = stringResource(R.string.feature_exercise_edit_label_name)) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
@@ -34,6 +34,7 @@ import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.State
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.State.Mode
+import io.github.stslex.workeeper.feature.exercise.ui.components.ImageEditRow
 import io.github.stslex.workeeper.feature.exercise.ui.components.TagPickerInline
 import io.github.stslex.workeeper.feature.exercise.ui.components.TypeToggle
 import io.github.stslex.workeeper.core.ui.kit.R as KitR
@@ -81,6 +82,14 @@ internal fun ExerciseEditScreen(
             verticalArrangement = Arrangement.spacedBy(AppDimension.sectionSpacing),
         ) {
             Spacer(Modifier.height(AppDimension.Space.sm))
+            FormSection(label = stringResource(R.string.feature_exercise_image_edit_title)) {
+                ImageEditRow(
+                    type = state.type,
+                    imageDisplay = state.effectiveImageDisplay,
+                    onEditClick = { consume(Action.Click.OnEditImageClick) },
+                    onRemoveClick = { consume(Action.Click.OnRemoveImageClick) },
+                )
+            }
             FormSection(label = stringResource(R.string.feature_exercise_edit_label_name)) {
                 val nameErrorText = when {
                     state.nameError -> stringResource(R.string.feature_exercise_edit_error_name_required)

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.ui
 
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.getValue
@@ -9,8 +15,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
@@ -21,19 +29,23 @@ import io.github.stslex.workeeper.core.ui.plan_editor.AppPlanEditor
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseFeature
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageErrorType
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.DiscardTarget
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Event
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.State.Mode
+import io.github.stslex.workeeper.feature.exercise.ui.components.ImageSourceDialog
+import io.github.stslex.workeeper.feature.exercise.ui.components.PermissionDeniedDialog
 
 @OptIn(ExperimentalSharedTransitionApi::class)
-@Suppress("UnusedParameter", "LongMethod")
+@Suppress("UnusedParameter", "LongMethod", "CyclomaticComplexMethod")
 fun NavGraphBuilder.exerciseGraph(
     sharedTransitionScope: SharedTransitionScope,
     modifier: Modifier = Modifier,
 ) {
     navComponentScreen(ExerciseFeature) { processor ->
         val haptic = LocalHapticFeedback.current
+        val context = LocalContext.current
         val undoLabel = stringResource(R.string.feature_exercise_detail_archive_undo)
         val discardTitle = stringResource(R.string.feature_exercise_edit_discard_title)
         val discardBody = stringResource(R.string.feature_exercise_edit_discard_body)
@@ -42,11 +54,45 @@ fun NavGraphBuilder.exerciseGraph(
         val archiveBlockedTitle =
             stringResource(R.string.feature_exercise_detail_archive_blocked_title)
         val archiveBlockedOk = stringResource(R.string.feature_exercise_detail_archive_blocked_ok)
+        val imageSaveFailed = stringResource(R.string.feature_exercise_image_error_save_failed)
+        val imageLoadFailed = stringResource(R.string.feature_exercise_image_error_load_failed)
+        val imageDecodeFailed = stringResource(R.string.feature_exercise_image_error_decode_failed)
 
         var pendingDiscard by remember { mutableStateOf<DiscardTarget?>(null) }
         var archiveBlockedBody by remember { mutableStateOf<String?>(null) }
         var permanentDeleteDialog by remember { mutableStateOf<Event.ShowPermanentDeleteConfirm?>(null) }
         var typeChangeDialog by remember { mutableStateOf<Event.ShowTypeChangeConfirm?>(null) }
+        var pendingCameraTempUri by remember { mutableStateOf<Uri?>(null) }
+
+        val cameraLauncher = rememberLauncherForActivityResult(
+            ActivityResultContracts.TakePicture(),
+        ) { success ->
+            val uri = pendingCameraTempUri
+            if (success && uri != null) {
+                processor.consume(Action.Common.ImagePicked(uri))
+            } else {
+                processor.consume(Action.Common.ImagePickCancelled)
+            }
+            pendingCameraTempUri = null
+        }
+        val galleryLauncher = rememberLauncherForActivityResult(
+            ActivityResultContracts.PickVisualMedia(),
+        ) { uri ->
+            if (uri != null) {
+                processor.consume(Action.Common.ImagePicked(uri))
+            } else {
+                processor.consume(Action.Common.ImagePickCancelled)
+            }
+        }
+        val cameraPermissionLauncher = rememberLauncherForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            if (granted) {
+                processor.consume(Action.Click.RequestCameraCapture)
+            } else {
+                processor.consume(Action.Click.OnCameraPermissionDenied)
+            }
+        }
 
         processor.Handle { event ->
             when (event) {
@@ -79,6 +125,38 @@ fun NavGraphBuilder.exerciseGraph(
 
                 is Event.ShowTypeChangeConfirm -> {
                     typeChangeDialog = event
+                }
+
+                is Event.NavigateLaunchCamera -> {
+                    pendingCameraTempUri = event.tempUri
+                    cameraLauncher.launch(event.tempUri)
+                }
+
+                Event.NavigateLaunchGallery -> {
+                    galleryLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    )
+                }
+
+                Event.NavigateRequestCameraPermission -> {
+                    cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+                }
+
+                is Event.NavigateOpenAppSettings -> {
+                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                        data = "package:${event.packageName}".toUri()
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                }
+
+                is Event.ShowImageError -> {
+                    val message = when (event.errorType) {
+                        ImageErrorType.SaveFailed -> imageSaveFailed
+                        ImageErrorType.LoadFailed -> imageLoadFailed
+                        ImageErrorType.DecodeFailed -> imageDecodeFailed
+                    }
+                    SnackbarManager.showSnackbar(message = message)
                 }
             }
         }
@@ -172,6 +250,26 @@ fun NavGraphBuilder.exerciseGraph(
                 draft = target.draft,
                 isWeighted = state.type == ExerciseTypeUiModel.WEIGHTED,
                 onAction = { action -> processor.consume(Action.PlanEditorAction(action)) },
+            )
+        }
+        if (state.sourceDialogVisible) {
+            ImageSourceDialog(
+                onSourceSelected = { source ->
+                    processor.consume(Action.Click.OnImageSourceSelected(source))
+                },
+                onDismiss = {
+                    processor.consume(Action.Click.OnImageSourceDialogDismiss)
+                },
+            )
+        }
+        if (state.permissionDeniedDialogVisible) {
+            PermissionDeniedDialog(
+                onSettingsClick = {
+                    processor.consume(Action.Click.OnPermissionDeniedSettingsClick)
+                },
+                onDismiss = {
+                    processor.consume(Action.Click.OnPermissionDeniedDialogDismiss)
+                },
             )
         }
     }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ExerciseHero.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ExerciseHero.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.exercise.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,13 +34,20 @@ internal fun ExerciseHero(
     type: ExerciseTypeUiModel,
     imageDisplay: ImageDisplay,
     modifier: Modifier = Modifier,
+    onImageClick: (() -> Unit)? = null,
 ) {
+    val clickableModifier = if (imageDisplay !is ImageDisplay.None && onImageClick != null) {
+        Modifier.clickable(onClick = onImageClick)
+    } else {
+        Modifier
+    }
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(120.dp)
             .clip(AppUi.shapes.medium)
             .background(AppUi.colors.surfaceTier1)
+            .then(clickableModifier)
             .testTag("ExerciseHero"),
         contentAlignment = Alignment.Center,
     ) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageEditRow.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageEditRow.kt
@@ -2,10 +2,12 @@
 package io.github.stslex.workeeper.feature.exercise.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessibilityNew
@@ -23,35 +25,82 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageDisplay
 
+private val THUMB_SIZE = 72.dp
+
 @Composable
-internal fun ExerciseHero(
+internal fun ImageEditRow(
     type: ExerciseTypeUiModel,
     imageDisplay: ImageDisplay,
+    onEditClick: () -> Unit,
+    onRemoveClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(
+    val hasImage = imageDisplay !is ImageDisplay.None
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(120.dp)
+            .testTag("ExerciseEditImageRow"),
+        horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ImageThumb(
+            type = type,
+            imageDisplay = imageDisplay,
+        )
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+        ) {
+            AppButton.Secondary(
+                modifier = Modifier.testTag("ExerciseEditImageEditButton"),
+                text = stringResource(
+                    if (hasImage) {
+                        R.string.feature_exercise_image_action_edit
+                    } else {
+                        R.string.feature_exercise_image_action_add
+                    },
+                ),
+                onClick = onEditClick,
+                size = AppButtonSize.SMALL,
+            )
+            if (hasImage) {
+                AppButton.Tertiary(
+                    modifier = Modifier.testTag("ExerciseEditImageRemoveButton"),
+                    text = stringResource(R.string.feature_exercise_image_action_remove),
+                    onClick = onRemoveClick,
+                    size = AppButtonSize.SMALL,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageThumb(
+    type: ExerciseTypeUiModel,
+    imageDisplay: ImageDisplay,
+) {
+    Box(
+        modifier = Modifier
+            .size(THUMB_SIZE)
             .clip(AppUi.shapes.medium)
             .background(AppUi.colors.surfaceTier1)
-            .testTag("ExerciseHero"),
+            .testTag("ExerciseEditImageThumb"),
         contentAlignment = Alignment.Center,
     ) {
         when (imageDisplay) {
-            ImageDisplay.None -> ExerciseTypePlaceholder(type = type)
+            ImageDisplay.None -> ThumbPlaceholder(type)
             is ImageDisplay.FromPath -> AsyncImage(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .testTag("ExerciseHeroImage"),
+                modifier = Modifier.fillMaxSize(),
                 model = ImageRequest.Builder(LocalContext.current)
-                    // Cache-bust by mtime so a replaced file at the same path is not served
-                    // from Coil's URI-keyed cache.
                     .data("${imageDisplay.path}?v=${imageDisplay.lastModified}")
                     .crossfade(true)
                     .build(),
@@ -60,9 +109,7 @@ internal fun ExerciseHero(
             )
 
             is ImageDisplay.FromUri -> AsyncImage(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .testTag("ExerciseHeroImage"),
+                modifier = Modifier.fillMaxSize(),
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(imageDisplay.uri)
                     .crossfade(true)
@@ -75,12 +122,10 @@ internal fun ExerciseHero(
 }
 
 @Composable
-private fun ExerciseTypePlaceholder(
-    type: ExerciseTypeUiModel,
-) {
+private fun ThumbPlaceholder(type: ExerciseTypeUiModel) {
     val isWeighted = type == ExerciseTypeUiModel.WEIGHTED
     Icon(
-        modifier = Modifier.size(36.dp),
+        modifier = Modifier.size(28.dp),
         imageVector = if (isWeighted) Icons.Filled.FitnessCenter else Icons.Filled.AccessibilityNew,
         contentDescription = stringResource(R.string.feature_exercise_image_placeholder_description),
         tint = if (isWeighted) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageEditRow.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageEditRow.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.exercise.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ internal fun ImageEditRow(
     imageDisplay: ImageDisplay,
     onEditClick: () -> Unit,
     onRemoveClick: () -> Unit,
+    onThumbClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val hasImage = imageDisplay !is ImageDisplay.None
@@ -54,6 +56,7 @@ internal fun ImageEditRow(
         ImageThumb(
             type = type,
             imageDisplay = imageDisplay,
+            onClick = if (hasImage) onThumbClick else null,
         )
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -87,12 +90,15 @@ internal fun ImageEditRow(
 private fun ImageThumb(
     type: ExerciseTypeUiModel,
     imageDisplay: ImageDisplay,
+    onClick: (() -> Unit)? = null,
 ) {
+    val clickModifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
     Box(
         modifier = Modifier
             .size(THUMB_SIZE)
             .clip(AppUi.shapes.medium)
             .background(AppUi.colors.surfaceTier1)
+            .then(clickModifier)
             .testTag("ExerciseEditImageThumb"),
         contentAlignment = Alignment.Center,
     ) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageSourceDialog.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/ImageSourceDialog.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.Dialog
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.feature.exercise.R
+import io.github.stslex.workeeper.feature.exercise.mvi.model.ImageSourceUiModel
+import io.github.stslex.workeeper.core.ui.kit.R as KitR
+
+@Composable
+internal fun ImageSourceDialog(
+    onSourceSelected: (ImageSourceUiModel) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dialogBg = if (AppUi.colors.isDark) AppUi.colors.surfaceTier1 else AppUi.colors.surfaceTier2
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = modifier
+                .clip(AppUi.shapes.medium)
+                .background(dialogBg)
+                .padding(AppDimension.Space.lg)
+                .testTag("ExerciseImageSourceDialog"),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+        ) {
+            Text(
+                text = stringResource(R.string.feature_exercise_image_source_dialog_title),
+                style = AppUi.typography.titleLarge,
+                color = AppUi.colors.textPrimary,
+            )
+            SourceOption(
+                label = stringResource(R.string.feature_exercise_image_source_camera),
+                icon = Icons.Filled.PhotoCamera,
+                tag = "ExerciseImageSourceCamera",
+                onClick = { onSourceSelected(ImageSourceUiModel.Camera) },
+            )
+            SourceOption(
+                label = stringResource(R.string.feature_exercise_image_source_gallery),
+                icon = Icons.Filled.PhotoLibrary,
+                tag = "ExerciseImageSourceGallery",
+                onClick = { onSourceSelected(ImageSourceUiModel.Gallery) },
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                AppButton.Tertiary(
+                    text = stringResource(KitR.string.core_ui_kit_action_cancel),
+                    onClick = onDismiss,
+                    size = AppButtonSize.MEDIUM,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceOption(
+    label: String,
+    icon: ImageVector,
+    tag: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(AppUi.shapes.small)
+            .clickable(onClick = onClick)
+            .padding(
+                horizontal = AppDimension.Space.sm,
+                vertical = AppDimension.Space.md,
+            )
+            .testTag(tag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+    ) {
+        Icon(
+            modifier = Modifier.size(AppDimension.iconSm),
+            imageVector = icon,
+            contentDescription = null,
+            tint = AppUi.colors.textPrimary,
+        )
+        Text(
+            text = label,
+            style = AppUi.typography.bodyMedium,
+            color = AppUi.colors.textPrimary,
+        )
+    }
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/PermissionDeniedDialog.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/components/PermissionDeniedDialog.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
+import io.github.stslex.workeeper.feature.exercise.R
+
+@Composable
+internal fun PermissionDeniedDialog(
+    onSettingsClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AppDialog(
+        title = stringResource(R.string.feature_exercise_image_permission_denied_title),
+        body = stringResource(R.string.feature_exercise_image_permission_denied_body),
+        confirmLabel = stringResource(
+            R.string.feature_exercise_image_permission_denied_action_settings,
+        ),
+        // Default dismissLabel falls back to the shared kit "Cancel" string.
+        onConfirm = onSettingsClick,
+        onDismiss = onDismiss,
+    )
+}

--- a/feature/exercise/src/main/res/values-ru/strings.xml
+++ b/feature/exercise/src/main/res/values-ru/strings.xml
@@ -55,4 +55,27 @@
     <string name="feature_exercise_edit_type_change_weightless_body">Значения веса из планов этого упражнения будут очищены. Это нельзя отменить.</string>
     <string name="feature_exercise_edit_type_change_weightless_impact">Все веса в планах очищены</string>
     <string name="feature_exercise_edit_type_change_weightless_confirm">Переключить</string>
+
+    <!-- Edit exercise — image -->
+    <string name="feature_exercise_image_edit_title">Изображение упражнения</string>
+    <string name="feature_exercise_image_action_add">Добавить фото</string>
+    <string name="feature_exercise_image_action_edit">Изменить фото</string>
+    <string name="feature_exercise_image_action_remove">Убрать</string>
+    <string name="feature_exercise_image_thumb_description">Прикреплённое фото упражнения</string>
+    <string name="feature_exercise_image_placeholder_description">Фото упражнения не прикреплено</string>
+
+    <!-- Source dialog -->
+    <string name="feature_exercise_image_source_dialog_title">Выберите источник</string>
+    <string name="feature_exercise_image_source_camera">Сделать фото</string>
+    <string name="feature_exercise_image_source_gallery">Выбрать из галереи</string>
+
+    <!-- Permission -->
+    <string name="feature_exercise_image_permission_denied_title">Доступ к камере запрещён</string>
+    <string name="feature_exercise_image_permission_denied_body">Чтобы сделать фото, разрешите доступ к камере в настройках приложения. Вы можете выбрать фото из галереи.</string>
+    <string name="feature_exercise_image_permission_denied_action_settings">Открыть настройки</string>
+
+    <!-- Errors -->
+    <string name="feature_exercise_image_error_save_failed">Не удалось сохранить фото — попробуйте ещё раз</string>
+    <string name="feature_exercise_image_error_load_failed">Не удалось загрузить фото</string>
+    <string name="feature_exercise_image_error_decode_failed">Формат изображения не поддерживается</string>
 </resources>

--- a/feature/exercise/src/main/res/values/strings.xml
+++ b/feature/exercise/src/main/res/values/strings.xml
@@ -54,4 +54,27 @@
     <string name="feature_exercise_edit_type_change_weightless_body">Weight values from this exercise’s plans will be cleared. This cannot be undone.</string>
     <string name="feature_exercise_edit_type_change_weightless_impact">All plan weights cleared</string>
     <string name="feature_exercise_edit_type_change_weightless_confirm">Switch</string>
+
+    <!-- Edit exercise — image -->
+    <string name="feature_exercise_image_edit_title">Exercise image</string>
+    <string name="feature_exercise_image_action_add">Add image</string>
+    <string name="feature_exercise_image_action_edit">Edit image</string>
+    <string name="feature_exercise_image_action_remove">Remove</string>
+    <string name="feature_exercise_image_thumb_description">Attached exercise photo</string>
+    <string name="feature_exercise_image_placeholder_description">No exercise photo attached</string>
+
+    <!-- Source dialog -->
+    <string name="feature_exercise_image_source_dialog_title">Choose source</string>
+    <string name="feature_exercise_image_source_camera">Take photo</string>
+    <string name="feature_exercise_image_source_gallery">Choose from gallery</string>
+
+    <!-- Permission -->
+    <string name="feature_exercise_image_permission_denied_title">Camera permission denied</string>
+    <string name="feature_exercise_image_permission_denied_body">To take a photo, grant camera access in app settings. You can still choose an existing photo from your gallery.</string>
+    <string name="feature_exercise_image_permission_denied_action_settings">Open settings</string>
+
+    <!-- Errors -->
+    <string name="feature_exercise_image_error_save_failed">Could not save image — try again</string>
+    <string name="feature_exercise_image_error_load_failed">Could not load image</string>
+    <string name="feature_exercise_image_error_decode_failed">Image format not supported</string>
 </resources>

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.domain
 
+import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.exercise.tags.TagRepository
@@ -21,9 +22,11 @@ internal class ExerciseInteractorImplTest {
 
     private val exerciseRepository = mockk<ExerciseRepository>(relaxed = true)
     private val tagRepository = mockk<TagRepository>(relaxed = true)
+    private val imageStorage = mockk<ImageStorage>(relaxed = true)
     private val interactor = ExerciseInteractorImpl(
         exerciseRepository = exerciseRepository,
         tagRepository = tagRepository,
+        imageStorage = imageStorage,
         defaultDispatcher = Dispatchers.Unconfined,
     )
 

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandlerTest.kt
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.mvi.handler
 
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
@@ -31,6 +33,10 @@ internal class ClickHandlerTest {
 
     private val interactor = mockk<ExerciseInteractor>(relaxed = true)
     private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true).apply {
+        every { packageName } returns "io.github.stslex.workeeper.test"
+        every { checkPermission(any(), any(), any()) } returns PackageManager.PERMISSION_GRANTED
+    }
 
     private fun setup(initialState: State = State.create(uuid = "uuid-1")): TestSetup {
         val stateFlow = MutableStateFlow(initialState)
@@ -47,6 +53,7 @@ internal class ClickHandlerTest {
             handler = ClickHandler(
                 interactor = interactor,
                 resourceWrapper = resourceWrapper,
+                context = context,
                 mainDispatcher = Dispatchers.Unconfined,
                 store = store,
             ),
@@ -356,6 +363,64 @@ internal class ClickHandlerTest {
         val events = mutableListOf<Event>()
         verify { store.sendEvent(capture(events)) }
         assertTrue(events.any { it is Event.ShowPermanentDeleteConfirm })
+    }
+
+    @Test
+    fun `OnEditImageClick opens the source dialog`() {
+        val (stateFlow, _, handler) = setup()
+        handler.invoke(Action.Click.OnEditImageClick)
+        assertTrue(stateFlow.value.sourceDialogVisible)
+    }
+
+    @Test
+    fun `OnRemoveImageClick stages a RemoveExisting pending image`() {
+        val (stateFlow, _, handler) = setup(
+            State.create(uuid = "uuid-1").copy(
+                imagePath = "/files/old.jpg",
+                imageLastModified = 100L,
+            ),
+        )
+        handler.invoke(Action.Click.OnRemoveImageClick)
+        assertEquals(
+            io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage.RemoveExisting,
+            stateFlow.value.pendingImage,
+        )
+    }
+
+    @Test
+    fun `OnImageSourceDialogDismiss hides the source dialog`() {
+        val (stateFlow, _, handler) = setup(
+            State.create(uuid = "uuid-1").copy(sourceDialogVisible = true),
+        )
+        handler.invoke(Action.Click.OnImageSourceDialogDismiss)
+        assertEquals(false, stateFlow.value.sourceDialogVisible)
+    }
+
+    @Test
+    fun `OnPermissionDeniedDialogDismiss hides the permission dialog`() {
+        val (stateFlow, _, handler) = setup(
+            State.create(uuid = "uuid-1").copy(permissionDeniedDialogVisible = true),
+        )
+        handler.invoke(Action.Click.OnPermissionDeniedDialogDismiss)
+        assertEquals(false, stateFlow.value.permissionDeniedDialogVisible)
+    }
+
+    @Test
+    fun `OnCameraPermissionDenied surfaces the permission denied dialog`() {
+        val (stateFlow, _, handler) = setup()
+        handler.invoke(Action.Click.OnCameraPermissionDenied)
+        assertTrue(stateFlow.value.permissionDeniedDialogVisible)
+    }
+
+    @Test
+    fun `OnPermissionDeniedSettingsClick emits NavigateOpenAppSettings`() {
+        val (_, store, handler) = setup(
+            State.create(uuid = "uuid-1").copy(permissionDeniedDialogVisible = true),
+        )
+        handler.invoke(Action.Click.OnPermissionDeniedSettingsClick)
+        val events = mutableListOf<Event>()
+        verify { store.sendEvent(capture(events)) }
+        assertTrue(events.any { it is Event.NavigateOpenAppSettings })
     }
 
     private fun assertHaptic(event: Event, expected: HapticFeedbackType) {

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/ClickHandlerTest.kt
@@ -423,6 +423,27 @@ internal class ClickHandlerTest {
         assertTrue(events.any { it is Event.NavigateOpenAppSettings })
     }
 
+    @Test
+    fun `OnImageThumbnailClick with committed path consumes OpenImageViewer with the path`() {
+        val path = "/data/user/0/app/files/exercise_images/uuid-1.jpg"
+        val (_, store, handler) = setup(
+            State.create(uuid = "uuid-1").copy(
+                imagePath = path,
+                imageLastModified = 100L,
+            ),
+        )
+        handler.invoke(Action.Click.OnImageThumbnailClick)
+        verify { store.consume(Action.Navigation.OpenImageViewer(path)) }
+    }
+
+    @Test
+    fun `OnImageThumbnailClick with no image is a no-op`() {
+        val (_, store, handler) = setup()
+        handler.invoke(Action.Click.OnImageThumbnailClick)
+        verify(exactly = 0) { store.consume(any<Action.Navigation.OpenImageViewer>()) }
+        verify(exactly = 0) { store.sendEvent(any()) }
+    }
+
     private fun assertHaptic(event: Event, expected: HapticFeedbackType) {
         assertTrue(event is Event.Haptic, "expected Event.Haptic but got $event")
         assertEquals(expected, (event as Event.Haptic).type)

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/CommonHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/CommonHandlerTest.kt
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise.mvi.handler
 
+import android.net.Uri
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
+import io.github.stslex.workeeper.feature.exercise.mvi.model.PendingImage
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.State
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class CommonHandlerTest {
@@ -19,26 +22,55 @@ internal class CommonHandlerTest {
     }
     private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true)
 
-    @Test
-    fun `Init for create mode does not load exercise`() {
-        val stateFlow = MutableStateFlow(State.create(uuid = null))
+    private fun setup(initialState: State): Pair<MutableStateFlow<State>, CommonHandler> {
+        val stateFlow = MutableStateFlow(initialState)
         val store = mockk<ExerciseHandlerStore>(relaxed = true).apply {
             every { state } returns stateFlow
+            every { updateState(any()) } answers {
+                val update = firstArg<(State) -> State>()
+                stateFlow.value = update(stateFlow.value)
+            }
         }
-        val handler = CommonHandler(interactor, resourceWrapper, store)
+        return stateFlow to CommonHandler(interactor, resourceWrapper, store)
+    }
+
+    @Test
+    fun `Init for create mode does not load exercise`() {
+        val (_, handler) = setup(State.create(uuid = null))
         handler.invoke(Action.Common.Init)
         // No exception means the handler short-circuited without trying to load.
     }
 
     @Test
     fun `Init for read mode kicks off observe + load`() {
-        val stateFlow = MutableStateFlow(State.create(uuid = "uuid-1"))
-        val store = mockk<ExerciseHandlerStore>(relaxed = true).apply {
-            every { state } returns stateFlow
-        }
-        val handler = CommonHandler(interactor, resourceWrapper, store)
+        val (_, handler) = setup(State.create(uuid = "uuid-1"))
         handler.invoke(Action.Common.Init)
         // No assertion on launch internals here — see ExerciseInteractorImplTest for repository
         // behaviour. The handler invariant is that Init does not throw.
+    }
+
+    @Test
+    fun `ImagePicked sets pendingImage to NewFromUri and hides the source dialog`() {
+        val uri = mockk<Uri>(relaxed = true)
+        val (stateFlow, handler) = setup(
+            State.create(uuid = "uuid-1").copy(sourceDialogVisible = true),
+        )
+
+        handler.invoke(Action.Common.ImagePicked(uri))
+
+        assertEquals(PendingImage.NewFromUri(uri), stateFlow.value.pendingImage)
+        assertEquals(false, stateFlow.value.sourceDialogVisible)
+    }
+
+    @Test
+    fun `ImagePickCancelled hides the source dialog without staging a pending image`() {
+        val (stateFlow, handler) = setup(
+            State.create(uuid = "uuid-1").copy(sourceDialogVisible = true),
+        )
+
+        handler.invoke(Action.Common.ImagePickCancelled)
+
+        assertEquals(PendingImage.Unchanged, stateFlow.value.pendingImage)
+        assertEquals(false, stateFlow.value.sourceDialogVisible)
     }
 }

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/mvi/handler/NavigationHandlerTest.kt
@@ -28,4 +28,11 @@ internal class NavigationHandlerTest {
         verify(exactly = 0) { navigator.popBack() }
         verify(exactly = 0) { navigator.navTo(any()) }
     }
+
+    @Test
+    fun `OpenImageViewer navigates to Screen ExerciseImage with the model arg`() {
+        val model = "/data/user/0/app/files/exercise_images/abc.jpg"
+        handler.invoke(Action.Navigation.OpenImageViewer(model))
+        verify(exactly = 1) { navigator.navTo(Screen.ExerciseImage(model)) }
+    }
 }

--- a/feature/image-viewer/build.gradle.kts
+++ b/feature/image-viewer/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    alias(libs.plugins.convention.composeLibrary)
+}
+
+dependencies {
+    implementation(project(":core:core"))
+
+    implementation(project(":core:ui:kit"))
+    implementation(project(":core:ui:mvi"))
+    implementation(project(":core:ui:navigation"))
+
+    androidTestImplementation(libs.bundles.android.test)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(project(":core:ui:test-utils"))
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerFeature.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerFeature.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.di
+
+import androidx.compose.runtime.Composable
+import io.github.stslex.workeeper.core.ui.mvi.Feature
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreProcessor
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.ImageViewerComponent
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStoreImpl
+
+internal typealias ImageViewerStoreProcessor = StoreProcessor<State, Action, Event>
+
+internal object ImageViewerFeature :
+    Feature<ImageViewerStoreProcessor, Screen.ExerciseImage, ImageViewerComponent>() {
+
+    @Composable
+    override fun processor(
+        screen: Screen.ExerciseImage,
+    ): ImageViewerStoreProcessor =
+        createProcessor<ImageViewerStoreImpl, ImageViewerStoreImpl.Factory>(screen)
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerHandlerStore.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerHandlerStore.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.di
+
+import io.github.stslex.workeeper.core.ui.mvi.handler.HandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+
+internal interface ImageViewerHandlerStore : HandlerStore<State, Action, Event>

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerHandlerStoreImpl.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerHandlerStoreImpl.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.di
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.BaseHandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ImageViewerHandlerStoreImpl @Inject constructor() :
+    ImageViewerHandlerStore,
+    BaseHandlerStore<State, Action, Event>()

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerModule.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/di/ImageViewerModule.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal interface ImageViewerModule {
+
+    @Binds
+    @ViewModelScoped
+    fun bindHandlerStore(impl: ImageViewerHandlerStoreImpl): ImageViewerHandlerStore
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ClickHandler.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ClickHandler.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerHandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ClickHandler @Inject constructor(
+    store: ImageViewerHandlerStore,
+) : Handler<Action.Click>, ImageViewerHandlerStore by store {
+
+    override fun invoke(action: Action.Click) {
+        when (action) {
+            Action.Click.OnBackClick -> processBack()
+            Action.Click.OnDoubleTap -> processDoubleTap()
+        }
+    }
+
+    private fun processBack() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        consume(Action.Navigation.Back)
+    }
+
+    private fun processDoubleTap() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { current ->
+            // Toggle: any zoomed-in scale collapses to MIN_SCALE; otherwise jump to the
+            // double-tap target. Pan resets only when collapsing — otherwise the target
+            // stays centered (offset 0,0) so the user can pan from a known origin.
+            if (current.scale > State.MIN_SCALE) {
+                current.copy(
+                    scale = State.MIN_SCALE,
+                    offsetX = 0f,
+                    offsetY = 0f,
+                )
+            } else {
+                current.copy(
+                    scale = State.DOUBLE_TAP_TARGET_SCALE,
+                    offsetX = 0f,
+                    offsetY = 0f,
+                )
+            }
+        }
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/CommonHandler.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/CommonHandler.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerHandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class CommonHandler @Inject constructor(
+    store: ImageViewerHandlerStore,
+) : Handler<Action.Common>, ImageViewerHandlerStore by store {
+
+    override fun invoke(action: Action.Common) {
+        when (action) {
+            Action.Common.Init -> Unit
+            is Action.Common.TransformChange -> processTransformChange(action)
+        }
+    }
+
+    private fun processTransformChange(action: Action.Common.TransformChange) {
+        // The Composable already clamps scale to [MIN_SCALE, MAX_SCALE] and pans
+        // within bounds before sending — store just persists the absolute values.
+        updateState {
+            it.copy(
+                scale = action.scale,
+                offsetX = action.offsetX,
+                offsetY = action.offsetY,
+            )
+        }
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ImageViewerComponent.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ImageViewerComponent.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Component
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+
+abstract class ImageViewerComponent(
+    data: Screen.ExerciseImage,
+) : Component<Screen.ExerciseImage>(data) {
+
+    companion object {
+
+        fun create(
+            navigator: Navigator,
+            screen: Screen.ExerciseImage,
+        ): ImageViewerComponent = NavigationHandler(navigator = navigator, data = screen)
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/NavigationHandler.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/NavigationHandler.kt
@@ -1,23 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
-package io.github.stslex.workeeper.feature.exercise.mvi.handler
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
 import io.github.stslex.workeeper.core.ui.navigation.Screen
-import io.github.stslex.workeeper.feature.exercise.mvi.store.ExerciseStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
 
 @Suppress("MviHandlerConstructorRule")
 internal class NavigationHandler(
     private val navigator: Navigator,
-    data: Screen.Exercise,
-) : ExerciseComponent(data), Handler<Action.Navigation> {
+    data: Screen.ExerciseImage,
+) : ImageViewerComponent(data), Handler<Action.Navigation> {
 
     override fun invoke(action: Action.Navigation) {
         when (action) {
             Action.Navigation.Back -> navigator.popBack()
-            is Action.Navigation.OpenSession -> Unit
-            is Action.Navigation.OpenImageViewer ->
-                navigator.navTo(Screen.ExerciseImage(action.model))
         }
     }
 }

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/store/ImageViewerStore.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/store/ImageViewerStore.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.store
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import io.github.stslex.workeeper.core.ui.mvi.Store
+
+internal interface ImageViewerStore :
+    Store<ImageViewerStore.State, ImageViewerStore.Action, ImageViewerStore.Event> {
+
+    @Stable
+    data class State(
+        val model: String,
+        val scale: Float,
+        val offsetX: Float,
+        val offsetY: Float,
+    ) : Store.State {
+
+        companion object {
+
+            const val MIN_SCALE: Float = 1f
+            const val MAX_SCALE: Float = 5f
+            const val DOUBLE_TAP_TARGET_SCALE: Float = 2.5f
+
+            fun create(model: String): State = State(
+                model = model,
+                scale = MIN_SCALE,
+                offsetX = 0f,
+                offsetY = 0f,
+            )
+        }
+    }
+
+    @Stable
+    sealed interface Action : Store.Action {
+
+        sealed interface Click : Action {
+
+            data object OnBackClick : Click
+
+            data object OnDoubleTap : Click
+        }
+
+        sealed interface Common : Action {
+
+            data object Init : Common
+
+            data class TransformChange(
+                val scale: Float,
+                val offsetX: Float,
+                val offsetY: Float,
+            ) : Common
+        }
+
+        sealed interface Navigation : Action {
+
+            data object Back : Navigation
+        }
+    }
+
+    @Stable
+    sealed interface Event : Store.Event {
+
+        data class HapticClick(val type: HapticFeedbackType) : Event
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/store/ImageViewerStoreImpl.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/store/ImageViewerStoreImpl.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.store
+
+import androidx.annotation.VisibleForTesting
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.stslex.workeeper.core.ui.mvi.BaseStore
+import io.github.stslex.workeeper.core.ui.mvi.di.StoreDispatchers
+import io.github.stslex.workeeper.core.ui.mvi.holders.AnalyticsHolder
+import io.github.stslex.workeeper.core.ui.mvi.holders.LoggerHolder
+import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerHandlerStoreImpl
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.ClickHandler
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.CommonHandler
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.ImageViewerComponent
+import io.github.stslex.workeeper.feature.image_viewer.mvi.handler.NavigationHandler
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+
+@HiltViewModel(assistedFactory = ImageViewerStoreImpl.Factory::class)
+internal class ImageViewerStoreImpl @AssistedInject constructor(
+    @Assisted component: ImageViewerComponent,
+    clickHandler: ClickHandler,
+    commonHandler: CommonHandler,
+    storeDispatchers: StoreDispatchers,
+    handlerStore: ImageViewerHandlerStoreImpl,
+    analyticsHolder: AnalyticsHolder,
+    loggerHolder: LoggerHolder,
+) : BaseStore<State, Action, Event>(
+    name = NAME,
+    initialState = State.create(model = component.data.model),
+    handlerCreator = { action ->
+        when (action) {
+            is Action.Navigation -> component as NavigationHandler
+            is Action.Common -> commonHandler
+            is Action.Click -> clickHandler
+        }
+    },
+    storeEmitter = handlerStore,
+    storeDispatchers = storeDispatchers,
+    initialActions = listOf(Action.Common.Init),
+    analyticsHolder = analyticsHolder,
+    loggerHolder = loggerHolder,
+) {
+
+    @AssistedFactory
+    interface Factory : StoreFactory<ImageViewerComponent, ImageViewerStoreImpl>
+
+    companion object {
+
+        @VisibleForTesting
+        private const val NAME = "ImageViewer"
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/ImageViewerGraph.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/ImageViewerGraph.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.navigation.NavGraphBuilder
+import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerFeature
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+
+fun NavGraphBuilder.imageViewerGraph(
+    modifier: Modifier = Modifier,
+) {
+    navComponentScreen(ImageViewerFeature) { processor ->
+        val haptic = LocalHapticFeedback.current
+
+        processor.Handle { event ->
+            when (event) {
+                is Event.HapticClick -> haptic.performHapticFeedback(event.type)
+            }
+        }
+
+        // Route system back through OnBackClick so haptic + analytics fire identically to
+        // the icon-button path; without this BackHandler, default popBack still works but
+        // skips those side effects.
+        BackHandler {
+            processor.consume(Action.Click.OnBackClick)
+        }
+
+        ImageViewerScreen(
+            modifier = modifier,
+            state = processor.state.value,
+            consume = processor::consume,
+        )
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/ImageViewerScreen.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/ImageViewerScreen.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.feature.image_viewer.R
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import io.github.stslex.workeeper.feature.image_viewer.ui.components.ZoomableImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ImageViewerScreen(
+    state: State,
+    consume: (Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .testTag("ImageViewerScreen"),
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(
+                        modifier = Modifier.testTag("ImageViewerBackButton"),
+                        onClick = { consume(Action.Click.OnBackClick) },
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(AppDimension.iconSm),
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(
+                                R.string.feature_image_viewer_back,
+                            ),
+                            tint = Color.White,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                    scrolledContainerColor = Color.Transparent,
+                ),
+                modifier = Modifier.systemBarsPadding(),
+            )
+        },
+        containerColor = Color.Black,
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            ZoomableImage(
+                modifier = Modifier.fillMaxSize(),
+                model = state.model,
+                scale = state.scale,
+                offsetX = state.offsetX,
+                offsetY = state.offsetY,
+                onTransform = { newScale, newOffsetX, newOffsetY ->
+                    consume(
+                        Action.Common.TransformChange(
+                            scale = newScale,
+                            offsetX = newOffsetX,
+                            offsetY = newOffsetY,
+                        ),
+                    )
+                },
+                onDoubleTap = { consume(Action.Click.OnDoubleTap) },
+            )
+        }
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/components/ZoomableImage.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/components/ZoomableImage.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BrokenImage
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import io.github.stslex.workeeper.feature.image_viewer.R
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State.Companion.MAX_SCALE
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State.Companion.MIN_SCALE
+
+private val UNAVAILABLE_ICON_SIZE = 48.dp
+
+@Composable
+internal fun ZoomableImage(
+    model: String,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float,
+    onTransform: (scale: Float, offsetX: Float, offsetY: Float) -> Unit,
+    onDoubleTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // animate so double-tap toggle and scale changes ease in instead of snapping.
+    val animatedScale by animateFloatAsState(scale, label = "scale")
+    val animatedOffsetX by animateFloatAsState(offsetX, label = "offsetX")
+    val animatedOffsetY by animateFloatAsState(offsetY, label = "offsetY")
+
+    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
+    var loadFailed by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .testTag("ImageViewerCanvas")
+            .onSizeChanged { viewportSize = it }
+            .pointerInput(viewportSize) {
+                // Compose runs only the first matching detector inside one pointerInput,
+                // so transform-gestures and tap-gestures must live in separate blocks.
+                detectTransformGestures { _, pan, zoom, _ ->
+                    val newScale = (scale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
+                    val newOffsetX: Float
+                    val newOffsetY: Float
+                    if (newScale <= MIN_SCALE) {
+                        newOffsetX = 0f
+                        newOffsetY = 0f
+                    } else {
+                        // Bound = ((scale - 1) * viewportSize) / 2 keeps image edges from
+                        // pulling beyond the viewport on either side.
+                        val maxOffsetX = (viewportSize.width * (newScale - 1f)) / 2f
+                        val maxOffsetY = (viewportSize.height * (newScale - 1f)) / 2f
+                        newOffsetX = (offsetX + pan.x).coerceIn(-maxOffsetX, maxOffsetX)
+                        newOffsetY = (offsetY + pan.y).coerceIn(-maxOffsetY, maxOffsetY)
+                    }
+                    onTransform(newScale, newOffsetX, newOffsetY)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(onDoubleTap = { onDoubleTap() })
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (loadFailed) {
+            UnavailableState()
+        } else {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(model)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(
+                    R.string.feature_image_viewer_content_description,
+                ),
+                contentScale = ContentScale.Fit,
+                onState = { state ->
+                    loadFailed = state is AsyncImagePainter.State.Error
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag("ImageViewerImage")
+                    .graphicsLayer {
+                        scaleX = animatedScale
+                        scaleY = animatedScale
+                        translationX = animatedOffsetX
+                        translationY = animatedOffsetY
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnavailableState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("ImageViewerUnavailable")
+            .padding(AppDimension.Space.md),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            modifier = Modifier.size(UNAVAILABLE_ICON_SIZE),
+            imageVector = Icons.Filled.BrokenImage,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.7f),
+        )
+        Text(
+            modifier = Modifier.padding(top = AppDimension.Space.sm),
+            text = stringResource(R.string.feature_image_viewer_unavailable),
+            style = AppUi.typography.bodyMedium,
+            color = Color.White,
+        )
+    }
+}

--- a/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/components/ZoomableImage.kt
+++ b/feature/image-viewer/src/main/kotlin/io/github/stslex/workeeper/feature/image_viewer/ui/components/ZoomableImage.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +59,18 @@ internal fun ZoomableImage(
     val animatedOffsetX by animateFloatAsState(offsetX, label = "offsetX")
     val animatedOffsetY by animateFloatAsState(offsetY, label = "offsetY")
 
+    // pointerInput's coroutine is launched once and captures whatever values
+    // existed at launch time. Without rememberUpdatedState, scale/offset reads
+    // inside the gesture lambda always see the launch-time snapshot, so each
+    // pinch frame computes newScale = STALE_scale * zoom — accumulation breaks.
+    // rememberUpdatedState gives the long-lived coroutine a stable State holder
+    // it can re-read on every frame without restarting the coroutine.
+    val currentScale by rememberUpdatedState(scale)
+    val currentOffsetX by rememberUpdatedState(offsetX)
+    val currentOffsetY by rememberUpdatedState(offsetY)
+    val currentOnTransform by rememberUpdatedState(onTransform)
+    val currentOnDoubleTap by rememberUpdatedState(onDoubleTap)
+
     var viewportSize by remember { mutableStateOf(IntSize.Zero) }
     var loadFailed by remember { mutableStateOf(false) }
 
@@ -69,7 +82,7 @@ internal fun ZoomableImage(
                 // Compose runs only the first matching detector inside one pointerInput,
                 // so transform-gestures and tap-gestures must live in separate blocks.
                 detectTransformGestures { _, pan, zoom, _ ->
-                    val newScale = (scale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
+                    val newScale = (currentScale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
                     val newOffsetX: Float
                     val newOffsetY: Float
                     if (newScale <= MIN_SCALE) {
@@ -80,14 +93,14 @@ internal fun ZoomableImage(
                         // pulling beyond the viewport on either side.
                         val maxOffsetX = (viewportSize.width * (newScale - 1f)) / 2f
                         val maxOffsetY = (viewportSize.height * (newScale - 1f)) / 2f
-                        newOffsetX = (offsetX + pan.x).coerceIn(-maxOffsetX, maxOffsetX)
-                        newOffsetY = (offsetY + pan.y).coerceIn(-maxOffsetY, maxOffsetY)
+                        newOffsetX = (currentOffsetX + pan.x).coerceIn(-maxOffsetX, maxOffsetX)
+                        newOffsetY = (currentOffsetY + pan.y).coerceIn(-maxOffsetY, maxOffsetY)
                     }
-                    onTransform(newScale, newOffsetX, newOffsetY)
+                    currentOnTransform(newScale, newOffsetX, newOffsetY)
                 }
             }
             .pointerInput(Unit) {
-                detectTapGestures(onDoubleTap = { onDoubleTap() })
+                detectTapGestures(onDoubleTap = { currentOnDoubleTap() })
             },
         contentAlignment = Alignment.Center,
     ) {

--- a/feature/image-viewer/src/main/res/values-ru/strings.xml
+++ b/feature/image-viewer/src/main/res/values-ru/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_image_viewer_back">Назад</string>
+    <string name="feature_image_viewer_content_description">Полноразмерное фото упражнения</string>
+    <string name="feature_image_viewer_unavailable">Фото недоступно</string>
+</resources>

--- a/feature/image-viewer/src/main/res/values/strings.xml
+++ b/feature/image-viewer/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feature_image_viewer_back">Back</string>
+    <string name="feature_image_viewer_content_description">Exercise image, full size</string>
+    <string name="feature_image_viewer_unavailable">Image unavailable</string>
+</resources>

--- a/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ClickHandlerTest.kt
+++ b/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/ClickHandlerTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerHandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Event
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ClickHandlerTest {
+
+    private fun setup(initialState: State = State.create("model")): TestSetup {
+        val stateFlow = MutableStateFlow(initialState)
+        val store = mockk<ImageViewerHandlerStore>(relaxed = true).apply {
+            every { state } returns stateFlow
+            every { updateState(any()) } answers {
+                val update = firstArg<(State) -> State>()
+                stateFlow.value = update(stateFlow.value)
+            }
+        }
+        return TestSetup(stateFlow, store, ClickHandler(store))
+    }
+
+    private data class TestSetup(
+        val stateFlow: MutableStateFlow<State>,
+        val store: ImageViewerHandlerStore,
+        val handler: ClickHandler,
+    )
+
+    @Test
+    fun `OnBackClick emits ContextClick haptic and consumes Navigation Back`() {
+        val (_, store, handler) = setup()
+        handler.invoke(Action.Click.OnBackClick)
+        val captured = slot<Event>()
+        verify { store.sendEvent(capture(captured)) }
+        assertTrue(captured.captured is Event.HapticClick)
+        assertEquals(
+            HapticFeedbackType.ContextClick,
+            (captured.captured as Event.HapticClick).type,
+        )
+        verify { store.consume(Action.Navigation.Back) }
+    }
+
+    @Test
+    fun `OnDoubleTap from MIN_SCALE jumps to DOUBLE_TAP_TARGET_SCALE and resets offsets`() {
+        val (stateFlow, _, handler) = setup(
+            State.create("model").copy(scale = State.MIN_SCALE, offsetX = 0f, offsetY = 0f),
+        )
+        handler.invoke(Action.Click.OnDoubleTap)
+        assertEquals(State.DOUBLE_TAP_TARGET_SCALE, stateFlow.value.scale)
+        assertEquals(0f, stateFlow.value.offsetX)
+        assertEquals(0f, stateFlow.value.offsetY)
+    }
+
+    @Test
+    fun `OnDoubleTap from any scale above MIN_SCALE collapses to MIN_SCALE and resets offsets`() {
+        val (stateFlow, _, handler) = setup(
+            State.create("model").copy(scale = 3f, offsetX = 100f, offsetY = -40f),
+        )
+        handler.invoke(Action.Click.OnDoubleTap)
+        assertEquals(State.MIN_SCALE, stateFlow.value.scale)
+        assertEquals(0f, stateFlow.value.offsetX)
+        assertEquals(0f, stateFlow.value.offsetY)
+    }
+
+    @Test
+    fun `OnDoubleTap emits ContextClick haptic`() {
+        val (_, store, handler) = setup()
+        handler.invoke(Action.Click.OnDoubleTap)
+        val captured = slot<Event>()
+        verify { store.sendEvent(capture(captured)) }
+        assertTrue(captured.captured is Event.HapticClick)
+    }
+}

--- a/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/CommonHandlerTest.kt
+++ b/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/CommonHandlerTest.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import io.github.stslex.workeeper.feature.image_viewer.di.ImageViewerHandlerStore
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.State
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class CommonHandlerTest {
+
+    private fun setup(initialState: State = State.create("model")): TestSetup {
+        val stateFlow = MutableStateFlow(initialState)
+        val store = mockk<ImageViewerHandlerStore>(relaxed = true).apply {
+            every { state } returns stateFlow
+            every { updateState(any()) } answers {
+                val update = firstArg<(State) -> State>()
+                stateFlow.value = update(stateFlow.value)
+            }
+        }
+        return TestSetup(stateFlow, store, CommonHandler(store))
+    }
+
+    private data class TestSetup(
+        val stateFlow: MutableStateFlow<State>,
+        val store: ImageViewerHandlerStore,
+        val handler: CommonHandler,
+    )
+
+    @Test
+    fun `Init is a no-op (state already from initial)`() {
+        val (_, store, handler) = setup()
+        handler.invoke(Action.Common.Init)
+        verify(exactly = 0) { store.updateState(any()) }
+        verify(exactly = 0) { store.sendEvent(any()) }
+    }
+
+    @Test
+    fun `TransformChange writes the absolute scale and offsets to State`() {
+        val (stateFlow, _, handler) = setup()
+        handler.invoke(
+            Action.Common.TransformChange(scale = 2.5f, offsetX = 150f, offsetY = -200f),
+        )
+        assertEquals(2.5f, stateFlow.value.scale)
+        assertEquals(150f, stateFlow.value.offsetX)
+        assertEquals(-200f, stateFlow.value.offsetY)
+    }
+}

--- a/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/image-viewer/src/test/kotlin/io/github/stslex/workeeper/feature/image_viewer/mvi/handler/NavigationHandlerTest.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.image_viewer.mvi.handler
+
+import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.feature.image_viewer.mvi.store.ImageViewerStore.Action
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+internal class NavigationHandlerTest {
+
+    private val navigator = mockk<Navigator>(relaxed = true)
+    private val handler = NavigationHandler(
+        navigator = navigator,
+        data = Screen.ExerciseImage(model = "/files/uuid-1.jpg"),
+    )
+
+    @Test
+    fun `Back triggers popBack`() {
+        handler.invoke(Action.Navigation.Back)
+        verify(exactly = 1) { navigator.popBack() }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/ScopeClassType.kt
+++ b/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/ScopeClassType.kt
@@ -16,6 +16,7 @@ enum class ScopeClassType(
             "Repository",
             "DataStore",
             "Database",
+            "Storage",
             "StoreDispatchers",
         )
         private val viewModelScopedClasses = listOf(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,5 +50,6 @@ include(":feature:settings")
 include(":feature:home")
 include(":feature:live-workout")
 include(":feature:past-session")
+include(":feature:image-viewer")
 
 include(":lint-rules")


### PR DESCRIPTION
## Summary

First feature attached to a real file lifecycle. Adds a single hero image per exercise, captured via camera or chosen from the gallery, persisted as 1280×1280 JPEG q85 at `filesDir/exercise_images/<exerciseUuid>.jpg`. Edit-time changes are staged in State (`pendingImage`) and committed to disk only on Save, so cancelled edits leave no orphan files. Permanent delete drops the file with the row; archive preserves it.

A second commit lands a routed fullscreen viewer (`feature/image-viewer`) reachable from the Exercise detail hero and the Edit-screen thumbnail with pinch-to-zoom, pan, and double-tap-to-toggle (1f ↔ 2.5f, max 5f).

Future features needing image attachment (training cover, etc — v2) should reuse `core/core/images/ImageStorage`. The viewer is generic over its `model` arg (file path OR content URI). Future image-viewing needs (training cover viewer, set-photo viewer) should reuse `Screen.ExerciseImage` route or refactor it to a generically-named `Screen.ImageViewer` if/when that's needed.

**Disk usage estimate:** at JPEG q85, 1280×1280, expect ~150-400 KB per image. 100 exercises with photos ≈ 25 MB.

## Files changed grouped by module

### `core/core` (new)
- `core/core/images/ImageStorage.kt` — interface (saveImage, createTempCaptureUri, deleteImage, cleanupTempFiles)
- `core/core/images/ImageStorageImpl.kt` — `ImageDecoder`-based downsample, JPEG compress, atomic rename via temp file, IO-dispatcher-confined
- `core/core/images/ImageStorageModule.kt` — Hilt `@Binds` (`@Singleton`)
- `core/core/images/model/ImageSaveResult.kt`, `ImageSaveError.kt`
- `core/core/src/test/.../ImageStorageImplTest.kt` — Robolectric smoke tests for `deleteImage` / `cleanupTempFiles`

### `core/exercise`
- `ExerciseRepositoryImpl` — injects `ImageStorage`; `deleteItem` / `deleteAllItems` / `permanentDelete` / `bulkPermanentDelete` snapshot `imagePath` before the row drop and delete the file after. Archive remains untouched.
- `ExerciseRepositoryImplTest` — adds coverage for the four delete paths and a regression on archive.

### `core/ui/navigation`
- `Screen.kt` — new `data class ExerciseImage(model: String) : Screen` (route accepts both file paths and content URIs).

### `feature/exercise`
- New MVI models: `PendingImage` (`Unchanged` / `NewFromUri(uri)` / `RemoveExisting`), `ImageDisplay` (`None` / `FromPath` / `FromUri`), `ImageSourceUiModel`, `ImageErrorType`.
- `ExerciseStore` — adds `imagePath`, `imageLastModified`, `pendingImage`, `sourceDialogVisible`, `permissionDeniedDialogVisible`; `effectiveImageDisplay` derives the rendered image; `hasChanges` includes image-dirty. New `Click.OnImageThumbnailClick` and `Navigation.OpenImageViewer(model)`.
- `ClickHandler` — image source/permission/remove flows; thumbnail-click derives the model from `effectiveImageDisplay` and routes to the viewer; Save now commits `pendingImage` first, aborts on failure, then writes the DB row and finally deletes the previous file (write-new → update-DB → delete-old, never reordered).
- `CommonHandler` — handles `ImagePicked` / `ImagePickCancelled`; `applyLoaded` reads the file's `lastModified` for cache-busting.
- `NavigationHandler` — handles `OpenImageViewer` → `navTo(Screen.ExerciseImage(model))`.
- `ExerciseInteractor`/`Impl` — passthroughs for `saveImage`, `createTempCaptureUri`, `deleteImageFile`.
- `ExerciseEditScreen` — adds the `ImageEditRow` form section (thumbnail + Add/Edit + Remove buttons; thumbnail also clickable when an image is displayed).
- `ExerciseDetailScreen` — passes `effectiveImageDisplay` into the hero and wires the click into `OnImageThumbnailClick`.
- `ExerciseGraph` — wires `TakePicture` / `PickVisualMedia` / `RequestPermission` launchers, `ImageSourceDialog`, `PermissionDeniedDialog`, and the app-settings deeplink.
- New components: `ImageEditRow`, `ImageSourceDialog`, `PermissionDeniedDialog`; `ExerciseHero` now renders `AsyncImage` (cache-busted by mtime) when an image is present and is clickable when so.
- New strings (en + ru): edit title, add/edit/remove actions, source dialog labels, permission denied copy, image error toasts.
- Tests: `ClickHandlerTest` covers edit-image / remove / dialog dismiss / permission-denied / open-settings / thumbnail-click flows; `CommonHandlerTest` covers `ImagePicked` / `ImagePickCancelled`; `NavigationHandlerTest` covers `OpenImageViewer` → `Screen.ExerciseImage`.

### `feature/image-viewer` (new module)
- `di/`: `ImageViewerFeature`, `ImageViewerHandlerStore`/`Impl`, `ImageViewerModule`.
- `mvi/store/`: `ImageViewerStore` (state: `model`, `scale`, `offsetX`, `offsetY`; `MIN_SCALE=1f`, `MAX_SCALE=5f`, `DOUBLE_TAP_TARGET_SCALE=2.5f`), `ImageViewerStoreImpl`.
- `mvi/handler/`: `ClickHandler` (back, double-tap toggle), `CommonHandler` (Init no-op, `TransformChange` writes absolute scale/offsets), `NavigationHandler` (Back → `popBack`), `ImageViewerComponent`.
- `ui/`: `ImageViewerGraph`, `ImageViewerScreen` (Scaffold + transparent top bar over `Color.Black`), `components/ZoomableImage` — self-written `detectTransformGestures` + `detectTapGestures` with bound clamping (`pan ∈ ±((scale - 1) * viewportSize) / 2`), `graphicsLayer` for animated transform, Coil `AsyncImage` with error fallback.
- Strings: `feature_image_viewer_back`, `feature_image_viewer_content_description`, `feature_image_viewer_unavailable` (en + ru).
- Tests: handler tests for back/double-tap-toggle, transform persistence, navigation popBack.

### `feature/all-exercises`
- `ExerciseUiModel` adds `imagePath: String?`; mapper passes through.
- `ExerciseRow` leading slot renders an `AsyncImage` (cache-busted) when `imagePath != null`, else falls back to `ExerciseTypeIcon`.

### `app/app`
- `AndroidManifest.xml` — `CAMERA` permission, `<uses-feature>` not required, `FileProvider` (authority `${applicationId}.fileprovider`).
- `res/xml/file_provider_paths.xml` — exposes `filesDir/exercise_images/`.
- `BaseApplication.onCreate` — fires a one-shot `cleanupTempFiles()` via Hilt `EntryPoint`.
- `AppNavigationHost` — registers `imageViewerGraph(...)`.
- `RootComponentImpl` — adds the `Screen.ExerciseImage` branch.
- `app/app/build.gradle.kts` — depends on `:feature:image-viewer`.
- `settings.gradle.kts` — includes `:feature:image-viewer`.

### `lint-rules`
- `ScopeClassType.singletonClasses` — adds `Storage` so `ImageStorageImpl` resolves to `@Singleton` instead of being flagged for `@ViewModelScoped`.

## Verification gate

- `./gradlew assembleDebug` — passes (both `app:dev` and `app:store`).
- `./gradlew testDebugUnitTest` — passes (includes new `ImageStorageImplTest`, `ClickHandlerTest`, `CommonHandlerTest`, `ExerciseRepositoryImplTest` cases, and the three image-viewer handler tests).
- `./gradlew detekt` — passes.
- `./gradlew lintDebug` — passes.
- `./gradlew compileDebugAndroidTestKotlin` — passes (sources compile; no new androidTest scenarios in this PR).

## Manual scenarios

Manual verification on a real device is **not yet performed** — see test plan below. Marked as draft until then.

## Test plan

- [ ] Add image via gallery → save → hero updates → Exercises tab row thumbnail updates.
- [ ] Add image via camera (permission granted) → save → thumbnail.
- [ ] Deny camera permission → permission dialog shown → "Open settings" deeplinks correctly.
- [ ] Replace image → save → hero shows new image (no stale cache).
- [ ] Remove image → save → placeholder returns.
- [ ] Cancel during edit → no file artifacts in `filesDir/exercise_images/`.
- [ ] Permanent delete exercise → file gone from disk (`adb shell run-as`).
- [ ] Archive exercise with image → file still present.
- [ ] Kill app during camera capture → next launch, no temp file left behind.
- [ ] Tap hero on Exercise detail (with image) → viewer opens, image fits viewport, status bar visible.
- [ ] In viewer: pinch to zoom in, pan around — image bounds clamp pan correctly. Pinch out → image snaps back to MIN_SCALE = 1f and centers.
- [ ] In viewer: double-tap zoomed-out image → animates to ~2.5x. Double-tap again → animates back to 1f.
- [ ] Back gesture from viewer → returns to entry screen.
- [ ] Tap thumbnail in Edit screen with a freshly picked (uncommitted) image → viewer shows the picked image (content URI). Back → Edit screen still has `pendingImage = NewFromUri`.
- [ ] Russian locale: all new strings translated.