### PR TITLE
Bug: empty androidTest stub classes fail with InvalidTestClassError #113

### DIFF
--- a/.claude/skills/write-ui-test.md
+++ b/.claude/skills/write-ui-test.md
@@ -56,7 +56,7 @@ Mirror the production package. Lifted directly from
 ```kotlin
 package io.github.stslex.workeeper.feature.<name_snake>
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/app/dev/src/androidTest/kotlin/io/github/stslex/workeeper/dev/ApplicationBottomBarTest.kt
+++ b/app/dev/src/androidTest/kotlin/io/github/stslex/workeeper/dev/ApplicationBottomBarTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/BaseDataStore.kt
+++ b/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/BaseDataStore.kt
@@ -7,7 +7,7 @@ import io.github.stslex.workeeper.core.core.logger.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-open class BaseDataStore internal constructor(
+internal open class BaseDataStore internal constructor(
     private val storeProvider: DataStoreProvider,
 ) {
 
@@ -24,9 +24,10 @@ open class BaseDataStore internal constructor(
         }
     }
 
-    fun getString(key: String, default: String): Flow<String> = storeProvider.dataStore.data.map { prefs ->
-        prefs[stringPreferencesKey(key)] ?: default
-    }
+    fun getString(key: String, default: String): Flow<String> =
+        storeProvider.dataStore.data.map { prefs ->
+            prefs[stringPreferencesKey(key)] ?: default
+        }
 
     suspend fun updateString(key: String, value: String) {
         logger.i("Update key: $key with value: $value")

--- a/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/DataStoreProvider.kt
+++ b/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/DataStoreProvider.kt
@@ -2,18 +2,39 @@ package io.github.stslex.workeeper.core.data.dataStore.core
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
 
-class DataStoreProvider @AssistedInject constructor(
+internal class DataStoreProvider @AssistedInject constructor(
     @Assisted private val name: String,
     @ApplicationContext context: Context,
 ) {
 
-    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = name)
+    val dataStore: DataStore<Preferences> = provideDataStore(context.applicationContext, name)
 
-    val dataStore: DataStore<Preferences> = context.dataStore
+    private companion object {
+
+        private val stores = ConcurrentHashMap<String, DataStore<Preferences>>()
+        private val lock = Any()
+
+        fun provideDataStore(context: Context, name: String): DataStore<Preferences> {
+            stores[name]?.let { return it }
+
+            synchronized(lock) {
+                stores[name]?.let { return it }
+
+                val dataStore = PreferenceDataStoreFactory.create {
+                    context.preferencesDataStoreFile(name)
+                }
+
+                stores[name] = dataStore
+                return dataStore
+            }
+        }
+    }
 }

--- a/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/DataStoreProviderFactory.kt
+++ b/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/core/DataStoreProviderFactory.kt
@@ -3,7 +3,7 @@ package io.github.stslex.workeeper.core.data.dataStore.core
 import dagger.assisted.AssistedFactory
 
 @AssistedFactory
-interface DataStoreProviderFactory {
+internal interface DataStoreProviderFactory {
 
     fun create(name: String): DataStoreProvider
 }

--- a/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/store/CommonDataStoreImpl.kt
+++ b/core/data/dataStore/src/main/kotlin/io/github/stslex/workeeper/core/data/dataStore/store/CommonDataStoreImpl.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class CommonDataStoreImpl @Inject internal constructor(
+internal class CommonDataStoreImpl @Inject internal constructor(
     storeFactory: DataStoreProviderFactory,
 ) : CommonDataStore, BaseDataStore(
     storeFactory.create(NAME),

--- a/documentation/tech-debt.md
+++ b/documentation/tech-debt.md
@@ -113,7 +113,7 @@ Items where shipped behaviour diverges from what specs originally asked for. Sur
 
 ## androidTest Coverage Gap
 
-Six stub files with `TODO(feature-rewrite-tests)` markers and zero test methods. Created during initial Stage rewrites (5.1 / 5.2 / 5.3) under the assumption tests would be filled once the smoke harness stabilised. v2.0 stage scheduled the fill-in work; remaining stubs are tracked in the v2.0 spec and addressed in their own PRs.
+Five stub files with `TODO(feature-rewrite-tests)` markers carry an `@Ignore`d placeholder method — skipped via `@Ignore` placeholder, real coverage tracked in #93. (`SettingsScreenTest.kt`, listed below, was filled with real tests in a prior PR; row kept for traceability.) Created during initial Stage rewrites (5.1 / 5.2 / 5.3) under the assumption tests would be filled once the smoke harness stabilised. v2.0 stage scheduled the fill-in work; remaining stubs are tracked in the v2.0 spec and addressed in their own PRs.
 
 | Severity | Location | Stage |
 |---|---|---|

--- a/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
+++ b/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.all_exercises
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
+++ b/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @Smoke
@@ -17,4 +19,11 @@ class AllExercisesScreenTest : BaseComposeTest() {
 
     // TODO(feature-rewrite-tests): cover ExerciseRow click, FAB click, archive swipe, tag-filter
     // toggle, and empty state once Smoke harness wiring for AllExercisesScreen is restored.
+
+    @Test
+    @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
+    fun pendingFeatureRewrite() {
+        // Placeholder so AndroidJUnit4 has at least one @Test to discover.
+        // Remove when real tests are added.
+    }
 }

--- a/feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt
+++ b/feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @Smoke
@@ -18,4 +20,11 @@ class AllTrainingsScreenTest : BaseComposeTest() {
     // TODO(feature-rewrite-tests): cover TrainingRow click, FAB click, long-press selection,
     // tag-filter toggle, bulk archive/delete, and empty state once Smoke harness wiring for
     // AllTrainingsScreen is restored.
+
+    @Test
+    @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
+    fun pendingFeatureRewrite() {
+        // Placeholder so AndroidJUnit4 has at least one @Test to discover.
+        // Remove when real tests are added.
+    }
 }

--- a/feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt
+++ b/feature/all-trainings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_trainings/AllTrainingsScreenTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.all_trainings
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/feature/exercise-chart/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise_chart/ExerciseChartScreenTest.kt
+++ b/feature/exercise-chart/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise_chart/ExerciseChartScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -220,6 +220,11 @@ class ExerciseChartScreenTest : BaseComposeTest() {
         composeTestRule.onNodeWithTag("ExerciseChartNoDataForExercise").assertDoesNotExist()
         // And the canvas itself must be displayed.
         composeTestRule.onNodeWithTag("ChartCanvas").assertIsDisplayed()
+
+        // TODO(#119): Fails if the point is rendered outside the canvas bounds - for
+        // example tablet landscape with a very wide canvas. We should ideally test the
+        // point position here, but for now just verify that the footer is still visible
+        // and not pushed off-screen by an excessively wide chart.
         composeTestRule.onNodeWithTag("ChartFooterStats").assertIsDisplayed()
     }
 }

--- a/feature/exercise/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise/ExerciseScreenTest.kt
+++ b/feature/exercise/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise/ExerciseScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @Smoke
@@ -18,4 +20,11 @@ class ExerciseScreenTest : BaseComposeTest() {
     // TODO(feature-rewrite-tests): cover ExerciseDetailScreen, ExerciseEditScreen, mode flip,
     // archive overflow, tag picker create+toggle, discard dialog and snackbar paths once Smoke
     // harness wiring for the Exercise feature lands.
+
+    @Test
+    @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
+    fun pendingFeatureRewrite() {
+        // Placeholder so AndroidJUnit4 has at least one @Test to discover.
+        // Remove when real tests are added.
+    }
 }

--- a/feature/exercise/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise/ExerciseScreenTest.kt
+++ b/feature/exercise/src/androidTest/kotlin/io/github/stslex/workeeper/feature/exercise/ExerciseScreenTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.exercise
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @Smoke
@@ -16,4 +18,11 @@ class ArchiveScreenTest : BaseComposeTest() {
     val composeTestRule = createComposeRule()
 
     // TODO(feature-rewrite-tests): exercise segment switch + paged restore + delete dialog after Stage 5.1 stabilises.
+
+    @Test
+    @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
+    fun pendingFeatureRewrite() {
+        // Placeholder so AndroidJUnit4 has at least one @Test to discover.
+        // Remove when real tests are added.
+    }
 }

--- a/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/ArchiveScreenTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.settings
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/androidTest/kotlin/io/github/stslex/workeeper/feature/settings/SettingsScreenTest.kt
@@ -2,7 +2,7 @@
 package io.github.stslex.workeeper.feature.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/feature/single-training/src/androidTest/kotlin/io/github/stslex/workeeper/feature/single_training/SingleTrainingScreenTest.kt
+++ b/feature/single-training/src/androidTest/kotlin/io/github/stslex/workeeper/feature/single_training/SingleTrainingScreenTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.single_training
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke

--- a/feature/single-training/src/androidTest/kotlin/io/github/stslex/workeeper/feature/single_training/SingleTrainingScreenTest.kt
+++ b/feature/single-training/src/androidTest/kotlin/io/github/stslex/workeeper/feature/single_training/SingleTrainingScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @Smoke
@@ -18,4 +20,11 @@ class SingleTrainingScreenTest : BaseComposeTest() {
     // TODO(feature-rewrite-tests): cover detail/edit mode flip, save validation, plan
     // editor flow, exercise picker, and back-gesture interception once the smoke harness
     // for SingleTrainingScreen is restored.
+
+    @Test
+    @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
+    fun pendingFeatureRewrite() {
+        // Placeholder so AndroidJUnit4 has at least one @Test to discover.
+        // Remove when real tests are added.
+    }
 }


### PR DESCRIPTION
This commit adds placeholder test methods marked with @Ignore in multiple UI test files. These methods serve as temporary stubs while awaiting feature rewrites, ensuring that the test framework can discover them without executing any tests until real implementations are added.

Also fix existed Ui tests and lint warnings in ui tests.

