### PR TITLE
refactor: separate interactors and use cases in the domain layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,32 @@ Project context for OpenAI Codex / Cursor agents (and any other tool that follow
 - [documentation/lint-rules.md](documentation/lint-rules.md) — Detekt MVI rules + Android Lint.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow, commit format.
 
+### Domain layer: interactors and use cases
+
+- Each feature has one Interactor injected into the Store. The Interactor
+  is the only domain-layer dependency the store sees.
+- Interactor methods that are pure repository pass-through stay in the
+  Interactor implementation, calling the repository directly. A method
+  qualifies as pass-through if it is a single repository call optionally
+  wrapped in `withContext`/`flowOn`, with no business branching.
+- Methods with non-trivial business logic — multiple repository calls,
+  conditional branching, synthesized sealed return types, multi-step
+  orchestration — extract into a single-method use case in
+  `feature/<name>/domain/usecase/`.
+- A use case is a class with one `suspend operator fun invoke(...)` (or
+  non-suspend `fun invoke` for `Flow`-returning use cases). It injects only
+  the repositories and helpers it actually uses, plus its own
+  `@DefaultDispatcher` if it does suspend work.
+- The Interactor delegates thick methods to use cases with a single line.
+  Threading (`withContext`) lives in the use case.
+- Reference implementation: `feature/exercise/.../domain/`. See
+  `ArchiveExerciseUseCase`, `ResolveTrackNowConflictUseCase`,
+  `StartTrackNowSessionUseCase`, `DeleteSessionUseCase`.
+- Domain models vs data models: this convention is partially violated
+  today — interactors leak `*DataModel` types in several features. A
+  separate audit and migration plan is tracked under
+  `documentation/tech-debt.md`.
+
 ## Workflow recipes (`.claude/skills/`)
 
 These are Claude Code-shaped skill files. Other agents can read them as procedural recipes for

--- a/documentation/tech-debt.md
+++ b/documentation/tech-debt.md
@@ -128,6 +128,20 @@ Six stub files with `TODO(feature-rewrite-tests)` markers and zero test methods.
 
 ---
 
+## Domain model boundary
+
+Interactors and use cases currently expose `*DataModel` types directly
+(e.g. `ExerciseDataModel`, `TagDataModel`, `PlanSetDataModel`,
+`HistoryEntry`, `PersonalRecordDataModel`) in their public surface. UI
+mappers in some features import `DataModel` types directly, skipping the
+domain abstraction. Convention target: domain layer accepts and returns
+`DomainModel`-suffixed types, mapping data→domain happens in the
+interactor or use case, mapping domain→ui happens in the UI mapper.
+Migration plan to be drafted from a parallel domain-boundary audit (in
+progress).
+
+---
+
 ## v2.0 Foundations Stage — closed entries
 
 The v2.0 stage addressed the following items. They are listed here for traceability before they roll into the next audit cleanup.

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
 import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
-import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
@@ -15,14 +14,15 @@ import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseType
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.HistoryEntry
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordDataModel
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordRepository
-import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
 import io.github.stslex.workeeper.core.data.exercise.tags.TagRepository
 import io.github.stslex.workeeper.core.data.exercise.tags.model.TagDataModel
-import io.github.stslex.workeeper.core.data.exercise.training.TrainingRepository
-import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.SaveResult
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.TrackNowConflict
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.ArchiveExerciseUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.DeleteSessionUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.ResolveTrackNowConflictUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.StartTrackNowSessionUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
@@ -35,10 +35,11 @@ internal class ExerciseInteractorImpl @Inject constructor(
     private val exerciseRepository: ExerciseRepository,
     private val tagRepository: TagRepository,
     private val imageStorage: ImageStorage,
-    private val sessionRepository: SessionRepository,
-    private val trainingRepository: TrainingRepository,
     private val personalRecordRepository: PersonalRecordRepository,
-    private val resourceWrapper: ResourceWrapper,
+    private val archiveExerciseUseCase: ArchiveExerciseUseCase,
+    private val resolveTrackNowConflictUseCase: ResolveTrackNowConflictUseCase,
+    private val startTrackNowSessionUseCase: StartTrackNowSessionUseCase,
+    private val deleteSessionUseCase: DeleteSessionUseCase,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : ExerciseInteractor {
 
@@ -84,15 +85,7 @@ internal class ExerciseInteractorImpl @Inject constructor(
         tagRepository.add(name)
     }
 
-    override suspend fun archive(uuid: String): ArchiveResult = withContext(defaultDispatcher) {
-        val activeTrainings = exerciseRepository.getActiveTrainingsUsing(uuid)
-        if (activeTrainings.isNotEmpty()) {
-            ArchiveResult.Blocked(activeTrainings)
-        } else {
-            exerciseRepository.archive(uuid)
-            ArchiveResult.Success
-        }
-    }
+    override suspend fun archive(uuid: String): ArchiveResult = archiveExerciseUseCase(uuid)
 
     override suspend fun restore(uuid: String) {
         withContext(defaultDispatcher) { exerciseRepository.restore(uuid) }
@@ -135,42 +128,13 @@ internal class ExerciseInteractorImpl @Inject constructor(
 
     override suspend fun deleteImageFile(path: String): Boolean = imageStorage.deleteImage(path)
 
-    override suspend fun resolveTrackNowConflict(): TrackNowConflict = withContext(defaultDispatcher) {
-        val active = sessionRepository.getAnyActiveSession()
-            ?: return@withContext TrackNowConflict.ProceedFresh
-        val training = trainingRepository.getTraining(active.trainingUuid)
-        val sessionLabel = training?.name?.takeIf { it.isNotBlank() }
-            ?: resourceWrapper.getString(R.string.feature_exercise_track_now_conflict_unnamed)
-        TrackNowConflict.NeedsUserChoice(active = active, sessionLabel = sessionLabel)
-    }
+    override suspend fun resolveTrackNowConflict(): TrackNowConflict = resolveTrackNowConflictUseCase()
 
     override suspend fun startTrackNowSession(
         exerciseUuid: String,
-    ): String = withContext(defaultDispatcher) {
-        val exercise = exerciseRepository.getExercise(exerciseUuid)
-        val trainingName = exercise?.name?.takeIf { it.isNotBlank() }
-            ?: resourceWrapper.getString(R.string.feature_exercise_track_now_default_training_name)
-        // Shared adhoc-session helper — same code path as v2.3 Quick start. Replaces the
-        // older two-step Training upsert + session start that left orphan training rows
-        // when Track Now was cancelled (the cancel path only deleted the session).
-        sessionRepository.createAdhocSession(
-            name = trainingName,
-            exerciseUuids = listOf(exerciseUuid),
-        ).sessionUuid
-    }
+    ): String = startTrackNowSessionUseCase(exerciseUuid)
 
     override suspend fun deleteSession(sessionUuid: String) {
-        withContext(defaultDispatcher) {
-            val session = sessionRepository.getById(sessionUuid) ?: return@withContext
-            val training = trainingRepository.getTraining(session.trainingUuid)
-            if (training?.isAdhoc == true) {
-                sessionRepository.discardAdhocSession(
-                    sessionUuid = sessionUuid,
-                    trainingUuid = session.trainingUuid,
-                )
-            } else {
-                sessionRepository.deleteSession(sessionUuid)
-            }
-        }
+        deleteSessionUseCase(sessionUuid)
     }
 }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/ArchiveExerciseUseCase.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/ArchiveExerciseUseCase.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.domain.usecase
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
+import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.ArchiveResult
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ArchiveExerciseUseCase @Inject constructor(
+    private val exerciseRepository: ExerciseRepository,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) {
+
+    suspend operator fun invoke(uuid: String): ArchiveResult = withContext(defaultDispatcher) {
+        val activeTrainings = exerciseRepository.getActiveTrainingsUsing(uuid)
+        if (activeTrainings.isNotEmpty()) {
+            ArchiveResult.Blocked(activeTrainings)
+        } else {
+            exerciseRepository.archive(uuid)
+            ArchiveResult.Success
+        }
+    }
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/DeleteSessionUseCase.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/DeleteSessionUseCase.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.domain.usecase
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.data.exercise.training.TrainingRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class DeleteSessionUseCase @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val trainingRepository: TrainingRepository,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) {
+
+    suspend operator fun invoke(sessionUuid: String) {
+        withContext(defaultDispatcher) {
+            val session = sessionRepository.getById(sessionUuid) ?: return@withContext
+            val training = trainingRepository.getTraining(session.trainingUuid)
+            if (training?.isAdhoc == true) {
+                sessionRepository.discardAdhocSession(
+                    sessionUuid = sessionUuid,
+                    trainingUuid = session.trainingUuid,
+                )
+            } else {
+                sessionRepository.deleteSession(sessionUuid)
+            }
+        }
+    }
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/ResolveTrackNowConflictUseCase.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/ResolveTrackNowConflictUseCase.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.domain.usecase
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
+import io.github.stslex.workeeper.core.data.exercise.training.TrainingRepository
+import io.github.stslex.workeeper.feature.exercise.R
+import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.TrackNowConflict
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class ResolveTrackNowConflictUseCase @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val trainingRepository: TrainingRepository,
+    private val resourceWrapper: ResourceWrapper,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) {
+
+    suspend operator fun invoke(): TrackNowConflict = withContext(defaultDispatcher) {
+        val active = sessionRepository.getAnyActiveSession()
+            ?: return@withContext TrackNowConflict.ProceedFresh
+        val training = trainingRepository.getTraining(active.trainingUuid)
+        val sessionLabel = training?.name?.takeIf { it.isNotBlank() }
+            ?: resourceWrapper.getString(R.string.feature_exercise_track_now_conflict_unnamed)
+        TrackNowConflict.NeedsUserChoice(active = active, sessionLabel = sessionLabel)
+    }
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/StartTrackNowSessionUseCase.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/usecase/StartTrackNowSessionUseCase.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.domain.usecase
+
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
+import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
+import io.github.stslex.workeeper.feature.exercise.R
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class StartTrackNowSessionUseCase @Inject constructor(
+    private val exerciseRepository: ExerciseRepository,
+    private val sessionRepository: SessionRepository,
+    private val resourceWrapper: ResourceWrapper,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) {
+
+    suspend operator fun invoke(exerciseUuid: String): String = withContext(defaultDispatcher) {
+        val exercise = exerciseRepository.getExercise(exerciseUuid)
+        val trainingName = exercise?.name?.takeIf { it.isNotBlank() }
+            ?: resourceWrapper.getString(R.string.feature_exercise_track_now_default_training_name)
+        // Shared adhoc-session helper — same code path as v2.3 Quick start. Replaces the
+        // older two-step Training upsert + session start that left orphan training rows
+        // when Track Now was cancelled (the cancel path only deleted the session).
+        sessionRepository.createAdhocSession(
+            name = trainingName,
+            exerciseUuids = listOf(exerciseUuid),
+        ).sessionUuid
+    }
+}

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
@@ -2,18 +2,19 @@
 package io.github.stslex.workeeper.feature.exercise.domain
 
 import io.github.stslex.workeeper.core.core.images.ImageStorage
-import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.SetsDataType
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordDataModel
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordRepository
-import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
 import io.github.stslex.workeeper.core.data.exercise.tags.TagRepository
-import io.github.stslex.workeeper.core.data.exercise.training.TrainingRepository
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor.SaveResult
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.ArchiveExerciseUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.DeleteSessionUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.ResolveTrackNowConflictUseCase
+import io.github.stslex.workeeper.feature.exercise.domain.usecase.StartTrackNowSessionUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -33,18 +34,20 @@ internal class ExerciseInteractorImplTest {
     private val exerciseRepository = mockk<ExerciseRepository>(relaxed = true)
     private val tagRepository = mockk<TagRepository>(relaxed = true)
     private val imageStorage = mockk<ImageStorage>(relaxed = true)
-    private val sessionRepository = mockk<SessionRepository>(relaxed = true)
-    private val trainingRepository = mockk<TrainingRepository>(relaxed = true)
     private val personalRecordRepository = mockk<PersonalRecordRepository>(relaxed = true)
-    private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true)
+    private val archiveExerciseUseCase = mockk<ArchiveExerciseUseCase>(relaxed = true)
+    private val resolveTrackNowConflictUseCase = mockk<ResolveTrackNowConflictUseCase>(relaxed = true)
+    private val startTrackNowSessionUseCase = mockk<StartTrackNowSessionUseCase>(relaxed = true)
+    private val deleteSessionUseCase = mockk<DeleteSessionUseCase>(relaxed = true)
     private val interactor = ExerciseInteractorImpl(
         exerciseRepository = exerciseRepository,
         tagRepository = tagRepository,
         imageStorage = imageStorage,
-        sessionRepository = sessionRepository,
-        trainingRepository = trainingRepository,
         personalRecordRepository = personalRecordRepository,
-        resourceWrapper = resourceWrapper,
+        archiveExerciseUseCase = archiveExerciseUseCase,
+        resolveTrackNowConflictUseCase = resolveTrackNowConflictUseCase,
+        startTrackNowSessionUseCase = startTrackNowSessionUseCase,
+        deleteSessionUseCase = deleteSessionUseCase,
         defaultDispatcher = Dispatchers.Unconfined,
     )
 
@@ -104,20 +107,20 @@ internal class ExerciseInteractorImplTest {
 
     @Test
     fun `archive returns Blocked when active trainings exist`() = runTest {
-        coEvery { exerciseRepository.getActiveTrainingsUsing("uuid-1") } returns listOf("Push")
+        coEvery { archiveExerciseUseCase("uuid-1") } returns ArchiveResult.Blocked(listOf("Push"))
 
         val result = interactor.archive("uuid-1")
         assertTrue(result is ArchiveResult.Blocked)
-        coVerify(exactly = 0) { exerciseRepository.archive(any()) }
+        coVerify { archiveExerciseUseCase("uuid-1") }
     }
 
     @Test
     fun `archive returns Success when no active trainings`() = runTest {
-        coEvery { exerciseRepository.getActiveTrainingsUsing("uuid-1") } returns emptyList()
+        coEvery { archiveExerciseUseCase("uuid-1") } returns ArchiveResult.Success
 
         val result = interactor.archive("uuid-1")
         assertTrue(result is ArchiveResult.Success)
-        coVerify { exerciseRepository.archive("uuid-1") }
+        coVerify { archiveExerciseUseCase("uuid-1") }
     }
 
     @Test


### PR DESCRIPTION
refactor: streamline ExerciseInteractorImpl by delegating responsibilities to use cases

Summary:
This commit refactors the domain layer by introducing distinct use cases for archiving exercises, resolving conflicts, starting sessions, and deleting sessions. The ExerciseInteractorImpl now delegates these responsibilities to their respective use cases, enhancing code clarity and maintainability.

Key changes:
- Added `ArchiveExerciseUseCase`, `DeleteSessionUseCase`, `ResolveTrackNowConflictUseCase`, and `StartTrackNowSessionUseCase`.
- Updated `ExerciseInteractorImpl` to utilize these use cases, removing direct repository calls.
- Enhanced documentation in AGENTS.md regarding the interaction between interactors and use cases.