### PR TITLE
refactor: adjust BottomNavBar height to include navigation bar insets

### DIFF
--- a/app/app/src/main/java/io/github/stslex/workeeper/bottom_app_bar/BottomAppBar.kt
+++ b/app/app/src/main/java/io/github/stslex/workeeper/bottom_app_bar/BottomAppBar.kt
@@ -57,7 +57,7 @@ internal fun WorkeeperBottomAppBar(
 
     BottomAppBar(
         modifier = modifier
-            .height(AppDimension.BottomNavBar.height)
+            .height(AppDimension.BottomNavBar.heightWithInsets)
             .testTag("WorkeeperBottomAppBar"),
         contentPadding = PaddingValues(AppDimension.Padding.medium),
     ) {

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppDimension.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/theme/AppDimension.kt
@@ -1,5 +1,9 @@
 package io.github.stslex.workeeper.core.ui.kit.theme
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -64,6 +68,10 @@ object AppDimension {
     object BottomNavBar {
 
         val height = 72.dp
+
+        val heightWithInsets: Dp
+            @Composable
+            get() = height + WindowInsets.navigationBars.getBottom(LocalDensity.current).toDp
     }
 
     object Space {


### PR DESCRIPTION
This commit modifies the BottomNavBar height calculation to account for the navigation bar insets, ensuring proper layout and spacing in the UI.