### PR TITLE
Fix/140 finish session update training

### DIFF
--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/session/SessionRepositoryImpl.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/session/SessionRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import io.github.stslex.workeeper.core.core.coroutine.asyncForEach
+import io.github.stslex.workeeper.core.core.coroutine.asyncScope
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.data.database.common.DbTransitionRunner
 import io.github.stslex.workeeper.core.data.database.converters.PlanSetsConverter
@@ -56,11 +57,12 @@ internal class SessionRepositoryImpl @Inject constructor(
 
     override fun observeActive(): Flow<SessionDataModel?> = dao
         .observeActive()
-        .map { entity -> entity?.toData() }
         .flowOn(ioDispatcher)
+        .map { entity -> entity?.toData() }
 
     override fun observeAnyActiveSession(): Flow<ActiveSessionInfo?> = dao
         .observeAnyActiveSession()
+        .flowOn(ioDispatcher)
         .map { row ->
             row?.let {
                 ActiveSessionInfo(
@@ -70,11 +72,11 @@ internal class SessionRepositoryImpl @Inject constructor(
                 )
             }
         }
-        .flowOn(ioDispatcher)
 
     override fun observeActiveSessionWithStats(): Flow<SessionRepository.ActiveSessionWithStats?> =
         dao
             .observeActiveSessionWithStats()
+            .flowOn(ioDispatcher)
             .map { row ->
                 row?.let {
                     SessionRepository.ActiveSessionWithStats(
@@ -88,7 +90,6 @@ internal class SessionRepositoryImpl @Inject constructor(
                     )
                 }
             }
-            .flowOn(ioDispatcher)
 
     override suspend fun getAnyActiveSession(): ActiveSessionInfo? = withContext(ioDispatcher) {
         dao.getActive()?.let { entity ->
@@ -106,15 +107,15 @@ internal class SessionRepositoryImpl @Inject constructor(
 
     override fun observeRecent(limit: Int): Flow<List<SessionDataModel>> = dao
         .observeRecent(limit)
-        .map { list -> list.map { it.toData() } }
         .flowOn(ioDispatcher)
+        .map { list -> list.map { it.toData() } }
 
     override fun observeRecentWithStats(
         limit: Int,
     ): Flow<List<RecentSessionDataModel>> = dao
         .observeRecentWithStats(limit)
-        .map { rows -> rows.map { it.toData() } }
         .flowOn(ioDispatcher)
+        .map { rows -> rows.map { it.toData() } }
 
     override suspend fun getSessionDetail(
         sessionUuid: String,
@@ -160,8 +161,8 @@ internal class SessionRepositoryImpl @Inject constructor(
         config = pagingConfig,
         pagingSourceFactory = dao::pagedFinished,
     ).flow
-        .map { pagingData -> pagingData.map { it.toData() } }
         .flowOn(ioDispatcher)
+        .map { pagingData -> pagingData.map { it.toData() } }
 
     override fun pagedFinishedByTraining(
         trainingUuid: String,
@@ -169,8 +170,8 @@ internal class SessionRepositoryImpl @Inject constructor(
         config = pagingConfig,
         pagingSourceFactory = { dao.pagedFinishedByTraining(Uuid.parse(trainingUuid)) },
     ).flow
-        .map { pagingData -> pagingData.map { it.toData() } }
         .flowOn(ioDispatcher)
+        .map { pagingData -> pagingData.map { it.toData() } }
 
     override suspend fun getRecentFinishedByTraining(
         trainingUuid: String,
@@ -269,14 +270,23 @@ internal class SessionRepositoryImpl @Inject constructor(
         // Adhoc lifecycle (v2.3): on finish, the training row and every exercise
         // plan-attached to it graduate to regular library entries. Runs inside the same
         // transaction as the state flip so a failed finish does not leak half-graduated rows.
-        exerciseDao.graduateAdhocForTraining(current.trainingUuid)
-        trainingDao.graduateTraining(current.trainingUuid)
-        dao.update(
-            current.copy(
-                state = SessionStateEntity.FINISHED,
-                finishedAt = finishedAt,
-            ),
-        )
+        val exerciseAdhoc = asyncScope {
+            exerciseDao.graduateAdhocForTraining(current.trainingUuid)
+        }
+        val trainingGraduate = asyncScope {
+            trainingDao.graduateTraining(current.trainingUuid)
+        }
+        val sessionGraduate = asyncScope {
+            dao.update(
+                current.copy(
+                    state = SessionStateEntity.FINISHED,
+                    finishedAt = finishedAt,
+                ),
+            )
+        }
+        exerciseAdhoc.await()
+        trainingGraduate.await()
+        sessionGraduate.await()
         true
     }
 

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImpl.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImpl.kt
@@ -9,7 +9,6 @@ import io.github.stslex.workeeper.core.data.exercise.session.PerformedExerciseRe
 import io.github.stslex.workeeper.core.data.exercise.session.PlanUpdate
 import io.github.stslex.workeeper.core.data.exercise.session.SessionRepository
 import io.github.stslex.workeeper.core.data.exercise.session.SetRepository
-import io.github.stslex.workeeper.core.data.exercise.sets.PlanUpdateRule
 import io.github.stslex.workeeper.core.data.exercise.training.TrainingExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.training.TrainingRepository
 import io.github.stslex.workeeper.feature.live_workout.domain.mapper.LiveWorkoutDomainMapper.toData
@@ -196,7 +195,9 @@ internal class LiveWorkoutInteractorImpl @Inject constructor(
                     )
                     ?: exerciseRepository.getAdhocPlan(row.exerciseUuid)
             }
-            val nextPlan = PlanUpdateRule.update(existingPlan, performedSets.map { it.toData() })
+            val nextPlan = performedSets
+                .map { it.toData() }
+                .ifEmpty { existingPlan }
             planUpdates += PlanUpdate(
                 trainingUuid = session.trainingUuid,
                 exerciseUuid = row.exerciseUuid,
@@ -324,7 +325,11 @@ internal class LiveWorkoutInteractorImpl @Inject constructor(
         plan: List<PlanSetDomain>?,
     ) {
         withContext(defaultDispatcher) {
-            trainingExerciseRepository.setPlan(trainingUuid, exerciseUuid, plan?.map { it.toData() })
+            trainingExerciseRepository.setPlan(
+                trainingUuid,
+                exerciseUuid,
+                plan?.map { it.toData() },
+            )
         }
     }
 

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandler.kt
@@ -15,19 +15,15 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMap
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMapper.toFinishStats
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ErrorType
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
 import kotlinx.collections.immutable.toImmutableSet
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions", "LongMethod", "LargeClass")
 @ViewModelScoped
-// TODO(tech-debt): v2.7 decomposition pass — this handler legitimately gained
-// training-name + empty-finish + add-exercise dispatch in v2.3 (per spec); further
-// splits (TrainingNameHandler, EmptyFinishHandler) belong with the rest of the
-// live-workout feature decomposition.
 internal class ClickHandler @Inject constructor(
     private val interactor: LiveWorkoutInteractor,
     private val resourceWrapper: ResourceWrapper,
@@ -45,21 +41,10 @@ internal class ClickHandler @Inject constructor(
             is Action.Click.OnAddSet -> processAddSet(action)
             is Action.Click.OnEditPlan -> processEditPlan(action)
             is Action.Click.OnResetSets -> processResetSetsAsk(action)
-            is Action.Click.OnResetSetsConfirm -> processResetSetsConfirm(action)
-            Action.Click.OnResetSetsDismiss -> processResetSetsDismiss()
             is Action.Click.OnSkipExercise -> processSkipExerciseAsk(action)
-            is Action.Click.OnSkipExerciseConfirm -> processSkipExerciseConfirm(action)
-            Action.Click.OnSkipExerciseDismiss -> processSkipExerciseDismiss()
             Action.Click.OnFinishClick -> processFinishClick()
-            Action.Click.OnFinishConfirm -> processFinishConfirm()
-            is Action.Click.OnFinishNameChange -> processFinishNameChange(action)
-            Action.Click.OnFinishDismiss -> processFinishDismiss()
             Action.Click.OnCancelSessionClick -> processCancelClick()
-            Action.Click.OnCancelSessionConfirm -> processCancelConfirm()
-            Action.Click.OnCancelSessionDismiss -> processCancelDismiss()
             Action.Click.OnDeleteSessionMenuClick -> processDeleteSessionMenuClick()
-            Action.Click.OnDeleteSessionConfirm -> processDeleteSessionConfirm()
-            Action.Click.OnDeleteSessionDismiss -> processDeleteSessionDismiss()
             is Action.Click.OnExerciseHeaderClick -> processExerciseHeaderClick(action)
             Action.Click.OnBackClick -> processBackClick()
             Action.Click.OnTrainingNameTap -> processTrainingNameTap()
@@ -67,9 +52,6 @@ internal class ClickHandler @Inject constructor(
             is Action.Click.OnTrainingNameSubmit -> processTrainingNameSubmit(action)
             Action.Click.OnTrainingNameDismiss -> processTrainingNameDismiss()
             Action.Click.OnAddExerciseClick -> processAddExerciseClick()
-            is Action.Click.PickerAction -> pickerHandler.invoke(action.action)
-            Action.Click.OnEmptyFinishDiscard -> processEmptyFinishDiscard()
-            Action.Click.OnEmptyFinishContinue -> processEmptyFinishContinue()
         }
     }
 
@@ -86,12 +68,12 @@ internal class ClickHandler @Inject constructor(
         // Spec dismissal order: picker → empty-finish dialog → name edit → plan-editor
         // dirty → default back.
         val current = state.value
-        if (current.isPickerVisible) {
+        if (current.bottomSheetState is BottomSheetState.ExercisePicker) {
             pickerHandler.invoke(ExercisePickerAction.OnDismiss)
             return
         }
-        if (current.isEmptyFinishDialogVisible) {
-            processEmptyFinishContinue()
+        if (current.dialogState is DialogState.EmptyFinish) {
+            consume(Action.DialogClick.OnEmptyFinishContinue)
             return
         }
         if (current.isTrainingNameEditing) {
@@ -304,60 +286,32 @@ internal class ClickHandler @Inject constructor(
 
     private fun processResetSetsAsk(action: Action.Click.OnResetSets) {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        updateState { it.copy(pendingResetExerciseUuid = action.performedExerciseUuid) }
-        sendEvent(
-            Event.ShowResetSetsConfirmDialog(
-                dialog = LiveWorkoutStore.ConfirmDialog(
+        updateState {
+            it.copy(
+                dialogState = DialogState.ConfirmDialog.ResetSets(
                     title = resourceWrapper.getString(R.string.feature_live_workout_reset_title),
                     body = resourceWrapper.getString(R.string.feature_live_workout_reset_body),
                     confirmLabel = resourceWrapper.getString(R.string.feature_live_workout_reset_confirm),
                     dismissLabel = resourceWrapper.getString(R.string.feature_live_workout_reset_dismiss),
+                    exerciseUuid = action.performedExerciseUuid,
                 ),
-            ),
-        )
-    }
-
-    private fun processResetSetsConfirm(action: Action.Click.OnResetSetsConfirm) {
-        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
-        updateState { latest -> setMutator.applyResetSets(latest, action.performedExerciseUuid) }
-        launch(
-            onError = { _ -> sendError(ErrorType.ResetFailed) },
-        ) {
-            interactor.resetExerciseSets(action.performedExerciseUuid)
+            )
         }
-    }
-
-    private fun processResetSetsDismiss() {
-        updateState { it.copy(pendingResetExerciseUuid = null) }
     }
 
     private fun processSkipExerciseAsk(action: Action.Click.OnSkipExercise) {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        updateState { it.copy(pendingSkipExerciseUuid = action.performedExerciseUuid) }
-        sendEvent(
-            Event.ShowSkipExerciseConfirmDialog(
-                dialog = LiveWorkoutStore.ConfirmDialog(
+        updateState {
+            it.copy(
+                dialogState = DialogState.ConfirmDialog.SkipExercise(
                     title = resourceWrapper.getString(R.string.feature_live_workout_skip_title),
                     body = resourceWrapper.getString(R.string.feature_live_workout_skip_body),
                     confirmLabel = resourceWrapper.getString(R.string.feature_live_workout_skip_confirm),
                     dismissLabel = resourceWrapper.getString(R.string.feature_live_workout_skip_dismiss),
+                    exerciseUuid = action.performedExerciseUuid,
                 ),
-            ),
-        )
-    }
-
-    private fun processSkipExerciseConfirm(action: Action.Click.OnSkipExerciseConfirm) {
-        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
-        updateState { latest -> setMutator.applySkip(latest, action.performedExerciseUuid) }
-        launch(
-            onError = { _ -> sendError(ErrorType.SkipFailed) },
-        ) {
-            interactor.setSkipped(action.performedExerciseUuid, skipped = true)
+            )
         }
-    }
-
-    private fun processSkipExerciseDismiss() {
-        updateState { it.copy(pendingSkipExerciseUuid = null) }
     }
 
     private fun processFinishClick() {
@@ -369,7 +323,7 @@ internal class ClickHandler @Inject constructor(
             // Continue-editing-only variant.
             updateState {
                 it.copy(
-                    emptyFinishDialog = State.EmptyFinishDialogState.Visible(
+                    dialogState = DialogState.EmptyFinish(
                         canDiscard = it.isAdhoc,
                         confirmLabel = resourceWrapper.getString(R.string.feature_live_workout_empty_finish_discard),
                         dismissLabel = resourceWrapper.getString(R.string.feature_live_workout_empty_finish_continue),
@@ -379,177 +333,46 @@ internal class ClickHandler @Inject constructor(
             return
         }
         val stats = current.toFinishStats(resourceWrapper)
-        updateState { it.copy(pendingFinishConfirm = stats) }
-        sendEvent(Event.ShowFinishConfirmDialog)
-    }
-
-    private fun processEmptyFinishContinue() {
-        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        updateState { it.copy(emptyFinishDialog = State.EmptyFinishDialogState.Hidden) }
-    }
-
-    private fun processEmptyFinishDiscard() {
-        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
-        val current = state.value
-        val sessionUuid = current.sessionUuid
-        val trainingUuid = current.trainingUuid
-        // Defence: discard cascade only fires for ad-hoc trainings. Library sessions can't
-        // reach this path (canDiscard = false in the dialog), but we double-check before
-        // calling the cascade DAO write.
-        if (!current.isAdhoc || sessionUuid.isNullOrBlank() || trainingUuid.isNullOrBlank()) {
-            updateState { it.copy(emptyFinishDialog = State.EmptyFinishDialogState.Hidden) }
-            return
-        }
         updateState {
             it.copy(
-                emptyFinishDialog = State.EmptyFinishDialogState.Hidden,
-                isFinishInFlight = true,
+                dialogState = stats,
             )
         }
-        launch(
-            onSuccess = { consumeOnMain(Action.Navigation.Back) },
-            onError = { _ ->
-                updateState { it.copy(isFinishInFlight = false) }
-                sendError(ErrorType.DiscardSessionFailed)
-            },
-        ) {
-            interactor.discardAdhocSession(
-                sessionUuid = sessionUuid,
-                trainingUuid = trainingUuid,
-            )
-        }
-    }
-
-    private fun processFinishConfirm() {
-        sendEvent(Event.HapticImpact(HapticFeedbackType.Confirm))
-        val current = state.value
-        val sessionUuid = current.sessionUuid ?: return
-        val stats = current.pendingFinishConfirm
-        val requiredName = stats?.nameDraft
-            ?.trim()
-            ?.takeIf { stats.requiresName }
-        if (stats?.requiresName == true && requiredName.isNullOrBlank()) {
-            val requiredError =
-                resourceWrapper.getString(R.string.feature_live_workout_finish_name_required)
-            updateState { latest ->
-                latest.copy(
-                    pendingFinishConfirm = latest.pendingFinishConfirm?.copy(
-                        nameError = requiredError,
-                        confirmEnabled = false,
-                    ),
-                )
-            }
-            return
-        }
-        val trainingUuid = current.trainingUuid
-        if (stats?.requiresName == true && trainingUuid.isNullOrBlank()) {
-            sendError(ErrorType.FinishFailed)
-            return
-        }
-        launch(
-            onSuccess = { result ->
-                if (result == null) {
-                    sendError(ErrorType.FinishMissingSession)
-                    updateState { it.copy(isFinishInFlight = false) }
-                    return@launch
-                }
-                sendEvent(
-                    Event.ShowSessionSavedSnackbar(
-                        message = resourceWrapper.getString(R.string.feature_live_workout_finish_success),
-                    ),
-                )
-                consumeOnMain(Action.Navigation.OpenPastSession(sessionUuid = sessionUuid))
-            },
-            onError = { _ ->
-                updateState { it.copy(isFinishInFlight = false) }
-                sendError(ErrorType.FinishFailed)
-            },
-        ) {
-            // Rename + finish are paired inside finishSessionAtomic so a crash between
-            // the two writes can no longer leave a named-but-IN_PROGRESS session.
-            interactor.finishSession(
-                sessionUuid = sessionUuid,
-                newTrainingName = requiredName,
-            )
-        }
-    }
-
-    private fun processFinishNameChange(action: Action.Click.OnFinishNameChange) {
-        val trimmed = action.text.trim()
-        val requiredError = resourceWrapper
-            .getString(R.string.feature_live_workout_finish_name_required)
-            .takeIf { trimmed.isBlank() }
-        updateState { latest ->
-            val current = latest.pendingFinishConfirm ?: return@updateState latest
-            latest.copy(
-                pendingFinishConfirm = current.copy(
-                    nameDraft = action.text,
-                    nameError = requiredError,
-                    confirmEnabled = trimmed.isNotBlank(),
-                ),
-            )
-        }
-    }
-
-    private fun processFinishDismiss() {
-        updateState { it.copy(pendingFinishConfirm = null) }
     }
 
     private fun processCancelClick() {
         sendEvent(Event.HapticClick(HapticFeedbackType.Confirm))
-        updateState { it.copy(pendingCancelConfirm = true) }
-        sendEvent(
-            Event.ShowCancelSessionConfirmDialog(
-                dialog = LiveWorkoutStore.ConfirmDialog(
+        updateState {
+            it.copy(
+                dialogState = DialogState.ConfirmDialog.CancelSession(
                     title = resourceWrapper.getString(R.string.feature_live_workout_cancel_title),
                     body = resourceWrapper.getString(R.string.feature_live_workout_cancel_body),
                     confirmLabel = resourceWrapper.getString(R.string.feature_live_workout_cancel_confirm),
                     dismissLabel = resourceWrapper.getString(R.string.feature_live_workout_cancel_dismiss),
                 ),
-            ),
-        )
-    }
-
-    private fun processCancelConfirm() {
-        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
-        val sessionUuid = state.value.sessionUuid ?: run {
-            consume(Action.Navigation.Back)
-            return
+            )
         }
-        launch(
-            onSuccess = { consumeOnMain(Action.Navigation.Back) },
-            onError = { _ -> sendError(ErrorType.CancelFailed) },
-        ) {
-            interactor.cancelSession(sessionUuid)
-        }
-    }
-
-    private fun processCancelDismiss() {
-        updateState { it.copy(pendingCancelConfirm = false) }
     }
 
     private fun processDeleteSessionMenuClick() {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        updateState { it.copy(deleteDialogVisible = true) }
-    }
 
-    private fun processDeleteSessionConfirm() {
-        val sessionUuid = state.value.sessionUuid ?: run {
-            updateState { it.copy(deleteDialogVisible = false) }
-            return
+        updateState { state ->
+            val sessionName = state.trainingNameLabel.takeIf { it.isNotBlank() }
+                ?: resourceWrapper.getString(R.string.feature_live_workout_delete_session_unnamed)
+            val progressLabel = resourceWrapper.getString(
+                R.string.feature_live_workout_delete_session_progress_format,
+                state.doneCount,
+                state.totalCount,
+                state.setsLogged,
+            )
+            state.copy(
+                dialogState = DialogState.DeleteDialog(
+                    sessionName = sessionName,
+                    progressLabel = progressLabel,
+                ),
+            )
         }
-        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
-        updateState { it.copy(deleteDialogVisible = false) }
-        launch(
-            onSuccess = { consumeOnMain(Action.Navigation.Back) },
-            onError = { _ -> sendError(ErrorType.CancelFailed) },
-        ) {
-            interactor.cancelSession(sessionUuid)
-        }
-    }
-
-    private fun processDeleteSessionDismiss() {
-        updateState { it.copy(deleteDialogVisible = false) }
     }
 
     private fun processExerciseHeaderClick(action: Action.Click.OnExerciseHeaderClick) {

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/DialogClickHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/DialogClickHandler.kt
@@ -1,0 +1,216 @@
+package io.github.stslex.workeeper.feature.live_workout.mvi.handler
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.feature.live_workout.R
+import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutHandlerStore
+import io.github.stslex.workeeper.feature.live_workout.domain.LiveWorkoutInteractor
+import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveSetMutator
+import io.github.stslex.workeeper.feature.live_workout.mvi.model.ErrorType
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
+import javax.inject.Inject
+
+@ViewModelScoped
+internal class DialogClickHandler @Inject constructor(
+    private val interactor: LiveWorkoutInteractor,
+    private val resourceWrapper: ResourceWrapper,
+    private val pickerHandler: ExercisePickerHandler,
+    private val setMutator: LiveSetMutator,
+    store: LiveWorkoutHandlerStore,
+) : Handler<Action.DialogClick>, LiveWorkoutHandlerStore by store {
+
+    override fun invoke(action: Action.DialogClick) {
+        when (action) {
+            Action.DialogClick.OnDeleteSessionConfirm -> processDeleteSessionConfirm()
+            Action.DialogClick.OnCancelSessionConfirm -> processCancelConfirm()
+            Action.DialogClick.OnFinishConfirm -> processFinishConfirm()
+            is Action.DialogClick.OnFinishNameChange -> processFinishNameChange(action)
+            is Action.DialogClick.OnResetSetsConfirm -> processResetSetsConfirm(action)
+            is Action.DialogClick.OnSkipExerciseConfirm -> processSkipExerciseConfirm(action)
+            is Action.DialogClick.PickerAction -> pickerHandler.invoke(action.action)
+            Action.DialogClick.OnEmptyFinishDiscard -> processEmptyFinishDiscard()
+            Action.DialogClick.OnEmptyFinishContinue -> processEmptyFinishContinue()
+            Action.DialogClick.OnDeleteSessionDismiss,
+            Action.DialogClick.OnCancelSessionDismiss,
+            Action.DialogClick.OnResetSetsDismiss,
+            Action.DialogClick.OnFinishDismiss,
+            Action.DialogClick.OnSkipExerciseDismiss,
+            -> processCloseDialog()
+        }
+    }
+
+    private fun processEmptyFinishContinue() {
+        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+        updateState { it.copy(dialogState = DialogState.Hidden) }
+    }
+
+    private fun processEmptyFinishDiscard() {
+        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
+        val current = state.value
+        val sessionUuid = current.sessionUuid
+        val trainingUuid = current.trainingUuid
+        // Defence: discard cascade only fires for ad-hoc trainings. Library sessions can't
+        // reach this path (canDiscard = false in the dialog), but we double-check before
+        // calling the cascade DAO write.
+        if (!current.isAdhoc || sessionUuid.isNullOrBlank() || trainingUuid.isNullOrBlank()) {
+            updateState { it.copy(dialogState = DialogState.Hidden) }
+            return
+        }
+        updateState {
+            it.copy(
+                dialogState = DialogState.Hidden,
+                isFinishInFlight = true,
+            )
+        }
+        launch(
+            onSuccess = { consumeOnMain(Action.Navigation.Back) },
+            onError = { _ ->
+                updateState { it.copy(isFinishInFlight = false) }
+                sendError(ErrorType.DiscardSessionFailed)
+            },
+        ) {
+            interactor.discardAdhocSession(
+                sessionUuid = sessionUuid,
+                trainingUuid = trainingUuid,
+            )
+        }
+    }
+
+    private fun processSkipExerciseConfirm(action: Action.DialogClick.OnSkipExerciseConfirm) {
+        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
+        updateState { latest -> setMutator.applySkip(latest, action.performedExerciseUuid) }
+        launch(
+            onError = { _ -> sendError(ErrorType.SkipFailed) },
+        ) {
+            interactor.setSkipped(action.performedExerciseUuid, skipped = true)
+        }
+    }
+
+    private fun processResetSetsConfirm(action: Action.DialogClick.OnResetSetsConfirm) {
+        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
+        updateState { latest -> setMutator.applyResetSets(latest, action.performedExerciseUuid) }
+        launch(
+            onError = { _ -> sendError(ErrorType.ResetFailed) },
+        ) {
+            interactor.resetExerciseSets(action.performedExerciseUuid)
+        }
+    }
+
+    private fun processFinishConfirm() {
+        sendEvent(Event.HapticImpact(HapticFeedbackType.Confirm))
+        val current = state.value
+        val sessionUuid = current.sessionUuid ?: return
+        val stats = current.dialogState as? DialogState.FinishSession
+        val requiredName = stats?.nameDraft
+            ?.trim()
+            ?.takeIf { stats.requiresName }
+        if (stats?.requiresName == true && requiredName.isNullOrBlank()) {
+            val requiredError = resourceWrapper.getString(
+                R.string.feature_live_workout_finish_name_required,
+            )
+            updateState { latest ->
+                latest.copy(
+                    dialogState = stats.copy(
+                        nameError = requiredError,
+                        confirmEnabled = false,
+                    ),
+                )
+            }
+            return
+        }
+        val trainingUuid = current.trainingUuid
+        if (stats?.requiresName == true && trainingUuid.isNullOrBlank()) {
+            sendError(ErrorType.FinishFailed)
+            return
+        }
+        launch(
+            onSuccess = { result ->
+                if (result == null) {
+                    sendError(ErrorType.FinishMissingSession)
+                    updateState { it.copy(isFinishInFlight = false) }
+                    return@launch
+                }
+                sendEvent(
+                    Event.ShowSessionSavedSnackbar(
+                        message = resourceWrapper.getString(R.string.feature_live_workout_finish_success),
+                    ),
+                )
+                consumeOnMain(Action.Navigation.OpenPastSession(sessionUuid = sessionUuid))
+            },
+            onError = { _ ->
+                updateState { it.copy(isFinishInFlight = false) }
+                sendError(ErrorType.FinishFailed)
+            },
+        ) {
+            // Rename + finish are paired inside finishSessionAtomic so a crash between
+            // the two writes can no longer leave a named-but-IN_PROGRESS session.
+            interactor.finishSession(
+                sessionUuid = sessionUuid,
+                newTrainingName = requiredName,
+            )
+        }
+    }
+
+    private fun processFinishNameChange(action: Action.DialogClick.OnFinishNameChange) {
+        val trimmed = action.text.trim()
+        val requiredError = resourceWrapper
+            .getString(R.string.feature_live_workout_finish_name_required)
+            .takeIf { trimmed.isBlank() }
+        updateState { latest ->
+            val current = latest.dialogState as? DialogState.FinishSession
+                ?: return@updateState latest
+            latest.copy(
+                dialogState = current.copy(
+                    nameDraft = action.text,
+                    nameError = requiredError,
+                    confirmEnabled = trimmed.isNotBlank(),
+                ),
+            )
+        }
+    }
+
+    private fun processCancelConfirm() {
+        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
+        val sessionUuid = state.value.sessionUuid ?: run {
+            consume(Action.Navigation.Back)
+            return
+        }
+        launch(
+            onSuccess = { consumeOnMain(Action.Navigation.Back) },
+            onError = { _ -> sendError(ErrorType.CancelFailed) },
+        ) {
+            interactor.cancelSession(sessionUuid)
+        }
+    }
+
+    private fun processDeleteSessionConfirm() {
+        val sessionUuid = state.value.sessionUuid ?: run {
+            updateState { it.copy(dialogState = DialogState.Hidden) }
+            return
+        }
+        sendEvent(Event.HapticImpact(HapticFeedbackType.LongPress))
+        updateState { it.copy(dialogState = DialogState.Hidden) }
+        launch(
+            onSuccess = { consumeOnMain(Action.Navigation.Back) },
+            onError = { _ -> sendError(ErrorType.CancelFailed) },
+        ) {
+            interactor.cancelSession(sessionUuid)
+        }
+    }
+
+    private fun processCloseDialog() {
+        updateState { it.copy(dialogState = DialogState.Hidden) }
+    }
+
+    private fun sendError(type: ErrorType) {
+        sendEvent(
+            Event.ShowError(
+                message = resourceWrapper.getString(type.msgRes),
+            ),
+        )
+    }
+}

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandler.kt
@@ -19,9 +19,9 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.StateStatusMap
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ErrorType
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State.ExercisePickerSheetState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
@@ -75,11 +75,12 @@ internal class ExercisePickerHandler @Inject constructor(
         // sheet animation snappy.
         updateState { current ->
             current.copy(
-                exercisePickerSheet = ExercisePickerSheetState.Visible(
+                bottomSheetState = BottomSheetState.ExercisePicker(
                     query = "",
                     results = persistentListOf(),
                     noMatchHeadline = null,
                     createCtaLabel = null,
+
                 ),
             )
         }
@@ -88,13 +89,14 @@ internal class ExercisePickerHandler @Inject constructor(
 
     private fun processQueryChange(query: String) {
         val current = state.value
-        val visible = current.exercisePickerSheet as? ExercisePickerSheetState.Visible
+        val visible = current.bottomSheetState as? BottomSheetState.ExercisePicker
             ?: return
+
         // Optimistic UI: surface the new query immediately so the keyboard input feels
         // immediate. Results are recomputed off-Main and merged when ready.
         updateState { latest ->
             latest.copy(
-                exercisePickerSheet = visible.copy(query = query),
+                bottomSheetState = visible.copy(query = query),
             )
         }
         loadResults(
@@ -107,7 +109,7 @@ internal class ExercisePickerHandler @Inject constructor(
     private fun processExerciseSelect(exerciseUuid: String) {
         val current = state.value
         if (!current.canAddExercise) return
-        val visible = current.exercisePickerSheet as? ExercisePickerSheetState.Visible
+        val visible = current.bottomSheetState as? BottomSheetState.ExercisePicker
             ?: return
         val picked = visible.results.firstOrNull { it.uuid == exerciseUuid } ?: return
         sendEvent(Event.HapticImpact(HapticFeedbackType.Confirm))
@@ -155,7 +157,7 @@ internal class ExercisePickerHandler @Inject constructor(
 
     private fun processDismiss() {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        updateState { it.copy(exercisePickerSheet = ExercisePickerSheetState.Hidden) }
+        updateState { it.copy(bottomSheetState = BottomSheetState.Hidden) }
     }
 
     private fun addExerciseFlow(
@@ -173,7 +175,7 @@ internal class ExercisePickerHandler @Inject constructor(
                 updateState {
                     it.copy(
                         isAddExerciseInFlight = false,
-                        exercisePickerSheet = ExercisePickerSheetState.Hidden,
+                        bottomSheetState = BottomSheetState.Hidden,
                     )
                 }
                 sendError(ErrorType.AddExerciseFailed)
@@ -222,7 +224,7 @@ internal class ExercisePickerHandler @Inject constructor(
                     activeExerciseUuids = activeNext,
                     expandedExerciseUuids = expandedNext,
                     isAddExerciseInFlight = false,
-                    exercisePickerSheet = ExercisePickerSheetState.Hidden,
+                    bottomSheetState = BottomSheetState.Hidden,
                     preSessionPrSnapshot = latest.preSessionPrSnapshot.mergePr(
                         exerciseUuid = picked.exerciseUuid,
                         type = picked.type,
@@ -272,13 +274,13 @@ internal class ExercisePickerHandler @Inject constructor(
                 excludedNames = excludedNames,
             )
             updateState { latest ->
-                val visible = latest.exercisePickerSheet as? ExercisePickerSheetState.Visible
+                val visible = latest.bottomSheetState as? BottomSheetState.ExercisePicker
                     ?: return@updateState latest
                 // Discard stale results when the user has typed a different query in the
                 // meantime — the latest in-flight load wins.
                 if (visible.query != query) return@updateState latest
                 latest.copy(
-                    exercisePickerSheet = visible.copy(
+                    bottomSheetState = visible.copy(
                         results = pickerEntries,
                         noMatchHeadline = noMatchHeadline,
                         createCtaLabel = createCta,

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveSetMutator.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveSetMutator.kt
@@ -12,6 +12,7 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMap
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -152,7 +153,7 @@ internal class LiveSetMutator @Inject constructor(
             state.copy(
                 exercises = updated,
                 setDrafts = nextDrafts,
-                pendingResetExerciseUuid = null,
+                dialogState = DialogState.Hidden,
             ),
         )
     }
@@ -193,7 +194,7 @@ internal class LiveSetMutator @Inject constructor(
             state.copy(
                 exercises = updated,
                 setDrafts = nextDrafts,
-                pendingSkipExerciseUuid = null,
+                dialogState = DialogState.Hidden,
             ),
             performedExerciseUuid,
         )

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveWorkoutMapper.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveWorkoutMapper.kt
@@ -21,8 +21,11 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveSetRowsRes
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
@@ -60,17 +63,11 @@ internal object LiveWorkoutMapper {
             activeExerciseUuids = persistentSetOf(),
             expandedExerciseUuids = persistentSetOf(),
             preSessionPrSnapshot = prSnapshot,
-            pendingFinishConfirm = null,
-            pendingResetExerciseUuid = null,
-            pendingSkipExerciseUuid = null,
-            pendingCancelConfirm = false,
-            deleteDialogVisible = false,
-            exercisePickerSheet = State.ExercisePickerSheetState.Hidden,
-            emptyFinishDialog = State.EmptyFinishDialogState.Hidden,
             isAddExerciseInFlight = false,
             isFinishInFlight = false,
             isLoading = false,
-            errorMessage = null,
+            dialogState = DialogState.Hidden,
+            bottomSheetState = BottomSheetState.Hidden,
         ).withPresentation(resourceWrapper)
     }
 
@@ -147,7 +144,7 @@ internal object LiveWorkoutMapper {
 
     private fun Map<String, PersonalRecordDomain?>.toUiSnapshot(
         typeByUuid: Map<String, ExerciseTypeDomain>,
-    ): kotlinx.collections.immutable.ImmutableMap<String, State.PrSnapshotItem> = entries
+    ): ImmutableMap<String, State.PrSnapshotItem> = entries
         .mapNotNull { (uuid, pr) ->
             pr?.let {
                 uuid to State.PrSnapshotItem(
@@ -209,9 +206,9 @@ internal object LiveWorkoutMapper {
         )
     }
 
-    fun State.toFinishStats(resourceWrapper: ResourceWrapper): State.FinishStats {
+    fun State.toFinishStats(resourceWrapper: ResourceWrapper): DialogState.FinishSession {
         val skippedCount = exercises.count { it.status == ExerciseStatusUiModel.SKIPPED }
-        return State.FinishStats(
+        return DialogState.FinishSession(
             durationMillis = elapsedMillis,
             durationLabel = elapsedDurationLabel,
             exercisesSummaryLabel = formatExerciseSummary(
@@ -236,7 +233,7 @@ internal object LiveWorkoutMapper {
 
     private fun State.computeNewPersonalRecords(
         resourceWrapper: ResourceWrapper,
-    ): ImmutableList<State.FinishStats.NewPrEntry> = exercises
+    ): ImmutableList<DialogState.FinishSession.NewPrEntry> = exercises
         .asSequence()
         .filter { it.status != ExerciseStatusUiModel.SKIPPED }
         .mapNotNull { it.toNewPrEntry(preSessionPrSnapshot, resourceWrapper) }
@@ -246,7 +243,7 @@ internal object LiveWorkoutMapper {
     private fun LiveExerciseUiModel.toNewPrEntry(
         snapshot: Map<String, State.PrSnapshotItem>,
         resourceWrapper: ResourceWrapper,
-    ): State.FinishStats.NewPrEntry? {
+    ): DialogState.FinishSession.NewPrEntry? {
         val performedAsPlanSets = performedSets
             .filter { it.isDone }
             .map { it.toPlanSetDomain() }
@@ -261,7 +258,7 @@ internal object LiveWorkoutMapper {
             hasBaseline = baseline != null,
         )
         if (!beatsBaseline) return null
-        return State.FinishStats.NewPrEntry(
+        return DialogState.FinishSession.NewPrEntry(
             exerciseUuid = exerciseUuid,
             exerciseName = exerciseName,
             displayLabel = formatPrLabel(

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/BottomSheetState.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/BottomSheetState.kt
@@ -1,0 +1,25 @@
+package io.github.stslex.workeeper.feature.live_workout.mvi.store
+
+import androidx.compose.runtime.Stable
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExercisePickerUiModel
+import kotlinx.collections.immutable.ImmutableList
+
+@Stable
+sealed interface BottomSheetState {
+
+    @Stable
+    data object Hidden : BottomSheetState
+
+    /**
+     * Inline exercise picker bottom-sheet state. Display strings (no-match headline,
+     * Create CTA label) are pre-formatted in the handler so the kit composable does
+     * not derive text — keeps the picker locale-shape agnostic.
+     */
+    @Stable
+    data class ExercisePicker(
+        val query: String,
+        val results: ImmutableList<ExercisePickerUiModel>,
+        val noMatchHeadline: String?,
+        val createCtaLabel: String?,
+    ) : BottomSheetState
+}

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/DialogState.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/DialogState.kt
@@ -1,0 +1,88 @@
+package io.github.stslex.workeeper.feature.live_workout.mvi.store
+
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+
+@Stable
+internal sealed interface DialogState {
+
+    @Stable
+    data object Hidden : DialogState
+
+    @Stable
+    data class DeleteDialog(
+        val sessionName: String,
+        val progressLabel: String,
+    ) : DialogState
+
+    /**
+     * Empty-finish confirm dialog (E1 lock). Triggered when the user taps Finish on a
+     * session with no performed sets. Discard CTA is enabled only for ad-hoc trainings;
+     * library training sessions get a Continue-editing-only variant — we do not delete
+     * library trainings via session cancellation.
+     */
+    @Stable
+    data class EmptyFinish(
+        val canDiscard: Boolean,
+        val confirmLabel: String,
+        val dismissLabel: String,
+    ) : DialogState
+
+    @Stable
+    sealed interface ConfirmDialog : DialogState {
+
+        val title: String
+        val body: String
+        val confirmLabel: String
+        val dismissLabel: String
+
+        @Stable
+        data class ResetSets(
+            override val title: String,
+            override val body: String,
+            override val confirmLabel: String,
+            override val dismissLabel: String,
+            val exerciseUuid: String,
+        ) : ConfirmDialog
+
+        @Stable
+        data class SkipExercise(
+            override val title: String,
+            override val body: String,
+            override val confirmLabel: String,
+            override val dismissLabel: String,
+            val exerciseUuid: String,
+        ) : ConfirmDialog
+
+        @Stable
+        data class CancelSession(
+            override val title: String,
+            override val body: String,
+            override val confirmLabel: String,
+            override val dismissLabel: String,
+        ) : ConfirmDialog
+    }
+
+    @Stable
+    data class FinishSession(
+        val durationMillis: Long,
+        val durationLabel: String,
+        val exercisesSummaryLabel: String,
+        val setsLoggedLabel: String,
+        val newPersonalRecords: ImmutableList<NewPrEntry>,
+        val requiresName: Boolean = false,
+        val nameDraft: String = "",
+        val nameLabel: String = "",
+        val namePlaceholder: String = "",
+        val nameError: String? = null,
+        val confirmEnabled: Boolean = true,
+    ) : DialogState {
+
+        @Stable
+        data class NewPrEntry(
+            val exerciseUuid: String,
+            val exerciseName: String,
+            val displayLabel: String,
+        )
+    }
+}

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStore.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStore.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.mvi.Store
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExercisePickerAction
-import io.github.stslex.workeeper.core.ui.plan_editor.model.ExercisePickerUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
@@ -54,17 +53,11 @@ internal interface LiveWorkoutStore :
          */
         val expandedExerciseUuids: ImmutableSet<String>,
         val preSessionPrSnapshot: ImmutableMap<String, PrSnapshotItem>,
-        val pendingFinishConfirm: FinishStats?,
-        val pendingResetExerciseUuid: String?,
-        val pendingSkipExerciseUuid: String?,
-        val pendingCancelConfirm: Boolean,
-        val deleteDialogVisible: Boolean,
-        val exercisePickerSheet: ExercisePickerSheetState,
-        val emptyFinishDialog: EmptyFinishDialogState,
         val isAddExerciseInFlight: Boolean,
         val isFinishInFlight: Boolean,
         val isLoading: Boolean,
-        val errorMessage: String?,
+        val dialogState: DialogState,
+        val bottomSheetState: BottomSheetState,
     ) : Store.State {
 
         @Stable
@@ -83,72 +76,7 @@ internal interface LiveWorkoutStore :
             val type: ExerciseTypeUiModel,
         )
 
-        @Stable
-        data class FinishStats(
-            val durationMillis: Long,
-            val durationLabel: String,
-            val exercisesSummaryLabel: String,
-            val setsLoggedLabel: String,
-            val newPersonalRecords: ImmutableList<NewPrEntry>,
-            val requiresName: Boolean = false,
-            val nameDraft: String = "",
-            val nameLabel: String = "",
-            val namePlaceholder: String = "",
-            val nameError: String? = null,
-            val confirmEnabled: Boolean = true,
-        ) {
-
-            @Stable
-            data class NewPrEntry(
-                val exerciseUuid: String,
-                val exerciseName: String,
-                val displayLabel: String,
-            )
-        }
-
-        /**
-         * Inline exercise picker bottom-sheet state. Display strings (no-match headline,
-         * Create CTA label) are pre-formatted in the handler so the kit composable does
-         * not derive text — keeps the picker locale-shape agnostic.
-         */
-        @Stable
-        sealed interface ExercisePickerSheetState {
-            data object Hidden : ExercisePickerSheetState
-
-            @Stable
-            data class Visible(
-                val query: String,
-                val results: ImmutableList<ExercisePickerUiModel>,
-                val noMatchHeadline: String?,
-                val createCtaLabel: String?,
-            ) : ExercisePickerSheetState
-        }
-
-        /**
-         * Empty-finish confirm dialog (E1 lock). Triggered when the user taps Finish on a
-         * session with no performed sets. Discard CTA is enabled only for ad-hoc trainings;
-         * library training sessions get a Continue-editing-only variant — we do not delete
-         * library trainings via session cancellation.
-         */
-        @Stable
-        sealed interface EmptyFinishDialogState {
-            data object Hidden : EmptyFinishDialogState
-
-            @Stable
-            data class Visible(
-                val canDiscard: Boolean,
-                val confirmLabel: String,
-                val dismissLabel: String,
-            ) : EmptyFinishDialogState
-        }
-
         val elapsedMillis: Long get() = (nowMillis - startedAt).coerceAtLeast(0L)
-
-        val isPickerVisible: Boolean
-            get() = exercisePickerSheet is ExercisePickerSheetState.Visible
-
-        val isEmptyFinishDialogVisible: Boolean
-            get() = emptyFinishDialog is EmptyFinishDialogState.Visible
 
         /**
          * "Empty session" predicate driving the E1 confirm dialog: no exercises at all,
@@ -175,8 +103,8 @@ internal interface LiveWorkoutStore :
          */
         val interceptBack: Boolean
             get() = isTrainingNameEditing ||
-                isPickerVisible ||
-                isEmptyFinishDialogVisible
+                bottomSheetState is BottomSheetState.ExercisePicker ||
+                dialogState is DialogState.EmptyFinish
 
         companion object {
 
@@ -201,17 +129,11 @@ internal interface LiveWorkoutStore :
                 activeExerciseUuids = persistentSetOf(),
                 expandedExerciseUuids = persistentSetOf(),
                 preSessionPrSnapshot = persistentMapOf(),
-                pendingFinishConfirm = null,
-                pendingResetExerciseUuid = null,
-                pendingSkipExerciseUuid = null,
-                pendingCancelConfirm = false,
-                deleteDialogVisible = false,
-                exercisePickerSheet = ExercisePickerSheetState.Hidden,
-                emptyFinishDialog = EmptyFinishDialogState.Hidden,
                 isAddExerciseInFlight = false,
                 isFinishInFlight = false,
                 isLoading = true,
-                errorMessage = null,
+                dialogState = DialogState.Hidden,
+                bottomSheetState = BottomSheetState.Hidden,
             )
         }
     }
@@ -233,21 +155,10 @@ internal interface LiveWorkoutStore :
             data class OnAddSet(val performedExerciseUuid: String) : Click
             data class OnEditPlan(val performedExerciseUuid: String) : Click
             data class OnResetSets(val performedExerciseUuid: String) : Click
-            data class OnResetSetsConfirm(val performedExerciseUuid: String) : Click
-            data object OnResetSetsDismiss : Click
             data class OnSkipExercise(val performedExerciseUuid: String) : Click
-            data class OnSkipExerciseConfirm(val performedExerciseUuid: String) : Click
-            data object OnSkipExerciseDismiss : Click
             data object OnFinishClick : Click
-            data object OnFinishConfirm : Click
-            data class OnFinishNameChange(val text: String) : Click
-            data object OnFinishDismiss : Click
             data object OnCancelSessionClick : Click
-            data object OnCancelSessionConfirm : Click
-            data object OnCancelSessionDismiss : Click
             data object OnDeleteSessionMenuClick : Click
-            data object OnDeleteSessionConfirm : Click
-            data object OnDeleteSessionDismiss : Click
             data class OnExerciseHeaderClick(val performedExerciseUuid: String) : Click
             data object OnBackClick : Click
 
@@ -259,19 +170,32 @@ internal interface LiveWorkoutStore :
 
             // v2.3 — mid-session add exercise (opens the picker sheet).
             data object OnAddExerciseClick : Click
+        }
+
+        sealed interface DialogClick : Action {
+
+            data object OnDeleteSessionConfirm : DialogClick
+            data object OnDeleteSessionDismiss : DialogClick
+            data object OnEmptyFinishDiscard : DialogClick
+            data object OnEmptyFinishContinue : DialogClick
+            data object OnCancelSessionConfirm : DialogClick
+            data class OnResetSetsConfirm(val performedExerciseUuid: String) : DialogClick
+            data object OnResetSetsDismiss : DialogClick
+            data class OnSkipExerciseConfirm(val performedExerciseUuid: String) : DialogClick
+            data object OnCancelSessionDismiss : DialogClick
+            data object OnSkipExerciseDismiss : DialogClick
+            data object OnFinishConfirm : DialogClick
+            data object OnFinishDismiss : DialogClick
+            data class OnFinishNameChange(val text: String) : DialogClick
 
             /**
              * Wraps the picker bottom-sheet action surface so the feature's top-level
-             * Click variants stay flat. `ClickHandler` delegates to the dedicated
+             * DialogClick variants stay flat. `ClickHandler` delegates to the dedicated
              * `ExercisePickerHandler` when this variant fires (per the action-wrapper
              * pattern from architecture docs).
              */
             @Suppress("MviActionNamingRule")
-            data class PickerAction(val action: ExercisePickerAction) : Click
-
-            // v2.3 — empty-finish confirm dialog (E1: Discard or Continue editing).
-            data object OnEmptyFinishDiscard : Click
-            data object OnEmptyFinishContinue : Click
+            data class PickerAction(val action: ExercisePickerAction) : DialogClick
         }
 
         sealed interface Input : Action {
@@ -323,10 +247,6 @@ internal interface LiveWorkoutStore :
         data class HapticImpact(val type: HapticFeedbackType) : Event
         data class ShowSessionSavedSnackbar(val message: String) : Event
         data class ShowError(val message: String) : Event
-        data object ShowFinishConfirmDialog : Event
-        data class ShowResetSetsConfirmDialog(val dialog: ConfirmDialog) : Event
-        data class ShowSkipExerciseConfirmDialog(val dialog: ConfirmDialog) : Event
-        data class ShowCancelSessionConfirmDialog(val dialog: ConfirmDialog) : Event
     }
 
     @Stable

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStoreImpl.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/store/LiveWorkoutStoreImpl.kt
@@ -14,6 +14,7 @@ import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
 import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutHandlerStoreImpl
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.ClickHandler
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.CommonHandler
+import io.github.stslex.workeeper.feature.live_workout.mvi.handler.DialogClickHandler
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.InputHandler
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.LiveWorkoutComponent
 import io.github.stslex.workeeper.feature.live_workout.mvi.handler.NavigationHandler
@@ -27,6 +28,7 @@ internal class LiveWorkoutStoreImpl @AssistedInject constructor(
     clickHandler: ClickHandler,
     inputHandler: InputHandler,
     commonHandler: CommonHandler,
+    dialogClickHandler: DialogClickHandler,
     storeDispatchers: StoreDispatchers,
     handlerStore: LiveWorkoutHandlerStoreImpl,
     analyticsHolder: AnalyticsHolder,
@@ -43,6 +45,7 @@ internal class LiveWorkoutStoreImpl @AssistedInject constructor(
             is Action.Common -> commonHandler
             is Action.Click -> clickHandler
             is Action.Input -> inputHandler
+            is Action.DialogClick -> dialogClickHandler
         }
     },
     storeEmitter = handlerStore,

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/LiveWorkoutGraph.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/LiveWorkoutGraph.kt
@@ -3,27 +3,15 @@ package io.github.stslex.workeeper.feature.live_workout.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.core.logger.Log
-import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
 import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
 import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
-import io.github.stslex.workeeper.core.ui.plan_editor.ExercisePickerBottomSheet
-import io.github.stslex.workeeper.feature.live_workout.R
 import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutFeature
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State.EmptyFinishDialogState
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State.ExercisePickerSheetState
-import io.github.stslex.workeeper.feature.live_workout.ui.components.FinishConfirmDialog
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "UnusedParameter")
 fun NavGraphBuilder.liveWorkoutGraph(
@@ -32,10 +20,6 @@ fun NavGraphBuilder.liveWorkoutGraph(
 ) {
     navComponentScreen(LiveWorkoutFeature) { processor ->
         val haptic = LocalHapticFeedback.current
-        var resetDialog by remember { mutableStateOf<LiveWorkoutStore.ConfirmDialog?>(null) }
-        var skipDialog by remember { mutableStateOf<LiveWorkoutStore.ConfirmDialog?>(null) }
-        var cancelDialog by remember { mutableStateOf<LiveWorkoutStore.ConfirmDialog?>(null) }
-        var showFinishDialog by remember { mutableStateOf(false) }
 
         processor.Handle { event ->
             Log.tag("MVI_STORE_LiveWorkout").i { "Received event: $event" }
@@ -44,22 +28,6 @@ fun NavGraphBuilder.liveWorkoutGraph(
                 is Event.HapticImpact -> haptic.performHapticFeedback(event.type)
                 is Event.ShowSessionSavedSnackbar -> SnackbarManager.showSnackbar(message = event.message)
                 is Event.ShowError -> SnackbarManager.showSnackbar(message = event.message)
-
-                Event.ShowFinishConfirmDialog -> {
-                    showFinishDialog = true
-                }
-
-                is Event.ShowResetSetsConfirmDialog -> {
-                    resetDialog = event.dialog
-                }
-
-                is Event.ShowSkipExerciseConfirmDialog -> {
-                    skipDialog = event.dialog
-                }
-
-                is Event.ShowCancelSessionConfirmDialog -> {
-                    cancelDialog = event.dialog
-                }
             }
         }
 
@@ -67,124 +35,10 @@ fun NavGraphBuilder.liveWorkoutGraph(
             processor.consume(Action.Click.OnBackClick)
         }
 
-        val state = processor.state.value
         LiveWorkoutScreen(
             modifier = modifier,
-            state = state,
+            state = processor.state.value,
             consume = processor::consume,
         )
-
-        (state.exercisePickerSheet as? ExercisePickerSheetState.Visible)?.let { sheet ->
-            ExercisePickerBottomSheet(
-                query = sheet.query,
-                results = sheet.results,
-                noMatchHeadline = sheet.noMatchHeadline,
-                createCtaLabel = sheet.createCtaLabel,
-                searchHint = stringResource(R.string.feature_live_workout_picker_search_hint),
-                isPrimaryActionEnabled = state.canAddExercise,
-                onAction = { action -> processor.consume(Action.Click.PickerAction(action)) },
-            )
-        }
-
-        (state.emptyFinishDialog as? EmptyFinishDialogState.Visible)?.let { dialog ->
-            AppDialog(
-                title = stringResource(R.string.feature_live_workout_empty_finish_title),
-                body = stringResource(R.string.feature_live_workout_empty_finish_body),
-                confirmLabel = dialog.confirmLabel,
-                dismissLabel = dialog.dismissLabel,
-                destructive = true,
-                onConfirm = {
-                    if (dialog.canDiscard) {
-                        processor.consume(Action.Click.OnEmptyFinishDiscard)
-                    } else {
-                        processor.consume(Action.Click.OnCancelSessionConfirm)
-                    }
-                },
-                onDismiss = { processor.consume(Action.Click.OnEmptyFinishContinue) },
-            )
-        }
-
-        if (showFinishDialog) {
-            state.pendingFinishConfirm?.let { stats ->
-                FinishConfirmDialog(
-                    stats = stats,
-                    onNameChange = { processor.consume(Action.Click.OnFinishNameChange(it)) },
-                    onConfirm = {
-                        showFinishDialog = false
-                        processor.consume(Action.Click.OnFinishConfirm)
-                    },
-                    onDismiss = {
-                        showFinishDialog = false
-                        processor.consume(Action.Click.OnFinishDismiss)
-                    },
-                )
-            } ?: run {
-                showFinishDialog = false
-            }
-        }
-
-        resetDialog?.let { dialog ->
-            val target = state.pendingResetExerciseUuid
-            if (target != null) {
-                AppDialog(
-                    title = dialog.title,
-                    body = dialog.body,
-                    confirmLabel = dialog.confirmLabel,
-                    dismissLabel = dialog.dismissLabel,
-                    destructive = true,
-                    onConfirm = {
-                        resetDialog = null
-                        processor.consume(Action.Click.OnResetSetsConfirm(target))
-                    },
-                    onDismiss = {
-                        resetDialog = null
-                        processor.consume(Action.Click.OnResetSetsDismiss)
-                    },
-                )
-            } else {
-                resetDialog = null
-            }
-        }
-
-        skipDialog?.let { dialog ->
-            val target = state.pendingSkipExerciseUuid
-            if (target != null) {
-                AppDialog(
-                    title = dialog.title,
-                    body = dialog.body,
-                    confirmLabel = dialog.confirmLabel,
-                    dismissLabel = dialog.dismissLabel,
-                    destructive = true,
-                    onConfirm = {
-                        skipDialog = null
-                        processor.consume(Action.Click.OnSkipExerciseConfirm(target))
-                    },
-                    onDismiss = {
-                        skipDialog = null
-                        processor.consume(Action.Click.OnSkipExerciseDismiss)
-                    },
-                )
-            } else {
-                skipDialog = null
-            }
-        }
-
-        cancelDialog?.let { dialog ->
-            AppDialog(
-                title = dialog.title,
-                body = dialog.body,
-                confirmLabel = dialog.confirmLabel,
-                dismissLabel = dialog.dismissLabel,
-                destructive = true,
-                onConfirm = {
-                    cancelDialog = null
-                    processor.consume(Action.Click.OnCancelSessionConfirm)
-                },
-                onDismiss = {
-                    cancelDialog = null
-                    processor.consume(Action.Click.OnCancelSessionDismiss)
-                },
-            )
-        }
     }
 }

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/LiveWorkoutScreen.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/LiveWorkoutScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.DiscardSessionConfirmDialog
 import io.github.stslex.workeeper.core.ui.kit.components.empty.AppEmptyState
 import io.github.stslex.workeeper.core.ui.kit.components.topbar.AppTopAppBar
@@ -41,6 +42,7 @@ import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.core.ui.plan_editor.ExercisePickerBottomSheet
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
@@ -48,8 +50,11 @@ import io.github.stslex.workeeper.feature.live_workout.R
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
+import io.github.stslex.workeeper.feature.live_workout.ui.components.FinishConfirmDialog
 import io.github.stslex.workeeper.feature.live_workout.ui.components.LiveExerciseCard
 import io.github.stslex.workeeper.feature.live_workout.ui.components.LiveWorkoutHeader
 import kotlinx.collections.immutable.persistentListOf
@@ -75,21 +80,88 @@ internal fun LiveWorkoutScreen(
             consume = consume,
         )
     }
-    if (state.deleteDialogVisible) {
-        val sessionName = state.trainingNameLabel.takeIf { it.isNotBlank() }
-            ?: stringResource(R.string.feature_live_workout_delete_session_unnamed)
-        val progressLabel = stringResource(
-            R.string.feature_live_workout_delete_session_progress_format,
-            state.doneCount,
-            state.totalCount,
-            state.setsLogged,
+
+    when (val sheetState = state.bottomSheetState) {
+        is BottomSheetState.ExercisePicker -> ExercisePickerBottomSheet(
+            query = sheetState.query,
+            results = sheetState.results,
+            noMatchHeadline = sheetState.noMatchHeadline,
+            createCtaLabel = sheetState.createCtaLabel,
+            searchHint = stringResource(R.string.feature_live_workout_picker_search_hint),
+            isPrimaryActionEnabled = state.canAddExercise,
+            onAction = { action -> consume(Action.DialogClick.PickerAction(action)) },
         )
-        DiscardSessionConfirmDialog(
-            sessionName = sessionName,
-            progressLabel = progressLabel,
-            onConfirmDelete = { consume(Action.Click.OnDeleteSessionConfirm) },
-            onDismiss = { consume(Action.Click.OnDeleteSessionDismiss) },
+
+        BottomSheetState.Hidden -> Unit
+    }
+
+    when (val dialog = state.dialogState) {
+        is DialogState.DeleteDialog -> DiscardSessionConfirmDialog(
+            sessionName = dialog.sessionName,
+            progressLabel = dialog.progressLabel,
+            onConfirmDelete = { consume(Action.DialogClick.OnDeleteSessionConfirm) },
+            onDismiss = { consume(Action.DialogClick.OnDeleteSessionDismiss) },
         )
+
+        is DialogState.EmptyFinish -> AppDialog(
+            title = stringResource(R.string.feature_live_workout_empty_finish_title),
+            body = stringResource(R.string.feature_live_workout_empty_finish_body),
+            confirmLabel = dialog.confirmLabel,
+            dismissLabel = dialog.dismissLabel,
+            destructive = true,
+            onConfirm = {
+                if (dialog.canDiscard) {
+                    consume(Action.DialogClick.OnEmptyFinishDiscard)
+                } else {
+                    consume(Action.DialogClick.OnCancelSessionConfirm)
+                }
+            },
+            onDismiss = { consume(Action.DialogClick.OnEmptyFinishContinue) },
+        )
+
+        is DialogState.ConfirmDialog -> {
+            AppDialog(
+                title = dialog.title,
+                body = dialog.body,
+                confirmLabel = dialog.confirmLabel,
+                dismissLabel = dialog.dismissLabel,
+                destructive = true,
+                onConfirm = {
+                    val action = when (dialog) {
+                        is DialogState.ConfirmDialog.CancelSession -> Action.DialogClick.OnCancelSessionConfirm
+                        is DialogState.ConfirmDialog.ResetSets -> Action.DialogClick.OnResetSetsConfirm(
+                            dialog.exerciseUuid,
+                        )
+
+                        is DialogState.ConfirmDialog.SkipExercise -> Action.DialogClick.OnSkipExerciseConfirm(
+                            dialog.exerciseUuid,
+                        )
+                    }
+                    consume(action)
+                },
+                onDismiss = {
+                    val action = when (dialog) {
+                        is DialogState.ConfirmDialog.CancelSession -> Action.DialogClick.OnCancelSessionDismiss
+                        is DialogState.ConfirmDialog.ResetSets -> Action.DialogClick.OnResetSetsDismiss
+                        is DialogState.ConfirmDialog.SkipExercise -> Action.DialogClick.OnSkipExerciseDismiss
+                    }
+                    consume(action)
+                },
+            )
+        }
+
+        is DialogState.FinishSession -> FinishConfirmDialog(
+            stats = dialog,
+            onNameChange = { consume(Action.DialogClick.OnFinishNameChange(it)) },
+            onConfirm = {
+                consume(Action.DialogClick.OnFinishConfirm)
+            },
+            onDismiss = {
+                consume(Action.DialogClick.OnFinishDismiss)
+            },
+        )
+
+        DialogState.Hidden -> Unit
     }
 }
 
@@ -398,15 +470,9 @@ private fun stubState(): State = State(
     activeExerciseUuids = kotlinx.collections.immutable.persistentSetOf(),
     expandedExerciseUuids = kotlinx.collections.immutable.persistentSetOf(),
     preSessionPrSnapshot = persistentMapOf(),
-    pendingFinishConfirm = null,
-    pendingResetExerciseUuid = null,
-    pendingSkipExerciseUuid = null,
-    pendingCancelConfirm = false,
-    deleteDialogVisible = false,
-    exercisePickerSheet = State.ExercisePickerSheetState.Hidden,
-    emptyFinishDialog = State.EmptyFinishDialogState.Hidden,
     isAddExerciseInFlight = false,
     isFinishInFlight = false,
     isLoading = false,
-    errorMessage = null,
+    dialogState = DialogState.Hidden,
+    bottomSheetState = BottomSheetState.Hidden,
 )

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/components/FinishConfirmDialog.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/ui/components/FinishConfirmDialog.kt
@@ -29,14 +29,14 @@ import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
 import io.github.stslex.workeeper.feature.live_workout.R
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 internal fun FinishConfirmDialog(
-    stats: LiveWorkoutStore.State.FinishStats,
+    stats: DialogState.FinishSession,
     onNameChange: (String) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
@@ -158,7 +158,7 @@ private fun StatRow(label: String, value: String) {
 
 @Composable
 private fun NewPersonalRecordsSection(
-    records: ImmutableList<LiveWorkoutStore.State.FinishStats.NewPrEntry>,
+    records: ImmutableList<DialogState.FinishSession.NewPrEntry>,
 ) {
     val palette = AppUi.colors.record
     val shape = RoundedCornerShape(AppDimension.Radius.medium)
@@ -205,7 +205,7 @@ private fun NewPersonalRecordsSection(
 private fun FinishConfirmDialogAllDoneLightPreview() {
     AppTheme(themeMode = ThemeMode.LIGHT) {
         FinishConfirmDialog(
-            stats = LiveWorkoutStore.State.FinishStats(
+            stats = DialogState.FinishSession(
                 durationMillis = 47 * 60_000L + 8_000L,
                 durationLabel = "47:08",
                 exercisesSummaryLabel = "5 of 5 done",
@@ -224,7 +224,7 @@ private fun FinishConfirmDialogAllDoneLightPreview() {
 private fun FinishConfirmDialogPartialDarkPreview() {
     AppTheme(themeMode = ThemeMode.DARK) {
         FinishConfirmDialog(
-            stats = LiveWorkoutStore.State.FinishStats(
+            stats = DialogState.FinishSession(
                 durationMillis = 32 * 60_000L,
                 durationLabel = "32:00",
                 exercisesSummaryLabel = "3 of 5 done · 1 skipped",
@@ -243,18 +243,18 @@ private fun FinishConfirmDialogPartialDarkPreview() {
 private fun FinishConfirmDialogWithRecordsPreview() {
     AppTheme(themeMode = ThemeMode.LIGHT) {
         FinishConfirmDialog(
-            stats = LiveWorkoutStore.State.FinishStats(
+            stats = DialogState.FinishSession(
                 durationMillis = 47 * 60_000L,
                 durationLabel = "47:00",
                 exercisesSummaryLabel = "5 of 5 done",
                 setsLoggedLabel = "22",
                 newPersonalRecords = listOf(
-                    LiveWorkoutStore.State.FinishStats.NewPrEntry(
+                    DialogState.FinishSession.NewPrEntry(
                         exerciseUuid = "ex-1",
                         exerciseName = "Bench press",
                         displayLabel = "105 × 5",
                     ),
-                    LiveWorkoutStore.State.FinishStats.NewPrEntry(
+                    DialogState.FinishSession.NewPrEntry(
                         exerciseUuid = "ex-2",
                         exerciseName = "Pull-ups",
                         displayLabel = "15 reps",

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandlerTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ClickHandlerTest.kt
@@ -5,7 +5,6 @@ import io.github.stslex.workeeper.core.core.logger.Logger
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
-import io.github.stslex.workeeper.feature.live_workout.R
 import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutHandlerStore
 import io.github.stslex.workeeper.feature.live_workout.domain.LiveWorkoutInteractor
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveSetMutator
@@ -13,6 +12,7 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.StateStatusMap
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
@@ -25,6 +25,7 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -42,7 +43,8 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnExerciseHeaderClick toggles expansion for DONE exercises`() {
-        val stateFlow = MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.DONE)))
+        val stateFlow =
+            MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.DONE)))
         val store = handlerStore(stateFlow)
         val handler = ClickHandler(
             interactor = interactor,
@@ -67,7 +69,8 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnExerciseHeaderClick is no-op for SKIPPED exercises`() {
-        val stateFlow = MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.SKIPPED)))
+        val stateFlow =
+            MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.SKIPPED)))
         val store = handlerStore(stateFlow)
         val handler = ClickHandler(
             interactor = interactor,
@@ -118,7 +121,8 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnExerciseHeaderClick on auto-default CURRENT promotes to active and toggles expanded`() {
-        val stateFlow = MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT)))
+        val stateFlow =
+            MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT)))
         val store = handlerStore(stateFlow)
         val handler = ClickHandler(
             interactor = interactor,
@@ -140,8 +144,9 @@ internal class ClickHandlerTest {
     }
 
     @Test
-    fun `OnDeleteSessionMenuClick flips deleteDialogVisible true`() {
-        val stateFlow = MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT)))
+    fun `OnDeleteSessionMenuClick shows DeleteDialog`() {
+        val stateFlow =
+            MutableStateFlow(baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT)))
         val store = handlerStore(stateFlow)
         val handler = ClickHandler(
             interactor = interactor,
@@ -153,74 +158,11 @@ internal class ClickHandlerTest {
 
         handler.invoke(Action.Click.OnDeleteSessionMenuClick)
 
-        assertEquals(true, stateFlow.value.deleteDialogVisible)
+        assertEquals(true, stateFlow.value.dialogState is DialogState.DeleteDialog)
     }
 
     @Test
-    fun `OnDeleteSessionDismiss flips deleteDialogVisible false`() {
-        val stateFlow = MutableStateFlow(
-            baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT))
-                .copy(deleteDialogVisible = true),
-        )
-        val store = handlerStore(stateFlow)
-        val handler = ClickHandler(
-            interactor = interactor,
-            resourceWrapper = resourceWrapper,
-            pickerHandler = pickerHandler,
-            setMutator = setMutator,
-            store = store,
-        )
-
-        handler.invoke(Action.Click.OnDeleteSessionDismiss)
-
-        assertEquals(false, stateFlow.value.deleteDialogVisible)
-    }
-
-    @Test
-    fun `OnDeleteSessionConfirm clears dialog without sessionUuid`() {
-        val stateFlow = MutableStateFlow(
-            baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT))
-                .copy(sessionUuid = null, deleteDialogVisible = true),
-        )
-        val store = handlerStore(stateFlow)
-        val handler = ClickHandler(
-            interactor = interactor,
-            resourceWrapper = resourceWrapper,
-            pickerHandler = pickerHandler,
-            setMutator = setMutator,
-            store = store,
-        )
-
-        handler.invoke(Action.Click.OnDeleteSessionConfirm)
-
-        assertEquals(false, stateFlow.value.deleteDialogVisible)
-    }
-
-    @Test
-    fun `OnDeleteSessionConfirm with sessionUuid hides dialog`() {
-        val stateFlow = MutableStateFlow(
-            baseState(doneExercise(status = ExerciseStatusUiModel.CURRENT))
-                .copy(deleteDialogVisible = true),
-        )
-        val store = handlerStore(stateFlow)
-        val handler = ClickHandler(
-            interactor = interactor,
-            resourceWrapper = resourceWrapper,
-            pickerHandler = pickerHandler,
-            setMutator = setMutator,
-            store = store,
-        )
-
-        handler.invoke(Action.Click.OnDeleteSessionConfirm)
-
-        assertEquals(false, stateFlow.value.deleteDialogVisible)
-    }
-
-    @Test
-    fun finishSession_blankName_blocksSubmit() {
-        every {
-            resourceWrapper.getString(R.string.feature_live_workout_finish_name_required)
-        } returns "Name is required"
+    fun `OnFinishClick on logged session shows FinishSession dialog with requiresName when name is blank`() {
         val stateFlow = MutableStateFlow(
             baseState(loggedExercise()).copy(
                 trainingName = "",
@@ -237,38 +179,20 @@ internal class ClickHandlerTest {
         )
 
         handler.invoke(Action.Click.OnFinishClick)
-        val pending = stateFlow.value.pendingFinishConfirm
+
+        val pending = stateFlow.value.dialogState as? DialogState.FinishSession
         assertTrue(pending?.requiresName == true)
         assertEquals(false, pending?.confirmEnabled)
-
-        handler.invoke(Action.Click.OnFinishConfirm)
-
-        assertEquals("Name is required", stateFlow.value.pendingFinishConfirm?.nameError)
-        coVerify(exactly = 0) { interactor.updateTrainingName(any(), any()) }
-        coVerify(exactly = 0) { interactor.finishSession(any(), any()) }
     }
 
     @Test
-    fun finishSession_withRequiredName_collapsesToSingleAtomicCall() = runTest {
-        val store = FakeLiveWorkoutHandlerStore(
-            baseState(loggedExercise()).copy(
-                trainingName = "",
-                trainingNameLabel = "Untitled",
-                pendingFinishConfirm = State.FinishStats(
-                    durationMillis = 60_000L,
-                    durationLabel = "1m",
-                    exercisesSummaryLabel = "1 / 1",
-                    setsLoggedLabel = "1",
-                    newPersonalRecords = kotlinx.collections.immutable.persistentListOf(),
-                    requiresName = true,
-                    nameDraft = "Push Day",
-                    nameLabel = "Training name",
-                    namePlaceholder = "Untitled",
-                    nameError = null,
-                    confirmEnabled = true,
-                ),
+    fun `OnFinishClick on empty session shows EmptyFinish dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState(doneExercise(status = ExerciseStatusUiModel.PENDING)).copy(
+                isAdhoc = true,
             ),
         )
+        val store = handlerStore(stateFlow)
         val handler = ClickHandler(
             interactor = interactor,
             resourceWrapper = resourceWrapper,
@@ -277,18 +201,11 @@ internal class ClickHandlerTest {
             store = store,
         )
 
-        handler.invoke(Action.Click.OnFinishConfirm)
-        store.runLatestLaunch(this)
+        handler.invoke(Action.Click.OnFinishClick)
 
-        // Standalone updateTrainingName must NOT fire here — the rename is now folded into
-        // finishSession's transaction so a crash between the two writes is impossible.
-        coVerify(exactly = 0) { interactor.updateTrainingName(any(), any()) }
-        coVerify(exactly = 1) {
-            interactor.finishSession(
-                sessionUuid = "session-1",
-                newTrainingName = "Push Day",
-            )
-        }
+        val empty = stateFlow.value.dialogState as? DialogState.EmptyFinish
+        assertTrue(empty != null)
+        assertEquals(true, empty?.canDiscard)
     }
 
     @Test
@@ -393,17 +310,18 @@ internal class ClickHandlerTest {
         exercises = persistentListOf(exercise),
     )
 
-    private fun doneExercise(status: ExerciseStatusUiModel): LiveExerciseUiModel = LiveExerciseUiModel(
-        performedExerciseUuid = "pe-1",
-        exerciseUuid = "ex-1",
-        exerciseName = "Bench Press",
-        exerciseType = ExerciseTypeUiModel.WEIGHTED,
-        position = 0,
-        status = status,
-        statusLabel = "",
-        planSets = persistentListOf(),
-        performedSets = persistentListOf(),
-    )
+    private fun doneExercise(status: ExerciseStatusUiModel): LiveExerciseUiModel =
+        LiveExerciseUiModel(
+            performedExerciseUuid = "pe-1",
+            exerciseUuid = "ex-1",
+            exerciseName = "Bench Press",
+            exerciseType = ExerciseTypeUiModel.WEIGHTED,
+            position = 0,
+            status = status,
+            statusLabel = "",
+            planSets = persistentListOf(),
+            performedSets = persistentListOf(),
+        )
 
     private fun loggedExercise(): LiveExerciseUiModel = doneExercise(
         status = ExerciseStatusUiModel.CURRENT,
@@ -473,7 +391,7 @@ internal class ClickHandlerTest {
             return Job()
         }
 
-        override fun <T> kotlinx.coroutines.flow.Flow<T>.launch(
+        override fun <T> Flow<T>.launch(
             onError: suspend (cause: Throwable) -> Unit,
             workDispatcher: CoroutineDispatcher?,
             eachDispatcher: CoroutineDispatcher?,

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/DialogClickHandlerTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/DialogClickHandlerTest.kt
@@ -1,0 +1,1024 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.live_workout.mvi.handler
+
+import io.github.stslex.workeeper.core.core.logger.Logger
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExercisePickerAction
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.live_workout.R
+import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutHandlerStore
+import io.github.stslex.workeeper.feature.live_workout.domain.LiveWorkoutInteractor
+import io.github.stslex.workeeper.feature.live_workout.domain.model.FinishResult
+import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveSetMutator
+import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.StateStatusMapper
+import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Action
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.Event
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class DialogClickHandlerTest {
+
+    private val interactor = mockk<LiveWorkoutInteractor>(relaxed = true)
+    private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true)
+    private val pickerHandler = mockk<ExercisePickerHandler>(relaxed = true)
+    private val statusMapper = StateStatusMapper(resourceWrapper)
+    private val setMutator = LiveSetMutator(resourceWrapper, statusMapper)
+
+    // region Dismiss actions — every dismiss flips DialogState to Hidden
+
+    @Test
+    fun `OnDeleteSessionDismiss hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                dialogState = DialogState.DeleteDialog(
+                    sessionName = "session name",
+                    progressLabel = "Progress label",
+                ),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnDeleteSessionDismiss)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `OnCancelSessionDismiss hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                dialogState = cancelDialog(),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnCancelSessionDismiss)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `OnResetSetsDismiss hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                dialogState = DialogState.ConfirmDialog.ResetSets(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnResetSetsDismiss)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `OnFinishDismiss hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(dialogState = finishDialog(requiresName = false)),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnFinishDismiss)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `OnSkipExerciseDismiss hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                dialogState = DialogState.ConfirmDialog.SkipExercise(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnSkipExerciseDismiss)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    // endregion
+
+    // region OnDeleteSessionConfirm
+
+    @Test
+    fun `OnDeleteSessionConfirm without sessionUuid hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                sessionUuid = null,
+                dialogState = DialogState.DeleteDialog("session", "progress"),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnDeleteSessionConfirm)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+        coVerify(exactly = 0) { interactor.cancelSession(any()) }
+    }
+
+    @Test
+    fun `OnDeleteSessionConfirm with sessionUuid hides dialog and calls cancelSession`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                dialogState = DialogState.DeleteDialog("session", "progress"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnDeleteSessionConfirm)
+        store.runLatestLaunch(this)
+
+        assertEquals(DialogState.Hidden, store.state.value.dialogState)
+        coVerify(exactly = 1) { interactor.cancelSession("session-1") }
+        assertEquals(listOf<Action>(Action.Navigation.Back), store.consumedOnMain)
+    }
+
+    @Test
+    fun `OnDeleteSessionConfirm failure surfaces CancelFailed error`() = runTest {
+        coEvery { interactor.cancelSession("session-1") } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_cancel_failed)
+        } returns "Cancel failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                dialogState = DialogState.DeleteDialog("session", "progress"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnDeleteSessionConfirm)
+        store.runLatestLaunch(this)
+
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Cancel failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnCancelSessionConfirm
+
+    @Test
+    fun `OnCancelSessionConfirm without sessionUuid only navigates back`() {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                sessionUuid = null,
+                dialogState = cancelDialog(),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnCancelSessionConfirm)
+
+        assertEquals(listOf<Action>(Action.Navigation.Back), store.consumed)
+        coVerify(exactly = 0) { interactor.cancelSession(any()) }
+    }
+
+    @Test
+    fun `OnCancelSessionConfirm calls cancelSession and navigates back`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(dialogState = cancelDialog()),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnCancelSessionConfirm)
+        store.runLatestLaunch(this)
+
+        coVerify(exactly = 1) { interactor.cancelSession("session-1") }
+        assertEquals(listOf<Action>(Action.Navigation.Back), store.consumedOnMain)
+    }
+
+    @Test
+    fun `OnCancelSessionConfirm failure surfaces CancelFailed error`() = runTest {
+        coEvery { interactor.cancelSession("session-1") } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_cancel_failed)
+        } returns "Cancel failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(dialogState = cancelDialog()),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnCancelSessionConfirm)
+        store.runLatestLaunch(this)
+
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Cancel failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnEmptyFinishContinue / OnEmptyFinishDiscard
+
+    @Test
+    fun `OnEmptyFinishContinue hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                dialogState = DialogState.EmptyFinish(
+                    canDiscard = true,
+                    confirmLabel = "Discard",
+                    dismissLabel = "Continue",
+                ),
+            ),
+        )
+
+        handler(stateFlow).invoke(Action.DialogClick.OnEmptyFinishContinue)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `OnEmptyFinishDiscard for library training only hides the dialog`() {
+        val stateFlow = MutableStateFlow(
+            baseState().copy(
+                isAdhoc = false,
+                dialogState = DialogState.EmptyFinish(
+                    canDiscard = false,
+                    confirmLabel = "Discard",
+                    dismissLabel = "Continue",
+                ),
+            ),
+        )
+        handler(stateFlow).invoke(Action.DialogClick.OnEmptyFinishDiscard)
+
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+        coVerify(exactly = 0) { interactor.discardAdhocSession(any(), any()) }
+    }
+
+    @Test
+    fun `OnEmptyFinishDiscard with adhoc training discards and navigates back`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                isAdhoc = true,
+                dialogState = DialogState.EmptyFinish(
+                    canDiscard = true,
+                    confirmLabel = "Discard",
+                    dismissLabel = "Continue",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnEmptyFinishDiscard)
+
+        // Optimistic update lands first: dialog hidden + finish-in-flight set.
+        assertEquals(DialogState.Hidden, store.state.value.dialogState)
+        assertEquals(true, store.state.value.isFinishInFlight)
+        store.runLatestLaunch(this)
+
+        coVerify(exactly = 1) {
+            interactor.discardAdhocSession(
+                sessionUuid = "session-1",
+                trainingUuid = "training-1",
+            )
+        }
+        assertEquals(listOf<Action>(Action.Navigation.Back), store.consumedOnMain)
+    }
+
+    @Test
+    fun `OnEmptyFinishDiscard with blank sessionUuid only hides the dialog`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                isAdhoc = true,
+                sessionUuid = "",
+                dialogState = DialogState.EmptyFinish(
+                    canDiscard = true,
+                    confirmLabel = "Discard",
+                    dismissLabel = "Continue",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnEmptyFinishDiscard)
+
+        assertEquals(DialogState.Hidden, store.state.value.dialogState)
+        assertEquals(false, store.state.value.isFinishInFlight)
+        coVerify(exactly = 0) { interactor.discardAdhocSession(any(), any()) }
+    }
+
+    @Test
+    fun `OnEmptyFinishDiscard failure clears the in-flight flag and surfaces error`() = runTest {
+        coEvery {
+            interactor.discardAdhocSession(any(), any())
+        } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_discard_session_failed)
+        } returns "Discard failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState().copy(
+                isAdhoc = true,
+                dialogState = DialogState.EmptyFinish(
+                    canDiscard = true,
+                    confirmLabel = "Discard",
+                    dismissLabel = "Continue",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnEmptyFinishDiscard)
+        store.runLatestLaunch(this)
+
+        assertEquals(false, store.state.value.isFinishInFlight)
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Discard failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnResetSetsConfirm
+
+    @Test
+    fun `OnResetSetsConfirm clears performed sets and calls resetExerciseSets`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                dialogState = DialogState.ConfirmDialog.ResetSets(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnResetSetsConfirm("pe-1"))
+        store.runLatestLaunch(this)
+
+        // Mutator clears performedSets and hides the dialog as part of the optimistic update.
+        assertTrue(store.state.value.exercises.first().performedSets.isEmpty())
+        assertEquals(DialogState.Hidden, store.state.value.dialogState)
+        coVerify(exactly = 1) { interactor.resetExerciseSets("pe-1") }
+    }
+
+    @Test
+    fun `OnResetSetsConfirm failure surfaces ResetFailed error`() = runTest {
+        coEvery { interactor.resetExerciseSets(any()) } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_reset_failed)
+        } returns "Reset failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                dialogState = DialogState.ConfirmDialog.ResetSets(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnResetSetsConfirm("pe-1"))
+        store.runLatestLaunch(this)
+
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Reset failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnSkipExerciseConfirm
+
+    @Test
+    fun `OnSkipExerciseConfirm flips status to SKIPPED and calls setSkipped`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                dialogState = DialogState.ConfirmDialog.SkipExercise(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnSkipExerciseConfirm("pe-1"))
+        store.runLatestLaunch(this)
+
+        assertEquals(
+            ExerciseStatusUiModel.SKIPPED,
+            store.state.value.exercises.first().status,
+        )
+        assertEquals(DialogState.Hidden, store.state.value.dialogState)
+        coVerify(exactly = 1) { interactor.setSkipped("pe-1", true) }
+    }
+
+    @Test
+    fun `OnSkipExerciseConfirm failure surfaces SkipFailed error`() = runTest {
+        coEvery { interactor.setSkipped(any(), any()) } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_skip_failed)
+        } returns "Skip failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                dialogState = DialogState.ConfirmDialog.SkipExercise(
+                    title = "title",
+                    body = "body",
+                    confirmLabel = "confirm",
+                    dismissLabel = "dismiss",
+                    exerciseUuid = "pe-1",
+                ),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnSkipExerciseConfirm("pe-1"))
+        store.runLatestLaunch(this)
+
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Skip failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnFinishConfirm
+
+    @Test
+    fun `OnFinishConfirm without sessionUuid is a no-op`() = runTest {
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                sessionUuid = null,
+                dialogState = finishDialog(requiresName = false),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+
+        coVerify(exactly = 0) { interactor.finishSession(any(), any()) }
+    }
+
+    @Test
+    fun `OnFinishConfirm with blank required name sets nameError and skips finishSession`() = runTest {
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_finish_name_required)
+        } returns "Name is required"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingName = "",
+                trainingNameLabel = "Untitled",
+                dialogState = finishDialog(requiresName = true, nameDraft = ""),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+
+        val finish = store.state.value.dialogState as? DialogState.FinishSession
+        assertEquals("Name is required", finish?.nameError)
+        assertEquals(false, finish?.confirmEnabled)
+        coVerify(exactly = 0) { interactor.finishSession(any(), any()) }
+        coVerify(exactly = 0) { interactor.updateTrainingName(any(), any()) }
+    }
+
+    @Test
+    fun `OnFinishConfirm with valid name calls finishSession atomically`() = runTest {
+        coEvery {
+            interactor.finishSession(sessionUuid = "session-1", newTrainingName = "Push Day")
+        } returns finishResult()
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_finish_success)
+        } returns "Saved"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingName = "",
+                trainingNameLabel = "Untitled",
+                dialogState = finishDialog(requiresName = true, nameDraft = "Push Day"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+        store.runLatestLaunch(this)
+
+        // Standalone updateTrainingName must NOT fire — the rename is folded into
+        // finishSession's transaction.
+        coVerify(exactly = 0) { interactor.updateTrainingName(any(), any()) }
+        coVerify(exactly = 1) {
+            interactor.finishSession(
+                sessionUuid = "session-1",
+                newTrainingName = "Push Day",
+            )
+        }
+        assertTrue(
+            store.events.any {
+                it is Event.ShowSessionSavedSnackbar && it.message == "Saved"
+            },
+        )
+        assertEquals(
+            listOf<Action>(Action.Navigation.OpenPastSession(sessionUuid = "session-1")),
+            store.consumedOnMain,
+        )
+    }
+
+    @Test
+    fun `OnFinishConfirm without required name reuses existing trainingName`() = runTest {
+        coEvery {
+            interactor.finishSession(sessionUuid = "session-1", newTrainingName = null)
+        } returns finishResult()
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_finish_success)
+        } returns "Saved"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingName = "Push Day",
+                trainingNameLabel = "Push Day",
+                dialogState = finishDialog(requiresName = false, nameDraft = "Push Day"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+        store.runLatestLaunch(this)
+
+        // No rename needed → newTrainingName is null so the transaction skips the rename branch.
+        coVerify(exactly = 1) {
+            interactor.finishSession(
+                sessionUuid = "session-1",
+                newTrainingName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `OnFinishConfirm with required name and missing trainingUuid surfaces FinishFailed`() = runTest {
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_finish_failed)
+        } returns "Finish failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingUuid = null,
+                trainingName = "",
+                dialogState = finishDialog(requiresName = true, nameDraft = "Push Day"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+
+        coVerify(exactly = 0) { interactor.finishSession(any(), any()) }
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Finish failed" },
+        )
+    }
+
+    @Test
+    fun `OnFinishConfirm null result surfaces FinishMissingSession`() = runTest {
+        coEvery {
+            interactor.finishSession(any(), any())
+        } returns null
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_finish_missing_session)
+        } returns "Missing session"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingName = "Push Day",
+                dialogState = finishDialog(requiresName = false, nameDraft = "Push Day"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+        store.runLatestLaunch(this)
+
+        assertEquals(false, store.state.value.isFinishInFlight)
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Missing session" },
+        )
+    }
+
+    @Test
+    fun `OnFinishConfirm failure clears the in-flight flag and surfaces FinishFailed`() = runTest {
+        coEvery {
+            interactor.finishSession(any(), any())
+        } throws IllegalStateException("boom")
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_error_finish_failed)
+        } returns "Finish failed"
+        val store = FakeLiveWorkoutHandlerStore(
+            baseState(loggedExercise()).copy(
+                trainingName = "Push Day",
+                dialogState = finishDialog(requiresName = false, nameDraft = "Push Day"),
+            ),
+        )
+        val handler = DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = store,
+        )
+
+        handler.invoke(Action.DialogClick.OnFinishConfirm)
+        store.runLatestLaunch(this)
+
+        assertEquals(false, store.state.value.isFinishInFlight)
+        assertTrue(
+            store.events.any { it is Event.ShowError && it.message == "Finish failed" },
+        )
+    }
+
+    // endregion
+
+    // region OnFinishNameChange
+
+    @Test
+    fun `OnFinishNameChange with non-blank text updates draft and clears error`() {
+        val stateFlow = MutableStateFlow(
+            baseState(loggedExercise()).copy(
+                dialogState = finishDialog(
+                    requiresName = true,
+                    nameDraft = "",
+                    nameError = "Name is required",
+                    confirmEnabled = false,
+                ),
+            ),
+        )
+
+        handler(stateFlow).invoke(Action.DialogClick.OnFinishNameChange("Push Day"))
+
+        val finish = stateFlow.value.dialogState as DialogState.FinishSession
+        assertEquals("Push Day", finish.nameDraft)
+        assertEquals(null, finish.nameError)
+        assertEquals(true, finish.confirmEnabled)
+    }
+
+    @Test
+    fun `OnFinishNameChange with blank text sets the required error and disables confirm`() {
+        every {
+            resourceWrapper.getString(R.string.feature_live_workout_finish_name_required)
+        } returns "Name is required"
+        val stateFlow = MutableStateFlow(
+            baseState(loggedExercise()).copy(
+                dialogState = finishDialog(
+                    requiresName = true,
+                    nameDraft = "Push Day",
+                    nameError = null,
+                    confirmEnabled = true,
+                ),
+            ),
+        )
+
+        handler(stateFlow).invoke(Action.DialogClick.OnFinishNameChange("   "))
+
+        val finish = stateFlow.value.dialogState as DialogState.FinishSession
+        assertEquals("   ", finish.nameDraft)
+        assertEquals("Name is required", finish.nameError)
+        assertEquals(false, finish.confirmEnabled)
+    }
+
+    @Test
+    fun `OnFinishNameChange is a no-op when dialog is not FinishSession`() {
+        val stateFlow = MutableStateFlow(
+            baseState(loggedExercise()).copy(
+                dialogState = DialogState.Hidden,
+            ),
+        )
+
+        handler(stateFlow).invoke(Action.DialogClick.OnFinishNameChange("Push Day"))
+
+        // Dialog stays hidden — no FinishSession to mutate.
+        assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    // endregion
+
+    // region PickerAction delegation
+
+    @Test
+    fun `PickerAction delegates to the picker sub-handler`() {
+        val stateFlow = MutableStateFlow(baseState(loggedExercise()))
+        val picker = ExercisePickerAction.OnDismiss
+
+        handler(stateFlow).invoke(Action.DialogClick.PickerAction(picker))
+
+        verify(exactly = 1) { pickerHandler.invoke(picker) }
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun handler(stateFlow: MutableStateFlow<State>): DialogClickHandler =
+        DialogClickHandler(
+            interactor = interactor,
+            resourceWrapper = resourceWrapper,
+            pickerHandler = pickerHandler,
+            setMutator = setMutator,
+            store = handlerStore(stateFlow),
+        )
+
+    private fun handlerStore(stateFlow: MutableStateFlow<State>): LiveWorkoutHandlerStore =
+        mockk(relaxed = true) {
+            every { state } returns stateFlow
+            every { updateState(any()) } answers {
+                val update = firstArg<(State) -> State>()
+                stateFlow.value = update(stateFlow.value)
+            }
+        }
+
+    private fun baseState(
+        exercise: LiveExerciseUiModel = doneExercise(ExerciseStatusUiModel.CURRENT),
+    ): State = State.create(
+        sessionUuid = "session-1",
+        trainingUuid = "training-1",
+    ).copy(
+        isLoading = false,
+        exercises = persistentListOf(exercise),
+    )
+
+    private fun doneExercise(status: ExerciseStatusUiModel): LiveExerciseUiModel =
+        LiveExerciseUiModel(
+            performedExerciseUuid = "pe-1",
+            exerciseUuid = "ex-1",
+            exerciseName = "Bench Press",
+            exerciseType = ExerciseTypeUiModel.WEIGHTED,
+            position = 0,
+            status = status,
+            statusLabel = "",
+            planSets = persistentListOf(),
+            performedSets = persistentListOf(),
+        )
+
+    private fun loggedExercise(): LiveExerciseUiModel = doneExercise(
+        status = ExerciseStatusUiModel.CURRENT,
+    ).copy(
+        performedSets = persistentListOf(
+            LiveSetUiModel(
+                position = 0,
+                weight = 100.0,
+                reps = 5,
+                type = SetTypeUiModel.WORK,
+                isDone = true,
+            ),
+        ),
+    )
+
+    private fun finishResult(): FinishResult = FinishResult(
+        durationMillis = 60_000L,
+        doneCount = 1,
+        totalCount = 1,
+        skippedCount = 0,
+        setsLogged = 1,
+    )
+
+    private fun cancelDialog(): DialogState.ConfirmDialog.CancelSession =
+        DialogState.ConfirmDialog.CancelSession(
+            title = "title",
+            body = "body",
+            confirmLabel = "confirm",
+            dismissLabel = "dismiss",
+        )
+
+    private fun finishDialog(
+        requiresName: Boolean,
+        nameDraft: String = "",
+        nameError: String? = null,
+        confirmEnabled: Boolean = !requiresName,
+    ): DialogState.FinishSession = DialogState.FinishSession(
+        durationMillis = 60_000L,
+        durationLabel = "1m",
+        exercisesSummaryLabel = "1 / 1",
+        setsLoggedLabel = "1",
+        newPersonalRecords = persistentListOf(),
+        requiresName = requiresName,
+        nameDraft = nameDraft,
+        nameLabel = "Training name",
+        namePlaceholder = "Untitled",
+        nameError = nameError,
+        confirmEnabled = confirmEnabled,
+    )
+
+    /**
+     * Test double for the handler store. Captures the latest [launch] block and the
+     * `consume`/`consumeOnMain` invocations so tests can assert on both the optimistic
+     * state changes and the post-coroutine effects.
+     */
+    private class FakeLiveWorkoutHandlerStore(
+        initialState: State,
+    ) : LiveWorkoutHandlerStore {
+
+        private val stateFlow = MutableStateFlow(initialState)
+        private var latestLaunch: (suspend CoroutineScope.() -> Any?)? = null
+        private var latestOnError: (suspend (Throwable) -> Unit)? = null
+        private var latestOnSuccess: (suspend CoroutineScope.(Any?) -> Unit)? = null
+
+        val consumed: MutableList<Action> = mutableListOf()
+        val consumedOnMain: MutableList<Action> = mutableListOf()
+        val events: MutableList<Event> = mutableListOf()
+
+        override val state: StateFlow<State> = stateFlow
+        override val lastAction: Action? = null
+        override val logger: Logger = mockk(relaxed = true)
+
+        override fun sendEvent(event: Event) {
+            events.add(event)
+        }
+
+        override fun consume(action: Action) {
+            consumed.add(action)
+        }
+
+        override suspend fun consumeOnMain(action: Action) {
+            consumedOnMain.add(action)
+        }
+
+        override fun updateState(update: (State) -> State) {
+            stateFlow.value = update(stateFlow.value)
+        }
+
+        override suspend fun updateStateImmediate(update: suspend (State) -> State) {
+            stateFlow.value = update(stateFlow.value)
+        }
+
+        override suspend fun updateStateImmediate(state: State) {
+            stateFlow.value = state
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> launch(
+            onError: suspend (Throwable) -> Unit,
+            onSuccess: suspend CoroutineScope.(T) -> Unit,
+            workDispatcher: CoroutineDispatcher?,
+            eachDispatcher: CoroutineDispatcher?,
+            action: suspend CoroutineScope.() -> T,
+        ): Job {
+            latestLaunch = action as suspend CoroutineScope.() -> Any?
+            latestOnError = onError
+            latestOnSuccess = onSuccess as suspend CoroutineScope.(Any?) -> Unit
+            return Job()
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> launchDefault(
+            onError: suspend (Throwable) -> Unit,
+            onSuccess: suspend CoroutineScope.(T) -> Unit,
+            action: suspend CoroutineScope.() -> T,
+        ): Job {
+            latestLaunch = action as suspend CoroutineScope.() -> Any?
+            latestOnError = onError
+            latestOnSuccess = onSuccess as suspend CoroutineScope.(Any?) -> Unit
+            return Job()
+        }
+
+        override fun <T> Flow<T>.launch(
+            onError: suspend (cause: Throwable) -> Unit,
+            workDispatcher: CoroutineDispatcher?,
+            eachDispatcher: CoroutineDispatcher?,
+            each: suspend (T) -> Unit,
+        ): Job = Job()
+
+        suspend fun runLatestLaunch(scope: CoroutineScope) {
+            // Mirror production: a thrown action routes through onError; otherwise the
+            // result feeds onSuccess so tests can observe both the success and error
+            // branches the real Handler would take.
+            try {
+                val result = latestLaunch?.invoke(scope)
+                latestOnSuccess?.invoke(scope, result)
+            } catch (throwable: Throwable) {
+                latestOnError?.invoke(throwable)
+            }
+        }
+    }
+
+    // endregion
+}

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandlerTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandlerTest.kt
@@ -13,8 +13,8 @@ import io.github.stslex.workeeper.feature.live_workout.domain.model.ExercisePick
 import io.github.stslex.workeeper.feature.live_workout.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.InlineAdhocResult
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.StateStatusMapper
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
-import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State.ExercisePickerSheetState
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -45,7 +45,7 @@ internal class ExercisePickerHandlerTest {
 
         handler(state).invoke(ExercisePickerAction.OnDismiss)
 
-        assertEquals(ExercisePickerSheetState.Hidden, state.value.exercisePickerSheet)
+        assertEquals(BottomSheetState.Hidden, state.value.bottomSheetState)
     }
 
     @Test
@@ -56,7 +56,7 @@ internal class ExercisePickerHandlerTest {
         ExercisePickerHandler(interactor, resourceWrapper, statusMapper, store)
             .invoke(ExercisePickerAction.OnQueryChange("bench"))
 
-        val visible = state.value.exercisePickerSheet as ExercisePickerSheetState.Visible
+        val visible = state.value.bottomSheetState as BottomSheetState.ExercisePicker
         assertEquals("bench", visible.query)
         verify {
             store.launch(
@@ -219,7 +219,7 @@ internal class ExercisePickerHandlerTest {
         handler.invoke(ExercisePickerAction.OnQueryChange("жим груди"))
         advanceUntilIdle()
 
-        val visible = state.value.exercisePickerSheet as ExercisePickerSheetState.Visible
+        val visible = state.value.bottomSheetState as BottomSheetState.ExercisePicker
         assertEquals("Create \"жим груди\"", visible.createCtaLabel)
         // Partial-match case: noMatchHeadline must stay null because results is non-empty.
         assertEquals(null, visible.noMatchHeadline)
@@ -248,7 +248,7 @@ internal class ExercisePickerHandlerTest {
         handler.invoke(ExercisePickerAction.OnQueryChange("BENCH PRESS"))
         advanceUntilIdle()
 
-        val visible = state.value.exercisePickerSheet as ExercisePickerSheetState.Visible
+        val visible = state.value.bottomSheetState as BottomSheetState.ExercisePicker
         // Exact case-insensitive match → CTA suppressed (DB-level dedupe would kick in).
         assertEquals(null, visible.createCtaLabel)
         assertEquals(null, visible.noMatchHeadline)
@@ -259,7 +259,10 @@ internal class ExercisePickerHandlerTest {
     fun loadResults_emptyResults_showsHeadlineAndCta() = runTest {
         val state = MutableStateFlow(stateWithVisiblePicker())
         coEvery {
-            interactor.searchExercisesForPicker(query = "skull crushers", excludedUuids = emptySet())
+            interactor.searchExercisesForPicker(
+                query = "skull crushers",
+                excludedUuids = emptySet(),
+            )
         } returns emptyList()
         every {
             resourceWrapper.getString(
@@ -285,7 +288,7 @@ internal class ExercisePickerHandlerTest {
         handler.invoke(ExercisePickerAction.OnQueryChange("skull crushers"))
         advanceUntilIdle()
 
-        val visible = state.value.exercisePickerSheet as ExercisePickerSheetState.Visible
+        val visible = state.value.bottomSheetState as BottomSheetState.ExercisePicker
         // Genuinely empty list — both indicators surface together (Q3: explicit no-match).
         assertEquals("No exercises match \"skull crushers\"", visible.noMatchHeadline)
         assertEquals("Create \"skull crushers\"", visible.createCtaLabel)
@@ -308,7 +311,7 @@ internal class ExercisePickerHandlerTest {
         handler.invoke(ExercisePickerAction.OnQueryChange("   "))
         advanceUntilIdle()
 
-        val visible = state.value.exercisePickerSheet as ExercisePickerSheetState.Visible
+        val visible = state.value.bottomSheetState as BottomSheetState.ExercisePicker
         assertEquals(null, visible.noMatchHeadline)
         assertEquals(null, visible.createCtaLabel)
     }
@@ -317,7 +320,7 @@ internal class ExercisePickerHandlerTest {
     fun `OnExerciseSelect for an unknown uuid does nothing`() {
         val state = MutableStateFlow(
             stateWithVisiblePicker().copy(
-                exercisePickerSheet = ExercisePickerSheetState.Visible(
+                bottomSheetState = BottomSheetState.ExercisePicker(
                     query = "",
                     results = persistentListOf(
                         ExercisePickerUiModel("u1", "Bench Press", ExerciseTypeUiModel.WEIGHTED),
@@ -435,7 +438,7 @@ internal class ExercisePickerHandlerTest {
         trainingUuid = "training-1",
     ).copy(
         isLoading = false,
-        exercisePickerSheet = ExercisePickerSheetState.Visible(
+        bottomSheetState = BottomSheetState.ExercisePicker(
             query = "",
             results = persistentListOf(),
             noMatchHeadline = null,

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveSetMutatorTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveSetMutatorTest.kt
@@ -8,8 +8,10 @@ import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
 import io.mockk.mockk
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -170,7 +172,8 @@ internal class LiveSetMutatorTest {
             ),
         )
 
-        val result = mutator.applySetTypeChange(state, PE_UUID, position = 1, type = SetTypeUiModel.FAILURE)
+        val result =
+            mutator.applySetTypeChange(state, PE_UUID, position = 1, type = SetTypeUiModel.FAILURE)
 
         val performed = result.exercises.first().performedSets
         assertEquals(SetTypeUiModel.WORK, performed[0].type)
@@ -189,10 +192,28 @@ internal class LiveSetMutatorTest {
                 ),
             ),
         ).copy(
-            pendingResetExerciseUuid = PE_UUID,
+            dialogState = DialogState.ConfirmDialog.ResetSets(
+                title = "title",
+                body = "body",
+                confirmLabel = "confirm",
+                dismissLabel = "dismiss",
+                exerciseUuid = PE_UUID,
+            ),
             setDrafts = mapOf(
-                State.DraftKey(PE_UUID, 1) to LiveSetUiModel(1, 110.0, 5, SetTypeUiModel.WORK, isDone = false),
-                State.DraftKey("OTHER", 0) to LiveSetUiModel(0, 50.0, 3, SetTypeUiModel.WARMUP, isDone = false),
+                State.DraftKey(PE_UUID, 1) to LiveSetUiModel(
+                    1,
+                    110.0,
+                    5,
+                    SetTypeUiModel.WORK,
+                    isDone = false,
+                ),
+                State.DraftKey("OTHER", 0) to LiveSetUiModel(
+                    0,
+                    50.0,
+                    3,
+                    SetTypeUiModel.WARMUP,
+                    isDone = false,
+                ),
             ).toImmutableMap(),
         )
 
@@ -201,7 +222,7 @@ internal class LiveSetMutatorTest {
         assertTrue(result.exercises.first().performedSets.isEmpty())
         assertNull(result.setDrafts[State.DraftKey(PE_UUID, 1)])
         assertNotNull(result.setDrafts[State.DraftKey("OTHER", 0)])
-        assertNull(result.pendingResetExerciseUuid)
+        assertNull((result.dialogState as? DialogState.ConfirmDialog.ResetSets)?.exerciseUuid)
     }
 
     @Test
@@ -213,9 +234,21 @@ internal class LiveSetMutatorTest {
                 ),
             ),
         ).copy(
-            pendingSkipExerciseUuid = PE_UUID,
+            dialogState = DialogState.ConfirmDialog.SkipExercise(
+                title = "title",
+                body = "body",
+                confirmLabel = "confirm",
+                dismissLabel = "dismiss",
+                exerciseUuid = PE_UUID,
+            ),
             setDrafts = persistentMapOf(
-                State.DraftKey(PE_UUID, 0) to LiveSetUiModel(0, 110.0, 5, SetTypeUiModel.WORK, isDone = false),
+                State.DraftKey(PE_UUID, 0) to LiveSetUiModel(
+                    0,
+                    110.0,
+                    5,
+                    SetTypeUiModel.WORK,
+                    isDone = false,
+                ),
             ),
         )
 
@@ -223,7 +256,7 @@ internal class LiveSetMutatorTest {
 
         assertEquals(ExerciseStatusUiModel.SKIPPED, result.exercises.first().status)
         assertTrue(result.setDrafts.isEmpty())
-        assertNull(result.pendingSkipExerciseUuid)
+        assertNull((result.dialogState as? DialogState.ConfirmDialog.SkipExercise)?.exerciseUuid)
     }
 
     @Test
@@ -271,7 +304,13 @@ internal class LiveSetMutatorTest {
             ),
         ).copy(
             setDrafts = persistentMapOf(
-                State.DraftKey(PE_UUID, 4) to LiveSetUiModel(4, 110.0, 5, SetTypeUiModel.WORK, isDone = false),
+                State.DraftKey(PE_UUID, 4) to LiveSetUiModel(
+                    4,
+                    110.0,
+                    5,
+                    SetTypeUiModel.WORK,
+                    isDone = false,
+                ),
             ),
         )
         val exercise = state.exercises.first()
@@ -292,7 +331,13 @@ internal class LiveSetMutatorTest {
             ),
         ).copy(
             setDrafts = persistentMapOf(
-                State.DraftKey(PE_UUID, 3) to LiveSetUiModel(3, 88.0, 11, SetTypeUiModel.DROP, isDone = false),
+                State.DraftKey(PE_UUID, 3) to LiveSetUiModel(
+                    3,
+                    88.0,
+                    11,
+                    SetTypeUiModel.DROP,
+                    isDone = false,
+                ),
             ),
         )
         val exercise = state.exercises.first()
@@ -341,8 +386,8 @@ internal class LiveSetMutatorTest {
     )
 
     private fun exerciseWithPlan(
-        plan: kotlinx.collections.immutable.ImmutableList<PlanSetUiModel>,
-        performed: kotlinx.collections.immutable.ImmutableList<LiveSetUiModel> = persistentListOf(),
+        plan: ImmutableList<PlanSetUiModel>,
+        performed: ImmutableList<LiveSetUiModel> = persistentListOf(),
         status: ExerciseStatusUiModel = ExerciseStatusUiModel.CURRENT,
     ): LiveExerciseUiModel = LiveExerciseUiModel(
         performedExerciseUuid = PE_UUID,

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveWorkoutMapperTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/mapper/LiveWorkoutMapperTest.kt
@@ -13,6 +13,7 @@ import io.github.stslex.workeeper.feature.live_workout.domain.model.PlanSetDomai
 import io.github.stslex.workeeper.feature.live_workout.domain.model.SessionDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.SessionSnapshotDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.SessionStateDomain
+import io.github.stslex.workeeper.feature.live_workout.domain.model.SetDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.SetTypeDomain
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMapper.toFinishStats
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMapper.toState
@@ -20,6 +21,8 @@ import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMap
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ExerciseStatusUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveExerciseUiModel
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.LiveSetUiModel
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.BottomSheetState
+import io.github.stslex.workeeper.feature.live_workout.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.live_workout.mvi.store.LiveWorkoutStore.State
 import io.mockk.every
 import io.mockk.mockk
@@ -105,7 +108,7 @@ internal class LiveWorkoutMapperTest {
                 pending(uuid = "pe-1", position = 0).copy(
                     planSets = null,
                     performedSets = listOf(
-                        io.github.stslex.workeeper.feature.live_workout.domain.model.SetDomain(
+                        SetDomain(
                             uuid = "set-1",
                             weight = null,
                             reps = 10,
@@ -153,13 +156,13 @@ internal class LiveWorkoutMapperTest {
     private fun fullyDone(uuid: String, position: Int): LiveExerciseDomain =
         pending(uuid, position).copy(
             performedSets = listOf(
-                io.github.stslex.workeeper.feature.live_workout.domain.model.SetDomain(
+                SetDomain(
                     uuid = "set-$uuid-0",
                     weight = 100.0,
                     reps = 5,
                     type = SetTypeDomain.WORK,
                 ),
-                io.github.stslex.workeeper.feature.live_workout.domain.model.SetDomain(
+                SetDomain(
                     uuid = "set-$uuid-1",
                     weight = 100.0,
                     reps = 5,
@@ -288,17 +291,11 @@ internal class LiveWorkoutMapperTest {
                     type = ExerciseTypeUiModel.WEIGHTLESS,
                 ),
             ).toImmutableMap(),
-            pendingFinishConfirm = null,
-            pendingResetExerciseUuid = null,
-            pendingSkipExerciseUuid = null,
-            pendingCancelConfirm = false,
-            deleteDialogVisible = false,
-            exercisePickerSheet = State.ExercisePickerSheetState.Hidden,
-            emptyFinishDialog = State.EmptyFinishDialogState.Hidden,
             isAddExerciseInFlight = false,
             isFinishInFlight = false,
             isLoading = false,
-            errorMessage = null,
+            dialogState = DialogState.Hidden,
+            bottomSheetState = BottomSheetState.Hidden,
         )
 
         val stats = state.toFinishStats(res)
@@ -450,17 +447,11 @@ internal class LiveWorkoutMapperTest {
         activeExerciseUuids = persistentSetOf(),
         expandedExerciseUuids = persistentSetOf(),
         preSessionPrSnapshot = persistentMapOf(),
-        pendingFinishConfirm = null,
-        pendingResetExerciseUuid = null,
-        pendingSkipExerciseUuid = null,
-        pendingCancelConfirm = false,
-        deleteDialogVisible = false,
-        exercisePickerSheet = State.ExercisePickerSheetState.Hidden,
-        emptyFinishDialog = State.EmptyFinishDialogState.Hidden,
         isAddExerciseInFlight = false,
         isFinishInFlight = false,
         isLoading = false,
-        errorMessage = null,
+        dialogState = DialogState.Hidden,
+        bottomSheetState = BottomSheetState.Hidden,
     )
 
     private fun exerciseUi(


### PR DESCRIPTION
This pull request primarily documents and codifies architectural rules for state derivation and draft management in the live workout feature, ensuring that state merging and draft updates are handled in the correct layer (the MVI mapper/handler) rather than in Composable UI components. It also introduces guidance for writing characterization tests before refactoring state logic, and marks the centralization of draft/visible row logic as resolved tech debt. Additionally, there are minor code improvements for coroutine handling and flow operator ordering in the `SessionRepositoryImpl`.

**Documentation and Architecture Improvements:**

* Added detailed architectural guidance in `.claude/skills/refactor-with-mvi-rules.md`, `documentation/architecture.md`, and `documentation/feature-specs/live-workout.md` to clarify that state merging (e.g., combining `performedSets`, `planSets`, `setDrafts`, and fallback) must occur in the MVI mapper layer, not in Composables, to prevent subtle data bugs. Also describes the correct pattern for draft seed/update logic and the importance of centralizing this logic in a single helper. [[1]](diffhunk://#diff-0c7b9e142e36dc9a1251af02a3c378a012a74ce9fed8a7ae5bc74bebf2d90e0eR141-R195) [[2]](diffhunk://#diff-8c61e6b16db459c8a3276a6cbf084db091cb279c17661fc3181a7e57652281c6R1135-R1233) [[3]](diffhunk://#diff-4c38723c12ec77d060069c5ad62159647b37ace0d3557098c6bee587e02454c6R218-R301)

* Added a section to `.claude/skills/write-handler-test.md` on writing characterization tests before refactoring, emphasizing red-green-refactor discipline to catch regressions when moving logic between layers.

* Updated `documentation/tech-debt.md` to mark the centralization of live-workout draft seed and visible-row merging as resolved tech debt, referencing the new architecture documentation and test coverage.

**Codebase Improvements:**

* Refactored coroutine usage in `SessionRepositoryImpl.kt` to use `asyncScope` for parallelizing database updates during session finishing, improving efficiency and clarity. [[1]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14R273-R289) [[2]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14R8)

* Reordered `map` and `flowOn` operators in Flow-returning methods in `SessionRepositoryImpl.kt` to ensure correct dispatcher usage and maintain idiomatic Kotlin Flow practices. [[1]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14L59-R65) [[2]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14L73-R79) [[3]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14L91) [[4]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14L109-R118) [[5]](diffhunk://#diff-438e8ff191d2fe78ff45f062234e86d44e528ad8f1423823be8de0b8edbbad14L163-R174)

These changes collectively reinforce architectural boundaries, improve testability and maintainability, and resolve a longstanding source of subtle UI-state bugs in the live workout feature.