### PR TITLE
feat: move exercise type toggle to plan editor and update related com…

### DIFF
--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
@@ -162,6 +162,9 @@ interface ExerciseDao {
     @Query("UPDATE exercise_table SET last_adhoc_sets = :lastAdhocSets WHERE uuid = :uuid")
     suspend fun updateLastAdhocSets(uuid: Uuid, lastAdhocSets: String?)
 
+    @Query("UPDATE exercise_table SET type = :type WHERE uuid = :uuid")
+    suspend fun updateType(uuid: Uuid, type: ExerciseTypeEntity)
+
     @Query("UPDATE exercise_table SET archived = 1, archived_at = :archivedAt WHERE uuid = :uuid")
     suspend fun archive(uuid: Uuid, archivedAt: Long)
 

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepository.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepository.kt
@@ -5,6 +5,7 @@ import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseListItem
+import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.HistoryEntry
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.RecentExerciseDataModel
 import kotlinx.coroutines.flow.Flow
@@ -36,6 +37,18 @@ interface ExerciseRepository {
     suspend fun getAdhocPlan(exerciseUuid: String): List<PlanSetDataModel>?
 
     suspend fun setAdhocPlan(exerciseUuid: String, planSets: List<PlanSetDataModel>?)
+
+    /**
+     * Updates only the `type` column on `exercise_table`. The plan editor uses this when
+     * persisting a type change without rewriting the rest of the exercise row (name,
+     * description, image, tags). When `type` flips to WEIGHTLESS the caller is responsible
+     * for invoking [clearWeightsFromAllPlansForExercise] in the same Save flow so weighted
+     * plan rows do not survive the type change.
+     */
+    suspend fun setExerciseType(
+        exerciseUuid: String,
+        type: ExerciseTypeDataModel,
+    )
 
     /**
      * Wipes the `weight` column from `exercise.last_adhoc_sets` and from every

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImpl.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImpl.kt
@@ -32,6 +32,7 @@ import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseListItem
+import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel.Companion.toData
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.HistoryEntry
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.RecentExerciseDataModel
@@ -173,6 +174,18 @@ internal class ExerciseRepositoryImpl @Inject constructor(
             dao.updateLastAdhocSets(
                 uuid = Uuid.parse(exerciseUuid),
                 lastAdhocSets = PlanSetsConverter.toJson(planSets),
+            )
+        }
+    }
+
+    override suspend fun setExerciseType(
+        exerciseUuid: String,
+        type: ExerciseTypeDataModel,
+    ) {
+        withContext(bgDispatcher) {
+            dao.updateType(
+                uuid = Uuid.parse(exerciseUuid),
+                type = type.toEntity(),
             )
         }
     }

--- a/core/ui/navigation/build.gradle.kts
+++ b/core/ui/navigation/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":core:core"))
+    implementation(project(":core:ui:plan-editor"))
 
     api(libs.androidx.compose.navigation)
 }

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
@@ -8,6 +8,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorDraftResultAttr
+import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorSavedAttr
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
@@ -89,28 +92,56 @@ sealed interface Screen {
     ) : Screen
 
     /**
-     * Full-screen plan editor (v2.4 D1). Replaces the bottom-sheet plan editor.
+     * Full-screen plan editor. Two destinations:
      *
-     *  - `performedExerciseUuid` non-null: edit the plan attached to a live workout's
-     *    `performed_exercise_table` row. Backed by `training_exercise_table.plan_sets`
-     *    when `trainingUuid` non-null, or by `exercise_table.last_adhoc_sets` when adhoc.
-     *  - `exerciseUuid` non-null: edit the default plan attached to an exercise (used
-     *    by Exercise detail screen "Edit default plan" action).
+     *  - [Existing]: edit the plan attached to a persisted exercise / performed-exercise /
+     *    training-exercise row. PlanEditor saves directly to DB and signals the caller via
+     *    [planEditorSavedAttr] = true so the caller can perform a partial reload of
+     *    `(type, plan)` (Exercise) or a full reload (Single-training, Live-workout) on
+     *    resume.
      *
-     * Exactly one of the two must be non-null.
+     *  - [Draft]: edit the plan for an in-flight exercise that is still being created
+     *    (no persisted UUID yet). PlanEditor does NOT touch the DB; on Done it pops back
+     *    with the serialized [PlanDraftResult] JSON via [planEditorDraftResultAttr]. The
+     *    caller merges the result into local state; final persistence happens on the
+     *    caller's own Save.
+     *
+     * Type ownership lives in PlanEditor for both destinations — the WEIGHTED ↔ WEIGHTLESS
+     * toggle and the type-change confirm dialog (with weight-wipe semantics) are the plan
+     * editor's responsibility.
      */
     @Serializable
-    data class PlanEditor(
-        val performedExerciseUuid: String?,
-        val exerciseUuid: String?,
-        val trainingUuid: String?,
-    ) : Screen {
+    @Stable
+    sealed interface PlanEditor : Screen {
+
+        @Serializable
+        data class Existing(
+            val performedExerciseUuid: String?,
+            val exerciseUuid: String?,
+            val trainingUuid: String?,
+        ) : PlanEditor
+
+        @Serializable
+        data class Draft(
+            val initialType: ExerciseTypeUiModel,
+            val initialPlanJson: String?,
+        ) : PlanEditor
 
         companion object {
 
             private const val SAVED_STATE_PLAN_EDITOR_SAVED: String = "plan-editor-saved"
+            private const val SAVED_STATE_PLAN_EDITOR_DRAFT_RESULT: String =
+                "plan-editor-draft-result"
 
             val planEditorSavedAttr = SaveHandlerAttr(SAVED_STATE_PLAN_EDITOR_SAVED, false)
+
+            /**
+             * Carries the serialized [PlanDraftResult] JSON back to a Draft-mode caller.
+             * Default value is `null` so the consumer's `LaunchedEffect(attrValue)` only
+             * fires after a real Done-click writes the JSON in.
+             */
+            val planEditorDraftResultAttr: SaveHandlerAttr<String> =
+                SaveHandlerAttr(SAVED_STATE_PLAN_EDITOR_DRAFT_RESULT, null)
         }
     }
 

--- a/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
+++ b/core/ui/navigation/src/main/kotlin/io.github/stslex/workeeper/core/ui/navigation/Screen.kt
@@ -8,8 +8,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorDraftResultAttr
-import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorSavedAttr
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi

--- a/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/ExerciseTypeUiModel.kt
+++ b/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/ExerciseTypeUiModel.kt
@@ -2,7 +2,9 @@
 package io.github.stslex.workeeper.core.ui.plan_editor.model
 
 import io.github.stslex.workeeper.core.ui.kit.R
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class ExerciseTypeUiModel(
     val labelRes: Int,
 ) {

--- a/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/PlanDraftResult.kt
+++ b/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/PlanDraftResult.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.ui.plan_editor.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Payload returned from a `Screen.PlanEditor.Draft` editor session back to the caller.
+ *
+ * Encoded as a JSON string and carried via `planEditorDraftResultAttr` in the previous
+ * backstack entry's `SavedStateHandle`. The caller decodes the JSON and merges the
+ * `(type, plan)` into its own local state — final persistence happens on the caller's
+ * own Save click.
+ *
+ * Lives in `core/ui/plan-editor` rather than the feature module so PlanEditor (producer)
+ * and the caller features (consumer) share the contract without cross-feature deps.
+ */
+@Serializable
+data class PlanDraftResult(
+    val type: ExerciseTypeUiModel,
+    val plan: List<PlanSetUiModel>,
+)

--- a/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/PlanSetUiModel.kt
+++ b/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/PlanSetUiModel.kt
@@ -2,8 +2,10 @@
 package io.github.stslex.workeeper.core.ui.plan_editor.model
 
 import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
 
 @Stable
+@Serializable
 data class PlanSetUiModel(
     val weight: Double?,
     val reps: Int,

--- a/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/SetTypeUiModel.kt
+++ b/core/ui/plan-editor/src/main/kotlin/io/github/stslex/workeeper/core/ui/plan_editor/model/SetTypeUiModel.kt
@@ -3,7 +3,9 @@ package io.github.stslex.workeeper.core.ui.plan_editor.model
 
 import io.github.stslex.workeeper.core.ui.kit.R
 import io.github.stslex.workeeper.core.ui.kit.components.setchip.SetType
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class SetTypeUiModel(
     val labelRes: Int,
 ) {

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -641,7 +641,9 @@ Detail destinations carry route arguments as value-type fields:
 `Screen.Training(uuid)`, `Screen.Exercise(uuid)`,
 `Screen.LiveWorkout(sessionUuid, trainingUuid)`,
 `Screen.PastSession(sessionUuid)`,
-`Screen.PlanEditor(performedExerciseUuid, exerciseUuid, trainingUuid)`,
+`Screen.PlanEditor.Existing(performedExerciseUuid, exerciseUuid, trainingUuid)` /
+`Screen.PlanEditor.Draft(initialType, initialPlanJson)` — see
+[Plan editor: Existing vs Draft](#plan-editor-existing-vs-draft) below,
 `Screen.ExerciseChart(exerciseUuid)`, `Screen.ExerciseImage(model)`. Pure
 single-instance destinations are `data object` (`Screen.Settings`,
 `Screen.Archive`).
@@ -931,7 +933,7 @@ The mechanics:
 
    LaunchedEffect(attrValue) {
        if (attrValue == true) {
-           processor.consume(Action.Common.Reload)
+           processor.consume(Action.Common.PlanEditorExistingReturned)
            stateHandle.setAttrDefaultValue(Screen.PlanEditor.planEditorSavedAttr)
        }
    }
@@ -950,6 +952,44 @@ attr key + default declared on `Screen.PlanEditor.Companion`.
 
 Currently `Screen.Exercise`, `Screen.Training` (single-training), and
 `Screen.LiveWorkout` consume the PlanEditor saved-result this way.
+
+### Plan editor: Existing vs Draft
+
+`Screen.PlanEditor` is a sealed interface with two destinations that share
+the same `PlanEditorStore` but differ in how they enter and exit:
+
+- **`Screen.PlanEditor.Existing(performedExerciseUuid, exerciseUuid, trainingUuid)`** —
+  the "edit a persisted plan" route. `CommonHandler.Init` reads `(type,
+  plan)` from disk via `PlanEditorInteractor.loadPlan`. On Save the editor
+  persists `(type, plan)` (Mode.Exercise also writes `exercise_table.type`
+  and runs `clearWeightsFromAllPlansForExercise` when type flips to
+  WEIGHTLESS) and pops back with `planEditorSavedAttr = true`. The caller
+  performs a *partial* reload — only `(type, adhocPlan)` are refreshed in
+  parent state — so any unsaved name/description/tag/image edit is
+  preserved (this is the v1.41.0 dirty-baseline regression fix).
+
+- **`Screen.PlanEditor.Draft(initialType, initialPlanJson)`** — the "edit a
+  plan for a brand-new exercise that has no UUID yet" route. `CommonHandler`
+  skips the DB load (`Mode.Draft` has no anchor); the seed comes straight
+  from the route args. On Done the editor encodes a `PlanDraftResult`
+  (`(type, plan)`) as JSON and pops back via `planEditorDraftResultAttr`.
+  The caller decodes the JSON and merges `(type, adhocPlan)` into local
+  state without touching `originalSnapshot` — the draft is treated as an
+  unsaved edit until the parent's own Save fires. PlanEditor.Draft never
+  writes to disk.
+
+Type ownership lives in PlanEditor for both destinations. The toggle and
+the type-change-confirm dialog (with weight-wipe semantics for
+WEIGHTED → WEIGHTLESS flips) are the plan editor's responsibility, not the
+parent form's. `Mode.PerformedExercise` (used by single-training and
+live-workout callsites) hides the toggle — the type lives on the parent
+exercise and isn't editable through a training-scoped editor.
+
+Two separate `composable<Screen.PlanEditor.Existing>` and
+`composable<Screen.PlanEditor.Draft>` destinations register inside
+`planEditorGraph`. A single composable with a polymorphic discriminator
+would also work in theory, but typed-nav route resolution on sealed
+parents has known edge cases — the two-route form is robust.
 
 #### Dispatching navigation from background coroutines
 

--- a/feature/exercise/build.gradle.kts
+++ b/feature/exercise/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation(project(":core:data:database"))
     implementation(project(":core:data:exercise"))
 
+    implementation(libs.kotlinx.serialization.json)
+
     androidTestImplementation(libs.bundles.android.test)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(project(":core:ui:test-utils"))

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseEditScreen.kt
@@ -39,7 +39,6 @@ import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanEditorBodyAction
 import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.ui.components.ImageEditRow
 import io.github.stslex.workeeper.feature.exercise.ui.components.TagPickerInline
-import io.github.stslex.workeeper.feature.exercise.ui.components.TypeToggle
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.State
@@ -125,10 +124,7 @@ internal fun ExerciseEditScreen(
                 }
             }
             FormSection(label = stringResource(R.string.feature_exercise_edit_label_type)) {
-                TypeToggle(
-                    selected = state.type,
-                    onSelect = { type -> consume(Action.Click.OnTypeSelect(type)) },
-                )
+                TypeChipReadOnly(type = state.type)
             }
             FormSection(label = stringResource(R.string.feature_exercise_edit_label_tags)) {
                 TagPickerInline(
@@ -156,6 +152,31 @@ internal fun ExerciseEditScreen(
             Spacer(Modifier.height(AppDimension.Space.md))
         }
         EditActionBar(state = state, consume = consume)
+    }
+}
+
+/**
+ * Read-only display of the current WEIGHTED / WEIGHTLESS type. PlanEditor owns the type
+ * for both Existing and Draft exercises (v1.42.0); the toggle moved with it. The chip
+ * here is purely informational with a hint that the user can change the type from the
+ * plan editor.
+ */
+@Composable
+private fun TypeChipReadOnly(type: ExerciseTypeUiModel) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xxs),
+    ) {
+        Text(
+            modifier = Modifier.testTag("ExerciseTypeReadOnlyChip"),
+            text = stringResource(type.labelRes),
+            style = AppUi.typography.labelLarge,
+            color = AppUi.colors.textPrimary,
+        )
+        Text(
+            text = stringResource(R.string.feature_exercise_edit_type_chip_hint),
+            style = AppUi.typography.bodySmall,
+            color = AppUi.colors.textTertiary,
+        )
     }
 }
 

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
@@ -47,14 +47,34 @@ fun NavGraphBuilder.exerciseGraph(
 ) {
     navComponentScreenWithState(ExerciseFeature) { stateHandle, processor ->
 
-        val attrValue by stateHandle
+        // Existing-mode return: PlanEditor wrote (type, plan) to disk and signaled with
+        // `planEditorSavedAttr = true`. The CommonHandler runs a *partial* reload — only
+        // (type, adhocPlan) are refreshed — so any unsaved name/description/tag/image
+        // edit on this form is preserved (this is the v1.41.0 dirty-baseline regression
+        // fix).
+        val savedAttr by stateHandle
             .getStateFlow(Screen.PlanEditor.planEditorSavedAttr)
             .collectAsState()
-
-        LaunchedEffect(attrValue) {
-            if (attrValue == true) {
-                processor.consume(Action.Common.Reload)
+        LaunchedEffect(savedAttr) {
+            if (savedAttr == true) {
+                processor.consume(Action.Common.PlanEditorExistingReturned)
                 stateHandle.setAttrDefaultValue(Screen.PlanEditor.planEditorSavedAttr)
+            }
+        }
+
+        // Draft-mode return: PlanEditor never touched the DB. The Done click pops back
+        // with the serialized PlanDraftResult JSON in `planEditorDraftResultAttr`. The
+        // CommonHandler decodes the JSON and merges (type, adhocPlan) into State without
+        // updating `originalSnapshot` — the draft is treated as an unsaved edit until the
+        // parent form's own Save fires.
+        val draftAttr by stateHandle
+            .getStateFlow(Screen.PlanEditor.planEditorDraftResultAttr)
+            .collectAsState()
+        LaunchedEffect(draftAttr) {
+            val payload = draftAttr
+            if (payload != null) {
+                processor.consume(Action.Common.PlanEditorDraftReturned(payload))
+                stateHandle.setAttrDefaultValue(Screen.PlanEditor.planEditorDraftResultAttr)
             }
         }
 
@@ -206,15 +226,6 @@ fun NavGraphBuilder.exerciseGraph(
                 confirmLabel = dialog.confirmLabel,
                 onConfirm = { processor.consume(Action.Click.OnConfirmPermanentDelete) },
                 onDismiss = { processor.consume(Action.Click.OnDismissPermanentDelete) },
-            )
-
-            is DialogState.TypeChangeConfirm -> AppConfirmDialog(
-                title = dialog.title,
-                body = dialog.body,
-                impactSummary = dialog.impactSummary,
-                confirmLabel = dialog.confirmLabel,
-                onConfirm = { processor.consume(Action.Click.OnTypeChangeConfirm) },
-                onDismiss = { processor.consume(Action.Click.OnTypeChangeDismiss) },
             )
 
             DialogState.ImageSourcePicker -> ImageSourceDialog(

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandler.kt
@@ -15,6 +15,7 @@ import io.github.stslex.workeeper.core.core.utils.CommonExt.parseOrRandom
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.plan_editor.domain.PlanDraftReducer
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.feature.exercise.R
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
@@ -39,6 +40,8 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import kotlin.uuid.Uuid
 
@@ -74,9 +77,6 @@ internal class ClickHandler @Inject constructor(
             Action.Click.OnConfirmPermanentDelete -> processConfirmPermanentDelete()
             Action.Click.OnDismissPermanentDelete -> processCloseDialog()
             is Action.Click.OnUndoArchive -> processUndoArchive(action)
-            is Action.Click.OnTypeSelect -> processTypeSelect(action)
-            Action.Click.OnTypeChangeConfirm -> processTypeChangeConfirm()
-            Action.Click.OnTypeChangeDismiss -> processTypeChangeDismiss()
             Action.Click.OnEditPlanClick -> processEditPlanClick()
             is Action.Click.OnAdhocPlanEditorAction -> processAdhocPlanEditorAction(action)
             is Action.Click.OnTagToggle -> processTagToggle(action)
@@ -130,6 +130,7 @@ internal class ClickHandler @Inject constructor(
                     type = current.type,
                     description = current.description,
                     tagUuids = current.tags.map { it.uuid },
+                    adhocPlan = current.adhocPlan,
                 ),
             )
         }
@@ -348,6 +349,7 @@ internal class ClickHandler @Inject constructor(
                 type = current.type,
                 description = current.description,
                 tagUuids = current.tags.map { it.uuid },
+                adhocPlan = current.adhocPlan,
             )
             updateStateImmediate { latest ->
                 latest.copy(
@@ -492,82 +494,35 @@ internal class ClickHandler @Inject constructor(
         launch { interactor.restore(action.uuid) }
     }
 
-    private fun processTypeSelect(action: Action.Click.OnTypeSelect) {
-        val current = state.value
-        if (current.type == action.type) return
-        // Switching from WEIGHTED to WEIGHTLESS while weighted plan rows exist would
-        // silently strand weight data once Live workout pre-fills. Surface a confirm so
-        // the user opts in to the multi-row wipe (handled by `processTypeChangeConfirm`).
-        val needsWeightWipe = action.type == ExerciseTypeUiModel.WEIGHTLESS &&
-            current.type == ExerciseTypeUiModel.WEIGHTED &&
-            (current.adhocPlan?.any { it.weight != null } == true)
-        if (needsWeightWipe) {
-            sendEvent(Event.Haptic(HapticFeedbackType.LongPress))
-            // Pre-resolve display strings outside the updateState lambda — Rule 1 of
-            // compose-state-discipline.
-            val title = resourceWrapper.getString(
-                R.string.feature_exercise_edit_type_change_weightless_title,
-            )
-            val body = resourceWrapper.getString(
-                R.string.feature_exercise_edit_type_change_weightless_body,
-            )
-            val impactSummary = resourceWrapper.getString(
-                R.string.feature_exercise_edit_type_change_weightless_impact,
-            )
-            val confirmLabel = resourceWrapper.getString(
-                R.string.feature_exercise_edit_type_change_weightless_confirm,
-            )
-            updateState {
-                it.copy(
-                    pendingTypeChange = action.type,
-                    dialogState = DialogState.TypeChangeConfirm(
-                        title = title,
-                        body = body,
-                        impactSummary = impactSummary,
-                        confirmLabel = confirmLabel,
-                    ),
-                )
-            }
-            return
-        }
-        sendEvent(Event.Haptic(HapticFeedbackType.SegmentTick))
-        updateState { it.copy(type = action.type) }
-    }
-
-    private fun processTypeChangeConfirm() {
-        val current = state.value
-        val pending = current.pendingTypeChange ?: return
-        val uuid = current.uuid
-        sendEvent(Event.Haptic(HapticFeedbackType.LongPress))
-        updateState { latest ->
-            val nextPlan = latest.adhocPlan?.map { it.copy(weight = null) }?.toImmutableList()
-            latest.copy(
-                type = pending,
-                pendingTypeChange = null,
-                dialogState = DialogState.Hidden,
-                adhocPlan = nextPlan,
-                adhocPlanSummaryLabel = nextPlan.toAdhocPlanSummary(resourceWrapper),
-            )
-        }
-        if (uuid == null) return
-        launch {
-            interactor.clearWeightsFromAllPlansForExercise(uuid)
-        }
-    }
-
-    private fun processTypeChangeDismiss() {
-        updateState {
-            it.copy(
-                pendingTypeChange = null,
-                dialogState = DialogState.Hidden,
-            )
-        }
-    }
-
     private fun processEditPlanClick() {
         sendEvent(Event.Haptic(HapticFeedbackType.ContextClick))
-        val uuid = state.value.uuid ?: return
-        consume(Action.Navigation.OpenPlanEditor(exerciseUuid = uuid))
+        val current = state.value
+        val uuid = current.uuid
+        if (uuid != null) {
+            // Existing exercise — PlanEditor saves directly to DB on its own Save,
+            // round-trips a `planEditorSavedAttr = true` signal, and the parent does a
+            // partial reload of (type, adhocPlan).
+            consume(Action.Navigation.OpenPlanEditorExisting(exerciseUuid = uuid))
+            return
+        }
+        // No persisted UUID yet — Draft mode. PlanEditor never touches the DB; on Done
+        // it pops back with the seed merged into local state, and the parent's own Save
+        // is what eventually persists everything to disk.
+        val seedJson = current.adhocPlan
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { plan ->
+                // Use the explicit serializer overload so the call resolves to a
+                // member function rather than the (deprecated-conflicting)
+                // `kotlinx.serialization.encodeToString` extension — see the
+                // MemberExtensionConflict lint and issuetracker.google.com/issues/350432371.
+                Json.encodeToString(ListSerializer(PlanSetUiModel.serializer()), plan.toList())
+            }
+        consume(
+            Action.Navigation.OpenPlanEditorDraft(
+                initialType = current.type,
+                initialPlanJson = seedJson,
+            ),
+        )
     }
 
     private fun processAdhocPlanEditorAction(action: Action.Click.OnAdhocPlanEditorAction) {

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandler.kt
@@ -4,6 +4,7 @@ package io.github.stslex.workeeper.feature.exercise.ui.mvi.handler
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseDomain
@@ -23,6 +24,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
 import java.io.File
 import javax.inject.Inject
 
@@ -36,18 +38,11 @@ internal class CommonHandler @Inject constructor(
     override fun invoke(action: Action.Common) {
         when (action) {
             Action.Common.Init -> processInit()
-            // Reload re-runs the exercise + adhoc-plan load pipeline without resetting form
-            // state. Used after returning from the full-screen PlanEditor route so the
-            // default-plan card and edit-mode plan summary reflect the just-saved draft.
-            Action.Common.Reload -> processReload()
             is Action.Common.ImagePicked -> processImagePicked(action)
             Action.Common.ImagePickCancelled -> processImagePickCancelled()
+            Action.Common.PlanEditorExistingReturned -> processPlanEditorExistingReturned()
+            is Action.Common.PlanEditorDraftReturned -> processPlanEditorDraftReturned(action)
         }
-    }
-
-    private fun processReload() {
-        val uuid = state.value.uuid?.takeIf { it.isNotBlank() } ?: return
-        loadExercise(uuid)
     }
 
     private fun processImagePicked(action: Action.Common.ImagePicked) {
@@ -94,6 +89,64 @@ internal class CommonHandler @Inject constructor(
                 history = history.await(),
                 canPermanentlyDelete = canPermanentlyDelete.await(),
                 adhocPlan = adhocPlan.await(),
+            )
+        }
+    }
+
+    /**
+     * Existing-mode return: PlanEditor wrote `(type, last_adhoc_sets)` to disk. Pull just
+     * those two fields and merge into State + the originalSnapshot baseline so the screen
+     * doesn't think the user has unsaved type/plan edits any more, while name /
+     * description / tags / image stay exactly as the user has them on the form.
+     */
+    private fun processPlanEditorExistingReturned() {
+        val uuid = state.value.uuid?.takeIf { it.isNotBlank() } ?: return
+        launch(
+            onSuccess = { partial ->
+                if (partial.exercise == null) return@launch
+                val newType = partial.exercise.type.toUi()
+                val newPlan = partial.adhocPlan
+                    ?.map { it.toUi() }
+                    ?.toImmutableList()
+                updateStateImmediate { current ->
+                    current.copy(
+                        type = newType,
+                        adhocPlan = newPlan,
+                        adhocPlanSummaryLabel = newPlan.toAdhocPlanSummary(resourceWrapper),
+                        // Reset the dirty baseline so a subsequent Save doesn't re-mark
+                        // type/plan as dirty. Other fields stay untouched.
+                        originalSnapshot = current.originalSnapshot?.copy(
+                            type = newType,
+                            adhocPlan = newPlan,
+                        ),
+                    )
+                }
+            },
+        ) {
+            val exercise = async { interactor.getExercise(uuid) }
+            val adhocPlan = async { interactor.getAdhocPlan(uuid) }
+            PartialReload(
+                exercise = exercise.await(),
+                adhocPlan = adhocPlan.await(),
+            )
+        }
+    }
+
+    /**
+     * Draft-mode return: PlanEditor never persisted anything. Decode the JSON payload and
+     * merge `(type, adhocPlan)` into State. Do NOT update [State.originalSnapshot] —
+     * the draft is treated as an unsaved edit until the parent form's own Save fires.
+     */
+    private fun processPlanEditorDraftReturned(action: Action.Common.PlanEditorDraftReturned) {
+        val result = runCatching {
+            Json.decodeFromString(PlanDraftResult.serializer(), action.resultJson)
+        }.getOrNull() ?: return
+        val plan = result.plan.toImmutableList()
+        updateState { current ->
+            current.copy(
+                type = result.type,
+                adhocPlan = plan,
+                adhocPlanSummaryLabel = plan.toAdhocPlanSummary(resourceWrapper),
             )
         }
     }
@@ -156,6 +209,7 @@ internal class CommonHandler @Inject constructor(
                 type = exercise.type.toUi(),
                 description = exercise.description.orEmpty(),
                 tagUuids = tags.map { it.uuid },
+                adhocPlan = adhocPlan,
             ),
         )
     }
@@ -165,6 +219,11 @@ internal class CommonHandler @Inject constructor(
         val labels: List<String>,
         val history: List<HistoryEntryDomain>,
         val canPermanentlyDelete: Boolean,
+        val adhocPlan: List<PlanSetDomain>?,
+    )
+
+    private data class PartialReload(
+        val exercise: ExerciseDomain?,
         val adhocPlan: List<PlanSetDomain>?,
     )
 }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/NavigationHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/NavigationHandler.kt
@@ -37,11 +37,18 @@ internal class NavigationHandler @Inject constructor(
                 Screen.ExerciseChart(exerciseUuid = action.exerciseUuid),
             )
 
-            is Action.Navigation.OpenPlanEditor -> navigator.navTo(
-                Screen.PlanEditor(
+            is Action.Navigation.OpenPlanEditorExisting -> navigator.navTo(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = null,
                     exerciseUuid = action.exerciseUuid,
                     trainingUuid = null,
+                ),
+            )
+
+            is Action.Navigation.OpenPlanEditorDraft -> navigator.navTo(
+                Screen.PlanEditor.Draft(
+                    initialType = action.initialType,
+                    initialPlanJson = action.initialPlanJson,
                 ),
             )
         }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/DialogState.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/DialogState.kt
@@ -39,19 +39,6 @@ internal sealed interface DialogState {
         val confirmLabel: String,
     ) : DialogState
 
-    /**
-     * "Switching to weightless will clear weights on N plan rows" confirmation. The
-     * pending target type lives in `State.pendingTypeChange` so the confirm handler
-     * knows which value to commit; this variant only carries the dialog payload.
-     */
-    @Stable
-    data class TypeChangeConfirm(
-        val title: String,
-        val body: String,
-        val impactSummary: String,
-        val confirmLabel: String,
-    ) : DialogState
-
     /** Camera-vs-Gallery picker shown after the user taps "Add image". */
     @Stable
     data object ImageSourcePicker : DialogState

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/ExerciseStore.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/ExerciseStore.kt
@@ -42,7 +42,6 @@ internal interface ExerciseStore : Store<State, Action, Event> {
         val adhocPlan: ImmutableList<PlanSetUiModel>?,
         val originalAdhocPlan: ImmutableList<PlanSetUiModel>?,
         val adhocPlanSummaryLabel: String,
-        val pendingTypeChange: ExerciseTypeUiModel?,
         val imagePath: String?,
         val imageLastModified: Long,
         val pendingImage: PendingImage,
@@ -114,12 +113,26 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             val type: ExerciseTypeUiModel,
             val description: String,
             val tagUuids: List<String>,
+            val adhocPlan: ImmutableList<PlanSetUiModel>?,
         ) {
 
             fun matches(state: State): Boolean = state.name == name &&
                 state.type == type &&
                 state.description == description &&
-                state.tags.map { it.uuid } == tagUuids
+                state.tags.map { it.uuid } == tagUuids &&
+                normalizePlan(state.adhocPlan) == normalizePlan(adhocPlan)
+
+            private companion object {
+
+                /**
+                 * Treat `null` and an empty list as equal — both mean "no plan attached".
+                 * Without this, an in-flight edit that toggles between empty list and null
+                 * would falsely register as dirty.
+                 */
+                fun normalizePlan(
+                    plan: ImmutableList<PlanSetUiModel>?,
+                ): ImmutableList<PlanSetUiModel> = plan ?: persistentListOf()
+            }
         }
 
         companion object {
@@ -142,7 +155,6 @@ internal interface ExerciseStore : Store<State, Action, Event> {
                 adhocPlan = null,
                 originalAdhocPlan = null,
                 adhocPlanSummaryLabel = "",
-                pendingTypeChange = null,
                 imagePath = null,
                 imageLastModified = 0L,
                 pendingImage = PendingImage.Unchanged,
@@ -159,17 +171,26 @@ internal interface ExerciseStore : Store<State, Action, Event> {
 
             data object Init : Common
 
-            /**
-             * Reload the exercise + adhoc plan from the repository without resetting form
-             * state. Dispatched after returning from the full-screen PlanEditor route
-             * (D1) so the read-mode default-plan card and edit-mode plan summary reflect
-             * the just-saved draft.
-             */
-            data object Reload : Common
-
             data class ImagePicked(val uri: Uri) : Common
 
             data object ImagePickCancelled : Common
+
+            /**
+             * Dispatched after returning from a `Screen.PlanEditor.Existing` save (DB
+             * round-trip). The handler does a *partial* reload — only `(type, adhocPlan)`
+             * are fetched and merged into State + `originalSnapshot` — so a pending
+             * unsaved name/description/tag/image edit on the parent form is preserved.
+             */
+            data object PlanEditorExistingReturned : Common
+
+            /**
+             * Dispatched after returning from a `Screen.PlanEditor.Draft` Done. The
+             * handler decodes the [io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult]
+             * JSON payload and merges `(type, adhocPlan)` into State without touching
+             * `originalSnapshot` — the draft is treated as an unsaved edit until the
+             * parent form's own Save fires.
+             */
+            data class PlanEditorDraftReturned(val resultJson: String) : Common
         }
 
         sealed interface Click : Action {
@@ -209,12 +230,6 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             data object OnDismissPermanentDelete : Click
 
             data class OnUndoArchive(val uuid: String) : Click
-
-            data class OnTypeSelect(val type: ExerciseTypeUiModel) : Click
-
-            data object OnTypeChangeConfirm : Click
-
-            data object OnTypeChangeDismiss : Click
 
             data object OnEditPlanClick : Click
 
@@ -281,11 +296,26 @@ internal interface ExerciseStore : Store<State, Action, Event> {
             data class OpenChart(val exerciseUuid: String) : Navigation
 
             /**
-             * Open the full-screen plan-editor route for this exercise's default plan
-             * (D1). Returns to ExerciseDetail; the graph picks up the
-             * `plan-editor-saved` flag and dispatches [Action.Common.Reload].
+             * Open `Screen.PlanEditor.Existing` for this exercise's default plan. Used in
+             * Edit mode when the exercise already has a persisted UUID. Returns to
+             * ExerciseDetail; the graph picks up `planEditorSavedAttr` and dispatches
+             * [Action.Common.PlanEditorExistingReturned] for a partial reload of
+             * `(type, adhocPlan)`.
              */
-            data class OpenPlanEditor(val exerciseUuid: String) : Navigation
+            data class OpenPlanEditorExisting(val exerciseUuid: String) : Navigation
+
+            /**
+             * Open `Screen.PlanEditor.Draft` for an in-flight exercise that has not been
+             * persisted yet (creation flow). Returns to ExerciseEditScreen with a
+             * [io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult] JSON
+             * payload via `planEditorDraftResultAttr`; the graph dispatches
+             * [Action.Common.PlanEditorDraftReturned] to merge `(type, adhocPlan)` into
+             * local state.
+             */
+            data class OpenPlanEditorDraft(
+                val initialType: ExerciseTypeUiModel,
+                val initialPlanJson: String?,
+            ) : Navigation
         }
     }
 

--- a/feature/exercise/src/main/res/values-ru/strings.xml
+++ b/feature/exercise/src/main/res/values-ru/strings.xml
@@ -51,11 +51,8 @@
     <string name="feature_exercise_edit_plan_add">+ Добавить план</string>
     <string name="feature_exercise_edit_plan_summary_no_plan">плана пока нет</string>
 
-    <!-- Type change confirmation -->
-    <string name="feature_exercise_edit_type_change_weightless_title">Переключить на без веса?</string>
-    <string name="feature_exercise_edit_type_change_weightless_body">Значения веса из планов этого упражнения будут очищены. Это нельзя отменить.</string>
-    <string name="feature_exercise_edit_type_change_weightless_impact">Все веса в планах очищены</string>
-    <string name="feature_exercise_edit_type_change_weightless_confirm">Переключить</string>
+    <!-- Type chip — read-only on the edit form. The toggle moved into the plan editor (v1.42.0). -->
+    <string name="feature_exercise_edit_type_chip_hint">Меняется в редакторе плана</string>
 
     <!-- Edit exercise — image -->
     <string name="feature_exercise_image_edit_title">Изображение упражнения</string>

--- a/feature/exercise/src/main/res/values/strings.xml
+++ b/feature/exercise/src/main/res/values/strings.xml
@@ -50,11 +50,8 @@
     <string name="feature_exercise_edit_plan_add">+ Add plan</string>
     <string name="feature_exercise_edit_plan_summary_no_plan">no plan yet</string>
 
-    <!-- Type change confirmation -->
-    <string name="feature_exercise_edit_type_change_weightless_title">Switch to weightless?</string>
-    <string name="feature_exercise_edit_type_change_weightless_body">Weight values from this exercise’s plans will be cleared. This cannot be undone.</string>
-    <string name="feature_exercise_edit_type_change_weightless_impact">All plan weights cleared</string>
-    <string name="feature_exercise_edit_type_change_weightless_confirm">Switch</string>
+    <!-- Type chip — read-only on the edit form. The toggle moved into the plan editor (v1.42.0). -->
+    <string name="feature_exercise_edit_type_chip_hint">Change in plan editor</string>
 
     <!-- Edit exercise — image -->
     <string name="feature_exercise_image_edit_title">Exercise image</string>

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandlerTest.kt
@@ -27,9 +27,9 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 
 internal class ClickHandlerTest {
 
@@ -69,66 +69,6 @@ internal class ClickHandlerTest {
     )
 
     @Test
-    fun `OnTypeSelect with same type is no-op`() {
-        val (_, store, handler) = setup()
-        handler.invoke(Action.Click.OnTypeSelect(ExerciseTypeUiModel.WEIGHTED))
-        verify(exactly = 0) { store.sendEvent(any()) }
-    }
-
-    @Test
-    fun `OnTypeSelect with new type emits SegmentTick haptic and updates state`() {
-        val (stateFlow, store, handler) = setup()
-        handler.invoke(Action.Click.OnTypeSelect(ExerciseTypeUiModel.WEIGHTLESS))
-        val captured = slot<Event>()
-        verify { store.sendEvent(capture(captured)) }
-        assertHaptic(captured.captured, HapticFeedbackType.SegmentTick)
-        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.type)
-    }
-
-    @Test
-    fun `OnTypeSelect from WEIGHTED to WEIGHTLESS with weighted plan asks for confirm`() {
-        val (stateFlow, _, handler) = setup(
-            State.create(uuid = "uuid-1").copy(
-                type = ExerciseTypeUiModel.WEIGHTED,
-                adhocPlan = persistentListOf(
-                    PlanSetUiModel(weight = 50.0, reps = 8, type = SetTypeUiModel.WORK),
-                ),
-            ),
-        )
-        handler.invoke(Action.Click.OnTypeSelect(ExerciseTypeUiModel.WEIGHTLESS))
-        assertTrue(stateFlow.value.dialogState is DialogState.TypeChangeConfirm)
-        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
-        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.pendingTypeChange)
-    }
-
-    @Test
-    fun `OnTypeChangeConfirm wipes weights from adhoc plan`() {
-        val (stateFlow, _, handler) = setup(
-            State.create(uuid = null).copy(
-                type = ExerciseTypeUiModel.WEIGHTED,
-                pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS,
-                adhocPlan = persistentListOf(
-                    PlanSetUiModel(weight = 50.0, reps = 8, type = SetTypeUiModel.WORK),
-                    PlanSetUiModel(weight = 60.0, reps = 6, type = SetTypeUiModel.FAILURE),
-                ),
-            ),
-        )
-        handler.invoke(Action.Click.OnTypeChangeConfirm)
-        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.type)
-        assertEquals(null, stateFlow.value.pendingTypeChange)
-        assertTrue(stateFlow.value.adhocPlan?.all { it.weight == null } == true)
-    }
-
-    @Test
-    fun `OnTypeChangeDismiss clears pending type change`() {
-        val (stateFlow, _, handler) = setup(
-            State.create(uuid = null).copy(pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS),
-        )
-        handler.invoke(Action.Click.OnTypeChangeDismiss)
-        assertNull(stateFlow.value.pendingTypeChange)
-    }
-
-    @Test
     fun `OnSaveClick with blank name sets nameError without saving`() {
         val (stateFlow, store, handler) = setup(State.create(uuid = null).copy(name = ""))
         handler.invoke(Action.Click.OnSaveClick)
@@ -152,19 +92,52 @@ internal class ClickHandlerTest {
     }
 
     @Test
-    fun `OnEditPlanClick navigates to PlanEditor route`() {
+    fun `OnEditPlanClick on existing exercise navigates to PlanEditor Existing`() {
         val (_, store, handler) = setup()
         handler.invoke(Action.Click.OnEditPlanClick)
         verify(exactly = 1) {
-            store.consume(Action.Navigation.OpenPlanEditor(exerciseUuid = "uuid-1"))
+            store.consume(
+                Action.Navigation.OpenPlanEditorExisting(exerciseUuid = "uuid-1"),
+            )
         }
     }
 
     @Test
-    fun `OnEditPlanClick is a no-op when uuid is null`() {
-        val (_, store, handler) = setup(State.create(uuid = null))
+    fun `OnEditPlanClick on Draft exercise navigates with empty seed`() {
+        val (_, store, handler) = setup(
+            State.create(uuid = null).copy(type = ExerciseTypeUiModel.WEIGHTLESS),
+        )
         handler.invoke(Action.Click.OnEditPlanClick)
-        verify(exactly = 0) { store.consume(any<Action.Navigation.OpenPlanEditor>()) }
+        verify(exactly = 1) {
+            store.consume(
+                Action.Navigation.OpenPlanEditorDraft(
+                    initialType = ExerciseTypeUiModel.WEIGHTLESS,
+                    initialPlanJson = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `OnEditPlanClick on Draft exercise serializes a non-empty plan into the seed`() {
+        val draft = listOf(
+            PlanSetUiModel(weight = 80.0, reps = 8, type = SetTypeUiModel.WORK),
+            PlanSetUiModel(weight = 90.0, reps = 5, type = SetTypeUiModel.WORK),
+        )
+        val (_, store, handler) = setup(
+            State.create(uuid = null).copy(
+                type = ExerciseTypeUiModel.WEIGHTED,
+                adhocPlan = persistentListOf<PlanSetUiModel>().addAll(draft),
+            ),
+        )
+        handler.invoke(Action.Click.OnEditPlanClick)
+        val captured = slot<Action.Navigation.OpenPlanEditorDraft>()
+        verify(exactly = 1) { store.consume(capture(captured)) }
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, captured.captured.initialType)
+        val decoded = kotlinx.serialization.json.Json.decodeFromString<List<PlanSetUiModel>>(
+            captured.captured.initialPlanJson!!,
+        )
+        assertEquals(draft, decoded)
     }
 
     @Test
@@ -279,6 +252,7 @@ internal class ClickHandlerTest {
                     type = ExerciseTypeUiModel.WEIGHTED,
                     description = "",
                     tagUuids = emptyList(),
+                    adhocPlan = null,
                 ),
             ),
         )
@@ -309,6 +283,7 @@ internal class ClickHandlerTest {
                     type = ExerciseTypeUiModel.WEIGHTED,
                     description = "",
                     tagUuids = emptyList(),
+                    adhocPlan = null,
                 ),
             ),
         )
@@ -556,22 +531,5 @@ internal class ClickHandlerTest {
         val events = mutableListOf<Event>()
         verify { store.sendEvent(capture(events)) }
         assertTrue((store.state.value.dialogState as? DialogState.DiscardConfirm)?.target == DiscardTarget.POP_SCREEN)
-    }
-
-    @Test
-    fun `OnEditPlanClick still navigates to full-screen route in edit-mode for existing exercise`() {
-        // Read-mode "Edit default plan" card — preserved from the v2.4 D1 migration.
-        val (_, store, handler) = setup(State.create(uuid = "uuid-1"))
-
-        handler.invoke(Action.Click.OnEditPlanClick)
-
-        verify(exactly = 1) {
-            store.consume(Action.Navigation.OpenPlanEditor(exerciseUuid = "uuid-1"))
-        }
-    }
-
-    private fun assertHaptic(event: Event, expected: HapticFeedbackType) {
-        assertTrue(event is Event.Haptic, "expected Event.Haptic but got $event")
-        assertEquals(expected, (event as Event.Haptic).type)
     }
 }

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandlerTest.kt
@@ -3,19 +3,29 @@ package io.github.stslex.workeeper.feature.exercise.ui.mvi.handler
 
 import android.net.Uri
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.PendingImage
+import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.State
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class CommonHandlerTest {
@@ -76,5 +86,89 @@ internal class CommonHandlerTest {
 
         assertEquals(PendingImage.Unchanged, stateFlow.value.pendingImage)
         assertEquals(DialogState.Hidden, stateFlow.value.dialogState)
+    }
+
+    @Test
+    fun `PlanEditorDraftReturned merges the JSON payload into State without resetting baseline`() {
+        // Arrange a State with some pending edits that must be preserved (no
+        // originalSnapshot — i.e. create-mode where Snapshot is null until first Save).
+        val originalName = "Bench"
+        val (stateFlow, handler) = setup(
+            State.create(uuid = null).copy(
+                name = originalName,
+                type = ExerciseTypeUiModel.WEIGHTED,
+                adhocPlan = null,
+            ),
+        )
+        val payload = PlanDraftResult(
+            type = ExerciseTypeUiModel.WEIGHTLESS,
+            plan = listOf(PlanSetUiModel(weight = null, reps = 8, type = SetTypeUiModel.WORK)),
+        )
+
+        handler.invoke(Action.Common.PlanEditorDraftReturned(Json.encodeToString(payload)))
+
+        // (type, adhocPlan) merge in.
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.type)
+        assertNotNull(stateFlow.value.adhocPlan)
+        assertEquals(payload.plan, stateFlow.value.adhocPlan?.toList())
+        // Other fields untouched.
+        assertEquals(originalName, stateFlow.value.name)
+        // Baseline (originalSnapshot) untouched — Draft is treated as an unsaved edit
+        // until the parent's own Save fires.
+        assertNull(stateFlow.value.originalSnapshot)
+    }
+
+    @Test
+    fun `PlanEditorDraftReturned with malformed JSON is silently skipped`() {
+        val (stateFlow, handler) = setup(
+            State.create(uuid = null).copy(
+                type = ExerciseTypeUiModel.WEIGHTED,
+                adhocPlan = persistentListOf(),
+            ),
+        )
+
+        handler.invoke(Action.Common.PlanEditorDraftReturned("not-json"))
+
+        // State unchanged — broken inputs don't corrupt the working draft.
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
+        assertTrue(stateFlow.value.adhocPlan?.isEmpty() == true)
+    }
+
+    @Test
+    fun `PlanEditorExistingReturned with no uuid is a no-op`() {
+        // Defence-in-depth: PlanEditorExistingReturned can only fire when the parent has
+        // a persisted UUID, but the handler must short-circuit if invoked without one.
+        val (stateFlow, handler) = setup(
+            State.create(uuid = null).copy(name = "Bench"),
+        )
+
+        handler.invoke(Action.Common.PlanEditorExistingReturned)
+
+        assertEquals("Bench", stateFlow.value.name)
+    }
+
+    @Test
+    fun `PlanEditorExistingReturned preserves baseline shape with adhocPlan and type fields`() {
+        // Pin the contract: State.Snapshot now carries adhocPlan + type. The
+        // partial-reload path (Phase 6) updates these fields on the snapshot so a
+        // following parent.Save doesn't see a phantom dirty diff.
+        val baseline = State.Snapshot(
+            name = "Bench",
+            type = ExerciseTypeUiModel.WEIGHTED,
+            description = "",
+            tagUuids = emptyList(),
+            adhocPlan = null,
+        )
+        val (stateFlow, _) = setup(
+            State.create(uuid = "uuid-1").copy(
+                name = "Bench",
+                originalSnapshot = baseline,
+                tags = persistentListOf<TagUiModel>(),
+            ),
+        )
+
+        // Verify pre-conditions: snapshot does include the new fields.
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.originalSnapshot?.type)
+        assertNull(stateFlow.value.originalSnapshot?.adhocPlan)
     }
 }

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/NavigationHandlerTest.kt
@@ -3,6 +3,7 @@ package io.github.stslex.workeeper.feature.exercise.ui.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
 import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Action
 import io.mockk.mockk
 import io.mockk.verify
@@ -51,14 +52,32 @@ internal class NavigationHandlerTest {
     }
 
     @Test
-    fun `OpenPlanEditor navigates to Screen PlanEditor with the exercise scope`() {
-        handler.invoke(Action.Navigation.OpenPlanEditor(exerciseUuid = "ex-1"))
+    fun `OpenPlanEditorExisting navigates to Screen PlanEditor Existing with exercise scope`() {
+        handler.invoke(Action.Navigation.OpenPlanEditorExisting(exerciseUuid = "ex-1"))
         verify(exactly = 1) {
             navigator.navTo(
-                Screen.PlanEditor(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = null,
                     exerciseUuid = "ex-1",
                     trainingUuid = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `OpenPlanEditorDraft navigates to Screen PlanEditor Draft carrying the seed`() {
+        handler.invoke(
+            Action.Navigation.OpenPlanEditorDraft(
+                initialType = ExerciseTypeUiModel.WEIGHTLESS,
+                initialPlanJson = "[]",
+            ),
+        )
+        verify(exactly = 1) {
+            navigator.navTo(
+                Screen.PlanEditor.Draft(
+                    initialType = ExerciseTypeUiModel.WEIGHTLESS,
+                    initialPlanJson = "[]",
                 ),
             )
         }

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandler.kt
@@ -22,7 +22,7 @@ internal class NavigationHandler @Inject constructor(
 
             is Action.Navigation.OpenPlanEditor ->
                 navigator.navTo(
-                    Screen.PlanEditor(
+                    Screen.PlanEditor.Existing(
                         performedExerciseUuid = action.performedExerciseUuid,
                         exerciseUuid = action.exerciseUuid,
                         trainingUuid = action.trainingUuid,

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/NavigationHandlerTest.kt
@@ -28,7 +28,7 @@ internal class NavigationHandlerTest {
     }
 
     @Test
-    fun `OpenPlanEditor navigates to Screen PlanEditor with the live-workout scope`() {
+    fun `OpenPlanEditor navigates to Screen PlanEditor Existing with the live-workout scope`() {
         handler.invoke(
             Action.Navigation.OpenPlanEditor(
                 performedExerciseUuid = "performed-1",
@@ -38,7 +38,7 @@ internal class NavigationHandlerTest {
         )
         verify(exactly = 1) {
             navigator.navTo(
-                Screen.PlanEditor(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = "performed-1",
                     exerciseUuid = "ex-1",
                     trainingUuid = "training-1",
@@ -58,7 +58,7 @@ internal class NavigationHandlerTest {
         )
         verify(exactly = 1) {
             navigator.navTo(
-                Screen.PlanEditor(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = "performed-1",
                     exerciseUuid = "ex-1",
                     trainingUuid = null,

--- a/feature/plan-editor/build.gradle.kts
+++ b/feature/plan-editor/build.gradle.kts
@@ -10,4 +10,6 @@ dependencies {
     implementation(project(":core:ui:plan-editor"))
     implementation(project(":core:data:database"))
     implementation(project(":core:data:exercise"))
+
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/PlanEditorInteractor.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/PlanEditorInteractor.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.plan_editor.domain
 
+import io.github.stslex.workeeper.feature.plan_editor.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanEditorLoadResult
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanSetDomain
 
@@ -9,18 +10,28 @@ internal interface PlanEditorInteractor {
     /**
      * Loads exercise metadata + initial plan. When [trainingUuid] is null the plan is read
      * from `exercise_table.last_adhoc_sets`; otherwise from
-     * `training_exercise_table.plan_sets` for the (training, exercise) pair.
+     * `training_exercise_table.plan_sets` for the (training, exercise) pair. The exercise's
+     * own `type` is always returned (it's the source of truth for both
+     * `last_adhoc_sets` and any plan_sets row in a training, since training-exercise rows
+     * inherit shape from the parent exercise).
      */
     suspend fun loadPlan(exerciseUuid: String, trainingUuid: String?): PlanEditorLoadResult
 
     /**
-     * Persists [plan] (or null to clear) to the appropriate backing store.
-     * Symmetric with [loadPlan]: when [trainingUuid] is null writes to
-     * `last_adhoc_sets`; otherwise to `plan_sets` on `training_exercise_table`.
+     * Persists [plan] (or null to clear) to the appropriate backing store, plus the
+     * [type] when [trainingUuid] is null (i.e. Mode.Exercise — PlanEditor owns the type
+     * for the parent exercise). For Mode.PerformedExercise the [type] is ignored — the
+     * type lives on the parent exercise and isn't editable through a training-scoped
+     * editor.
+     *
+     * When [type] flips a Mode.Exercise from WEIGHTED to WEIGHTLESS the implementation
+     * also wipes weights from every plan_sets row that references this exercise so
+     * weighted plan values do not survive the type change.
      */
     suspend fun savePlan(
         exerciseUuid: String,
         trainingUuid: String?,
+        type: ExerciseTypeDomain,
         plan: List<PlanSetDomain>?,
     )
 }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/PlanEditorInteractorImpl.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/PlanEditorInteractorImpl.kt
@@ -5,9 +5,9 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.DefaultDispatcher
 import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.training.TrainingExerciseRepository
-import io.github.stslex.workeeper.feature.plan_editor.domain.mapper.PlanEditorDomainMapper.isWeighted
 import io.github.stslex.workeeper.feature.plan_editor.domain.mapper.PlanEditorDomainMapper.toData
 import io.github.stslex.workeeper.feature.plan_editor.domain.mapper.PlanEditorDomainMapper.toDomain
+import io.github.stslex.workeeper.feature.plan_editor.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanEditorLoadResult
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanSetDomain
 import kotlinx.coroutines.CoroutineDispatcher
@@ -34,7 +34,7 @@ internal class PlanEditorInteractorImpl @Inject constructor(
         }
         PlanEditorLoadResult.Success(
             exerciseName = exercise.name,
-            isWeighted = exercise.type.isWeighted(),
+            type = exercise.type.toDomain(),
             plan = plan.map { it.toDomain() },
         )
     }
@@ -42,13 +42,25 @@ internal class PlanEditorInteractorImpl @Inject constructor(
     override suspend fun savePlan(
         exerciseUuid: String,
         trainingUuid: String?,
+        type: ExerciseTypeDomain,
         plan: List<PlanSetDomain>?,
     ) {
         withContext(defaultDispatcher) {
             val data = plan?.map { it.toData() }
             if (trainingUuid.isNullOrBlank()) {
+                // Mode.Exercise — PlanEditor owns the type for the parent exercise. Persist
+                // the type first so a concurrent reader who hits last_adhoc_sets sees the
+                // matching `type` column. When the type flips to WEIGHTLESS, also wipe
+                // weights from every other plan_sets row that references this exercise so
+                // weighted plan values do not survive the type change.
+                exerciseRepository.setExerciseType(exerciseUuid, type.toData())
+                if (type == ExerciseTypeDomain.WEIGHTLESS) {
+                    exerciseRepository.clearWeightsFromAllPlansForExercise(exerciseUuid)
+                }
                 exerciseRepository.setAdhocPlan(exerciseUuid, data)
             } else {
+                // Mode.PerformedExercise — type lives on the parent exercise and isn't
+                // editable from a training-scoped editor. Only the plan_sets row changes.
                 trainingExerciseRepository.setPlan(trainingUuid, exerciseUuid, data)
             }
         }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/mapper/PlanEditorDomainMapper.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/mapper/PlanEditorDomainMapper.kt
@@ -4,12 +4,21 @@ package io.github.stslex.workeeper.feature.plan_editor.domain.mapper
 import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
 import io.github.stslex.workeeper.core.data.database.sets.SetTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
+import io.github.stslex.workeeper.feature.plan_editor.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanSetDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.SetTypeDomain
 
 internal object PlanEditorDomainMapper {
 
-    fun ExerciseTypeDataModel.isWeighted(): Boolean = this == ExerciseTypeDataModel.WEIGHTED
+    fun ExerciseTypeDataModel.toDomain(): ExerciseTypeDomain = when (this) {
+        ExerciseTypeDataModel.WEIGHTED -> ExerciseTypeDomain.WEIGHTED
+        ExerciseTypeDataModel.WEIGHTLESS -> ExerciseTypeDomain.WEIGHTLESS
+    }
+
+    fun ExerciseTypeDomain.toData(): ExerciseTypeDataModel = when (this) {
+        ExerciseTypeDomain.WEIGHTED -> ExerciseTypeDataModel.WEIGHTED
+        ExerciseTypeDomain.WEIGHTLESS -> ExerciseTypeDataModel.WEIGHTLESS
+    }
 
     fun PlanSetDataModel.toDomain(): PlanSetDomain = PlanSetDomain(
         weight = weight,

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/model/ExerciseTypeDomain.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/model/ExerciseTypeDomain.kt
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.plan_editor.domain.model
+
+internal enum class ExerciseTypeDomain {
+    WEIGHTED,
+    WEIGHTLESS,
+}

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/model/PlanEditorLoadResult.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/domain/model/PlanEditorLoadResult.kt
@@ -5,7 +5,7 @@ internal sealed interface PlanEditorLoadResult {
 
     data class Success(
         val exerciseName: String,
-        val isWeighted: Boolean,
+        val type: ExerciseTypeDomain,
         val plan: List<PlanSetDomain>,
     ) : PlanEditorLoadResult
 

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/PlanEditorGraph.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/PlanEditorGraph.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.plan_editor.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -9,51 +10,70 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.kit.snackbar.AppSnackbarModel
 import io.github.stslex.workeeper.core.ui.kit.snackbar.SnackbarManager
-import io.github.stslex.workeeper.core.ui.mvi.navComponentScreen
+import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.core.ui.navigation.navScreen
 import io.github.stslex.workeeper.feature.plan_editor.di.PlanEditorFeature
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.ErrorType
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Event
 
 /**
- * Registers the plan editor route. The screen carries unsaved-state interception via
- * `BackHandler(enabled = state.interceptBack)`; when intercepted, it dispatches
- * `Action.Click.OnBackClick` which the click handler routes to either Pop or
- * Discard-confirm-dialog depending on dirty state.
+ * Registers the two plan editor destinations:
+ *
+ *  - [Screen.PlanEditor.Existing] — DB-backed; persists `(type, plan)` to disk on Save
+ *    and signals the caller via `planEditorSavedAttr`.
+ *  - [Screen.PlanEditor.Draft] — in-memory; pops back with the draft as
+ *    `PlanDraftResult` JSON via `planEditorDraftResultAttr` for the caller to merge into
+ *    its local state.
+ *
+ * Two separate `composable<...>` blocks (rather than one with a polymorphic discriminator)
+ * keep route resolution simple — typed-nav has known edge cases on sealed parents.
  */
 fun NavGraphBuilder.planEditorGraph(
     modifier: Modifier = Modifier,
 ) {
-    navComponentScreen(PlanEditorFeature) { processor ->
-        val haptic = LocalHapticFeedback.current
-        val state by processor.state
-        // Pre-resolve error copy in composable scope so the suspend Handle lambda below
-        // does not call `Context.getString` (Lint: LocalContextGetResourceValueCall).
-        val loadFailedMessage = stringResource(ErrorType.LoadFailed.msgRes)
-        val saveFailedMessage = stringResource(ErrorType.SaveFailed.msgRes)
-
-        processor.Handle { event ->
-            when (event) {
-                is Event.HapticClick -> haptic.performHapticFeedback(event.type)
-                is Event.ShowError -> SnackbarManager.showSnackbar(
-                    AppSnackbarModel(
-                        message = when (event.type) {
-                            ErrorType.LoadFailed -> loadFailedMessage
-                            ErrorType.SaveFailed -> saveFailedMessage
-                        },
-                    ),
-                )
-            }
-        }
-
-        BackHandler(enabled = state.interceptBack) {
-            processor.consume(Action.Click.OnBackClick)
-        }
-
-        PlanEditorScreen(
-            modifier = modifier,
-            state = state,
-            consume = processor::consume,
-        )
+    navScreen<Screen.PlanEditor.Existing> { screen ->
+        PlanEditorContent(modifier = modifier, screen = screen)
     }
+    navScreen<Screen.PlanEditor.Draft> { screen ->
+        PlanEditorContent(modifier = modifier, screen = screen)
+    }
+}
+
+@Composable
+private fun PlanEditorContent(
+    modifier: Modifier,
+    screen: Screen.PlanEditor,
+) {
+    val processor = PlanEditorFeature.processor(screen)
+    val haptic = LocalHapticFeedback.current
+    val state by processor.state
+    // Pre-resolve error copy in composable scope so the suspend Handle lambda below
+    // does not call `Context.getString` (Lint: LocalContextGetResourceValueCall).
+    val loadFailedMessage = stringResource(ErrorType.LoadFailed.msgRes)
+    val saveFailedMessage = stringResource(ErrorType.SaveFailed.msgRes)
+
+    processor.Handle { event ->
+        when (event) {
+            is Event.HapticClick -> haptic.performHapticFeedback(event.type)
+            is Event.ShowError -> SnackbarManager.showSnackbar(
+                AppSnackbarModel(
+                    message = when (event.type) {
+                        ErrorType.LoadFailed -> loadFailedMessage
+                        ErrorType.SaveFailed -> saveFailedMessage
+                    },
+                ),
+            )
+        }
+    }
+
+    BackHandler(enabled = state.interceptBack) {
+        processor.consume(Action.Click.OnBackClick)
+    }
+
+    PlanEditorScreen(
+        modifier = modifier,
+        state = state,
+        consume = processor::consume,
+    )
 }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/PlanEditorScreen.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/PlanEditorScreen.kt
@@ -34,15 +34,21 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.plan_editor.PlanEditorBody
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.plan_editor.R
+import io.github.stslex.workeeper.feature.plan_editor.ui.components.TypeToggle
+import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State
+import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State.Mode
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import io.github.stslex.workeeper.core.ui.kit.R as KitR
 
@@ -58,6 +64,11 @@ internal fun PlanEditorScreen(
         stringResource(R.string.core_ui_plan_editor_screen_title_default)
     } else {
         stringResource(R.string.core_ui_plan_editor_screen_title_format, state.exerciseName)
+    }
+    val saveLabel = if (state.mode is Mode.Draft) {
+        stringResource(R.string.feature_plan_editor_action_done)
+    } else {
+        stringResource(R.string.core_ui_plan_editor_screen_save)
     }
     Scaffold(
         modifier = modifier
@@ -99,6 +110,7 @@ internal fun PlanEditorScreen(
         bottomBar = {
             PlanEditorActionBar(
                 isSaving = state.isSaving,
+                saveLabel = saveLabel,
                 onCancel = { consume(Action.Click.OnBackClick) },
                 onSave = { consume(Action.Click.OnSave) },
             )
@@ -114,6 +126,24 @@ internal fun PlanEditorScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             PlanEditorHeader(exerciseName = state.exerciseName)
+            // Type toggle is editable from PlanEditor whenever the type ownership is the
+            // editor's own concern (Mode.Exercise — owns parent exercise.type, Mode.Draft —
+            // seeds the in-flight exercise's type). Mode.PerformedExercise renders nothing
+            // here: type lives on the parent exercise and isn't editable through a
+            // training-scoped editor.
+            if (state.mode is Mode.Exercise || state.mode is Mode.Draft) {
+                Spacer(Modifier.height(AppDimension.Space.lg))
+                Text(
+                    text = stringResource(R.string.feature_plan_editor_label_type),
+                    style = AppUi.typography.labelSmall,
+                    color = AppUi.colors.textTertiary,
+                )
+                Spacer(Modifier.height(AppDimension.Space.xs))
+                TypeToggle(
+                    selected = state.type,
+                    onSelect = { type -> consume(Action.Click.OnTypeToggle(type)) },
+                )
+            }
             Spacer(Modifier.height(AppDimension.Space.lg))
             PlanEditorBody(
                 draft = state.draft,
@@ -141,6 +171,19 @@ internal fun PlanEditorScreen(
                 onSave = { consume(Action.Click.OnConfirmSave) },
                 onDiscard = { consume(Action.Click.OnConfirmDiscard) },
                 onContinue = { consume(Action.Click.OnDismissDiscard) },
+            )
+        }
+
+        when (val dialog = state.dialogState) {
+            DialogState.Hidden -> Unit
+
+            is DialogState.TypeChangeConfirm -> AppConfirmDialog(
+                title = dialog.title,
+                body = dialog.body,
+                impactSummary = dialog.impactSummary,
+                confirmLabel = dialog.confirmLabel,
+                onConfirm = { consume(Action.Click.OnTypeChangeConfirm) },
+                onDismiss = { consume(Action.Click.OnTypeChangeDismiss) },
             )
         }
     }
@@ -215,6 +258,7 @@ private fun DiscardDialog(
 @Composable
 private fun PlanEditorActionBar(
     isSaving: Boolean,
+    saveLabel: String,
     onCancel: () -> Unit,
     onSave: () -> Unit,
 ) {
@@ -240,7 +284,7 @@ private fun PlanEditorActionBar(
             modifier = Modifier
                 .weight(1f)
                 .testTag("PlanEditorSave"),
-            text = stringResource(R.string.core_ui_plan_editor_screen_save),
+            text = saveLabel,
             onClick = onSave,
             size = AppButtonSize.MEDIUM,
             enabled = !isSaving,
@@ -278,16 +322,19 @@ private fun PlanEditorScreenPreview() {
                 mode = State.Mode.Exercise(exerciseUuid = "uuid"),
                 isLoading = false,
                 exerciseName = "Bench press",
-                isWeighted = true,
-                initialDraft = listOf<PlanSetUiModel>().toImmutableList(),
+                type = ExerciseTypeUiModel.WEIGHTED,
+                initialDraft = persistentListOf(),
                 draft = listOf(
                     PlanSetUiModel(60.0, 10, SetTypeUiModel.WARMUP),
                     PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
                     PlanSetUiModel(100.0, 5, SetTypeUiModel.WORK),
                     PlanSetUiModel(85.0, 6, SetTypeUiModel.FAILURE),
                 ).toImmutableList(),
+                initialType = ExerciseTypeUiModel.WEIGHTED,
+                pendingTypeChange = null,
                 confirmDiscardOpen = false,
                 isSaving = false,
+                dialogState = DialogState.Hidden,
             ),
             consume = {},
         )

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/components/TypeToggle.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/components/TypeToggle.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-package io.github.stslex.workeeper.feature.exercise.ui.components
+package io.github.stslex.workeeper.feature.plan_editor.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,7 +33,7 @@ internal fun TypeToggle(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .testTag("ExerciseTypeToggle"),
+            .testTag("PlanEditorTypeToggle"),
         horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
     ) {
         TypeOption(
@@ -42,7 +42,7 @@ internal fun TypeToggle(
             onClick = { onSelect(ExerciseTypeUiModel.WEIGHTED) },
             modifier = Modifier
                 .weight(1f)
-                .testTag("ExerciseTypeOption_WEIGHTED"),
+                .testTag("PlanEditorTypeOption_WEIGHTED"),
         )
         TypeOption(
             label = stringResource(ExerciseTypeUiModel.WEIGHTLESS.labelRes),
@@ -50,7 +50,7 @@ internal fun TypeToggle(
             onClick = { onSelect(ExerciseTypeUiModel.WEIGHTLESS) },
             modifier = Modifier
                 .weight(1f)
-                .testTag("ExerciseTypeOption_WEIGHTLESS"),
+                .testTag("PlanEditorTypeOption_WEIGHTLESS"),
         )
     }
 }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mapper/PlanEditorMapper.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mapper/PlanEditorMapper.kt
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.plan_editor.ui.mapper
 
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.plan_editor.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.PlanSetDomain
 import io.github.stslex.workeeper.feature.plan_editor.domain.model.SetTypeDomain
 
 internal object PlanEditorMapper {
+
+    fun ExerciseTypeDomain.toUi(): ExerciseTypeUiModel = when (this) {
+        ExerciseTypeDomain.WEIGHTED -> ExerciseTypeUiModel.WEIGHTED
+        ExerciseTypeDomain.WEIGHTLESS -> ExerciseTypeUiModel.WEIGHTLESS
+    }
+
+    fun ExerciseTypeUiModel.toDomain(): ExerciseTypeDomain = when (this) {
+        ExerciseTypeUiModel.WEIGHTED -> ExerciseTypeDomain.WEIGHTED
+        ExerciseTypeUiModel.WEIGHTLESS -> ExerciseTypeDomain.WEIGHTLESS
+    }
 
     fun PlanSetDomain.toUi(): PlanSetUiModel = PlanSetUiModel(
         weight = weight,

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/ClickHandler.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/ClickHandler.kt
@@ -3,23 +3,31 @@ package io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler
 
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import dagger.hilt.android.scopes.ViewModelScoped
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.plan_editor.domain.PlanDraftReducer
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanEditorBodyAction
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
+import io.github.stslex.workeeper.feature.plan_editor.R
 import io.github.stslex.workeeper.feature.plan_editor.di.PlanEditorHandlerStore
 import io.github.stslex.workeeper.feature.plan_editor.domain.PlanEditorInteractor
 import io.github.stslex.workeeper.feature.plan_editor.ui.mapper.PlanEditorMapper.toDomain
+import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.ErrorType
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Event
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State.Mode
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
 @ViewModelScoped
 internal class ClickHandler @Inject constructor(
     private val interactor: PlanEditorInteractor,
+    private val resourceWrapper: ResourceWrapper,
     store: PlanEditorHandlerStore,
 ) : Handler<Action.Click>, PlanEditorHandlerStore by store {
 
@@ -27,12 +35,15 @@ internal class ClickHandler @Inject constructor(
         when (action) {
             Action.Click.OnAddSet -> processAddSet()
             is Action.Click.OnSetRemove -> processRemove(action.index)
-            is Action.Click.OnSetTypeChange -> processTypeChange(action.index, action.value)
+            is Action.Click.OnSetTypeChange -> processSetTypeChange(action.index, action.value)
+            is Action.Click.OnTypeToggle -> processTypeToggle(action.target)
+            Action.Click.OnTypeChangeConfirm -> processTypeChangeConfirm()
+            Action.Click.OnTypeChangeDismiss -> processTypeChangeDismiss()
             Action.Click.OnSave -> processSave()
             Action.Click.OnBackClick -> processBack()
             Action.Click.OnConfirmDiscard -> processDiscard()
             Action.Click.OnConfirmSave -> processConfirmSave()
-            Action.Click.OnDismissDiscard -> processDismissDialog()
+            Action.Click.OnDismissDiscard -> processDismissDiscard()
         }
     }
 
@@ -62,7 +73,7 @@ internal class ClickHandler @Inject constructor(
         }
     }
 
-    private fun processTypeChange(index: Int, value: SetTypeUiModel) {
+    private fun processSetTypeChange(index: Int, value: SetTypeUiModel) {
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
         updateState { current ->
             current.copy(
@@ -75,7 +86,76 @@ internal class ClickHandler @Inject constructor(
         }
     }
 
+    private fun processTypeToggle(target: ExerciseTypeUiModel) {
+        val current = state.value
+        if (current.type == target) return
+        // Switching from WEIGHTED to WEIGHTLESS while weighted draft rows exist would
+        // silently strand weight data. Surface a confirm so the user opts in to the wipe.
+        val needsWeightWipe = target == ExerciseTypeUiModel.WEIGHTLESS &&
+            current.type == ExerciseTypeUiModel.WEIGHTED &&
+            current.draft.any { it.weight != null }
+        if (needsWeightWipe) {
+            sendEvent(Event.HapticClick(HapticFeedbackType.LongPress))
+            // Pre-resolve display strings outside the updateState lambda — Rule 1 of
+            // compose-state-discipline.
+            val title = resourceWrapper.getString(
+                R.string.feature_plan_editor_type_change_weightless_title,
+            )
+            val body = resourceWrapper.getString(
+                R.string.feature_plan_editor_type_change_weightless_body,
+            )
+            val impactSummary = resourceWrapper.getString(
+                R.string.feature_plan_editor_type_change_weightless_impact,
+            )
+            val confirmLabel = resourceWrapper.getString(
+                R.string.feature_plan_editor_type_change_weightless_confirm,
+            )
+            updateState {
+                it.copy(
+                    pendingTypeChange = target,
+                    dialogState = DialogState.TypeChangeConfirm(
+                        title = title,
+                        body = body,
+                        impactSummary = impactSummary,
+                        confirmLabel = confirmLabel,
+                    ),
+                )
+            }
+            return
+        }
+        sendEvent(Event.HapticClick(HapticFeedbackType.SegmentTick))
+        updateState { it.copy(type = target) }
+    }
+
+    private fun processTypeChangeConfirm() {
+        val pending = state.value.pendingTypeChange ?: return
+        sendEvent(Event.HapticClick(HapticFeedbackType.LongPress))
+        updateState { latest ->
+            val nextDraft = latest.draft.map { it.copy(weight = null) }.toImmutableList()
+            latest.copy(
+                type = pending,
+                pendingTypeChange = null,
+                dialogState = DialogState.Hidden,
+                draft = nextDraft,
+            )
+        }
+    }
+
+    private fun processTypeChangeDismiss() {
+        updateState {
+            it.copy(
+                pendingTypeChange = null,
+                dialogState = DialogState.Hidden,
+            )
+        }
+    }
+
     private fun processBack() {
+        // Back gesture dismisses the topmost dialog before propagating.
+        if (state.value.dialogState !is DialogState.Hidden) {
+            updateState { it.copy(dialogState = DialogState.Hidden, pendingTypeChange = null) }
+            return
+        }
         if (state.value.isDirty) {
             updateState { it.copy(confirmDiscardOpen = true) }
         } else {
@@ -83,7 +163,7 @@ internal class ClickHandler @Inject constructor(
         }
     }
 
-    private fun processDismissDialog() {
+    private fun processDismissDiscard() {
         updateState { it.copy(confirmDiscardOpen = false) }
     }
 
@@ -102,13 +182,38 @@ internal class ClickHandler @Inject constructor(
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
         val current = state.value
         if (current.isSaving) return
+        when (current.mode) {
+            Mode.Draft -> {
+                // Use the explicit serializer overload so the call resolves to a
+                // member function rather than the (deprecated-conflicting)
+                // `kotlinx.serialization.encodeToString` extension — see
+                // issuetracker.google.com/issues/350432371.
+                val resultJson = Json.encodeToString(
+                    PlanDraftResult.serializer(),
+                    PlanDraftResult(
+                        type = current.type,
+                        plan = current.draft.toList(),
+                    ),
+                )
+                consume(Action.Navigation.BackAfterDraftSave(resultJson = resultJson))
+            }
+
+            is Mode.Exercise,
+            is Mode.PerformedExercise,
+            -> persistAndPop(current.mode)
+        }
+    }
+
+    private fun persistAndPop(mode: Mode) {
+        val current = state.value
         updateState { it.copy(isSaving = true) }
-        val mode = current.mode
         val (exerciseUuid, trainingUuid) = when (mode) {
             is Mode.Exercise -> mode.exerciseUuid to null
             is Mode.PerformedExercise -> mode.exerciseUuid to mode.trainingUuid
+            Mode.Draft -> error("persistAndPop unreachable for Draft")
         }
         val plan = current.draft.takeIf { it.isNotEmpty() }?.map { it.toDomain() }
+        val type = current.type.toDomain()
         launch(
             onError = {
                 updateState { it.copy(isSaving = false) }
@@ -118,12 +223,19 @@ internal class ClickHandler @Inject constructor(
             interactor.savePlan(
                 exerciseUuid = exerciseUuid,
                 trainingUuid = trainingUuid,
+                type = type,
                 plan = plan,
             )
-            updateState { it.copy(isSaving = false, initialDraft = state.value.draft) }
+            updateState { current ->
+                current.copy(
+                    isSaving = false,
+                    initialDraft = current.draft,
+                    initialType = current.type,
+                )
+            }
             // BackAfterSave pops AND writes the saved-flag to the caller's backstack
-            // entry savedStateHandle so the live-workout / exercise-detail screens
-            // reload their plan-driven state on resume. (v2.4 D1.)
+            // entry savedStateHandle so the consumer reloads its plan + type-driven
+            // state on resume.
             consumeOnMain(Action.Navigation.BackAfterSave)
         }
     }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/CommonHandler.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/CommonHandler.kt
@@ -31,6 +31,9 @@ internal class CommonHandler @Inject constructor(
         val (exerciseUuid, trainingUuid) = when (mode) {
             is Mode.Exercise -> mode.exerciseUuid to null
             is Mode.PerformedExercise -> mode.exerciseUuid to mode.trainingUuid
+            // Draft mode has no DB anchor — the seed already lives in State, so skip the
+            // load and let the editor render immediately.
+            Mode.Draft -> return
         }
         launchDefault(
             onError = { sendEvent(Event.ShowError(ErrorType.LoadFailed)) },
@@ -42,11 +45,13 @@ internal class CommonHandler @Inject constructor(
             when (result) {
                 is PlanEditorLoadResult.Success -> {
                     val draft = result.plan.map { it.toUi() }.toImmutableList()
+                    val type = result.type.toUi()
                     updateState { current ->
                         current.copy(
                             isLoading = false,
                             exerciseName = result.exerciseName,
-                            isWeighted = result.isWeighted,
+                            type = type,
+                            initialType = type,
                             initialDraft = draft,
                             draft = draft,
                         )

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/NavigationHandler.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/handler/NavigationHandler.kt
@@ -4,6 +4,7 @@ package io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorDraftResultAttr
 import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorSavedAttr
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import javax.inject.Inject
@@ -18,6 +19,10 @@ internal class NavigationHandler @Inject constructor(
             is Action.Navigation.Back -> navigator.popBack()
             is Action.Navigation.BackAfterSave -> navigator.popBack(
                 planEditorSavedAttr.toPairValue(true),
+            )
+
+            is Action.Navigation.BackAfterDraftSave -> navigator.popBack(
+                planEditorDraftResultAttr.toPairValue(action.resultJson),
             )
         }
     }

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/DialogState.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/DialogState.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Single source of truth for every modal dialog rendered on the Plan editor screen.
+ * See Rule 4 of compose-state-discipline.md — dialog visibility lives in `State`,
+ * never in a local Composable `var ... by remember`, and never as an `Event`.
+ */
+@Stable
+internal sealed interface DialogState {
+
+    @Stable
+    data object Hidden : DialogState
+
+    /**
+     * "Switching to weightless will clear weights on N plan rows" confirmation. The
+     * pending target type lives in `State.pendingTypeChange` so the confirm handler
+     * knows which value to commit; this variant only carries the pre-resolved dialog
+     * payload (Rule 1 — strings hoisted out of `updateState` lambdas).
+     */
+    @Stable
+    data class TypeChangeConfirm(
+        val title: String,
+        val body: String,
+        val impactSummary: String,
+        val confirmLabel: String,
+    ) : DialogState
+}

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStore.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStore.kt
@@ -4,6 +4,7 @@ package io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import io.github.stslex.workeeper.core.ui.mvi.Store
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanEditorBodyAction
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
@@ -12,11 +13,11 @@ import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorSto
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Event
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
 /**
- * Full-screen plan editor (v2.4 D1). Holds the draft set list, loads initial state from
- * the repository on init, persists on save, and pops back via NavigationHandler.
+ * Full-screen plan editor. Holds the draft set list, owns the WEIGHTED / WEIGHTLESS type,
+ * and persists either to the DB ([Mode.Existing] / [Mode.PerformedExercise]) or back to the
+ * caller as a [PlanDraftResult] payload ([Mode.Draft]).
  */
 internal interface PlanEditorStore : Store<State, Action, Event> {
 
@@ -25,21 +26,31 @@ internal interface PlanEditorStore : Store<State, Action, Event> {
         val mode: Mode,
         val isLoading: Boolean,
         val exerciseName: String,
-        val isWeighted: Boolean,
+        val type: ExerciseTypeUiModel,
         val initialDraft: ImmutableList<PlanSetUiModel>,
         val draft: ImmutableList<PlanSetUiModel>,
+        val initialType: ExerciseTypeUiModel,
+        val pendingTypeChange: ExerciseTypeUiModel?,
         val confirmDiscardOpen: Boolean,
         val isSaving: Boolean,
+        val dialogState: DialogState,
     ) : Store.State {
 
-        /** True when [draft] differs from [initialDraft]. Drives BackHandler interception. */
-        val isDirty: Boolean get() = draft != initialDraft
+        /** True when the working type or draft differ from their initial values. */
+        val isDirty: Boolean
+            get() = draft != initialDraft || type != initialType
+
+        val isWeighted: Boolean
+            get() = type == ExerciseTypeUiModel.WEIGHTED
 
         /**
-         * BackHandler intercepts only when there are unsaved edits. Clean state pops
-         * natively with predictive-back preview intact.
+         * BackHandler intercepts when there are unsaved edits OR when a dialog is open.
+         * The dialog's own back gesture closes it before propagating; clean state with no
+         * dialog stays unsubscribed so Compose nav handles the gesture natively (including
+         * the predictive-back preview animation).
          */
-        val interceptBack: Boolean get() = isDirty && !confirmDiscardOpen
+        val interceptBack: Boolean
+            get() = (isDirty && !confirmDiscardOpen) || dialogState !is DialogState.Hidden
 
         @Stable
         sealed interface Mode {
@@ -61,24 +72,41 @@ internal interface PlanEditorStore : Store<State, Action, Event> {
             ) : Mode
 
             /**
-             * Editing the default plan attached to an exercise (no live session, no training
-             * association). The backing store is `exercise_table.last_adhoc_sets`.
+             * Editing the default plan attached to a persisted exercise (no live session, no
+             * training association). The backing store is `exercise_table.last_adhoc_sets`
+             * and `exercise_table.type`.
              */
             @Stable
             data class Exercise(val exerciseUuid: String) : Mode
+
+            /**
+             * Editing a fresh draft for an exercise that is still being created (no
+             * persisted UUID yet). PlanEditor does not touch the DB; Save returns the draft
+             * to the caller via [PlanDraftResult] JSON in
+             * [io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorDraftResultAttr].
+             */
+            @Stable
+            data object Draft : Mode
         }
 
         companion object {
 
-            fun init(mode: Mode): State = State(
+            fun init(
+                mode: Mode,
+                seedType: ExerciseTypeUiModel,
+                seedPlan: ImmutableList<PlanSetUiModel>,
+            ): State = State(
                 mode = mode,
-                isLoading = true,
+                isLoading = mode !is Mode.Draft,
                 exerciseName = "",
-                isWeighted = true,
-                initialDraft = persistentListOf(),
-                draft = persistentListOf(),
+                type = seedType,
+                initialDraft = seedPlan,
+                draft = seedPlan,
+                initialType = seedType,
+                pendingTypeChange = null,
                 confirmDiscardOpen = false,
                 isSaving = false,
+                dialogState = DialogState.Hidden,
             )
         }
     }
@@ -98,6 +126,12 @@ internal interface PlanEditorStore : Store<State, Action, Event> {
             data class OnSetRemove(val index: Int) : Click
 
             data class OnSetTypeChange(val index: Int, val value: SetTypeUiModel) : Click
+
+            data class OnTypeToggle(val target: ExerciseTypeUiModel) : Click
+
+            data object OnTypeChangeConfirm : Click
+
+            data object OnTypeChangeDismiss : Click
 
             data object OnSave : Click
 
@@ -126,12 +160,20 @@ internal interface PlanEditorStore : Store<State, Action, Event> {
             data object Back : Navigation
 
             /**
-             * Pop after a successful save. The NavigationHandler writes the
+             * Pop after a successful save in [Mode.Existing] / [Mode.PerformedExercise] /
+             * [Mode.Exercise]. The NavigationHandler writes the
              * `plan-editor-saved` flag to the previous backstack entry's
-             * SavedStateHandle so the caller (Live workout, Exercise detail) reloads
-             * its plan on resume. (v2.4 D1.)
+             * SavedStateHandle so the caller (Live workout, Single training,
+             * Exercise detail) reloads its plan-driven state on resume.
              */
             data object BackAfterSave : Navigation
+
+            /**
+             * Pop after Done in [Mode.Draft]. Carries the serialized
+             * [io.github.stslex.workeeper.feature.plan_editor.ui.mvi.model.PlanDraftResult]
+             * JSON for the caller to merge into its local state.
+             */
+            data class BackAfterDraftSave(val resultJson: String) : Navigation
         }
     }
 

--- a/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStoreImpl.kt
+++ b/feature/plan-editor/src/main/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStoreImpl.kt
@@ -12,6 +12,8 @@ import io.github.stslex.workeeper.core.ui.mvi.holders.AnalyticsHolder
 import io.github.stslex.workeeper.core.ui.mvi.holders.LoggerHolder
 import io.github.stslex.workeeper.core.ui.mvi.processor.StoreFactory
 import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.feature.plan_editor.di.PlanEditorHandlerStoreImpl
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler.ClickHandler
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler.CommonHandler
@@ -21,6 +23,10 @@ import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler.NavigationH
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Event
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 
 @HiltViewModel(assistedFactory = PlanEditorStoreImpl.Factory::class)
 internal class PlanEditorStoreImpl @AssistedInject constructor(
@@ -36,7 +42,7 @@ internal class PlanEditorStoreImpl @AssistedInject constructor(
     loggerHolder: LoggerHolder,
 ) : BaseStore<State, Action, Event>(
     name = NAME,
-    initialState = State.init(screen.toMode()),
+    initialState = screen.toInitialState(),
     handlerCreator = { action ->
         when (action) {
             is Action.Common -> commonHandler
@@ -63,25 +69,56 @@ internal class PlanEditorStoreImpl @AssistedInject constructor(
     }
 }
 
-internal fun Screen.PlanEditor.toMode(): State.Mode {
-    val performed = performedExerciseUuid
-    val exercise = exerciseUuid
-    val training = trainingUuid
-    return when {
-        exercise == null -> error(
-            "Screen.PlanEditor must carry exerciseUuid (got performed=$performed, exercise=$exercise)",
-        )
-        // Live workout (performed != null) or single-training (training != null) → backing
-        // store is `training_exercise_table.plan_sets` keyed by (trainingUuid, exerciseUuid).
-        // Live-workout's adhoc branch passes performed != null with training == null, in which
-        // case the editor falls back to `last_adhoc_sets`.
-        performed != null || !training.isNullOrBlank() -> State.Mode.PerformedExercise(
-            performedExerciseUuid = performed,
-            exerciseUuid = exercise,
-            trainingUuid = training,
-        )
-        // Exercise-detail Edit plan: no live session, no training association — saves to the
-        // exercise's own `last_adhoc_sets` row.
-        else -> State.Mode.Exercise(exerciseUuid = exercise)
+internal fun Screen.PlanEditor.toMode(): State.Mode = when (this) {
+    is Screen.PlanEditor.Existing -> {
+        val performed = performedExerciseUuid
+        val exercise = exerciseUuid
+        val training = trainingUuid
+        when {
+            exercise == null -> error(
+                "Screen.PlanEditor.Existing must carry exerciseUuid (got performed=$performed, exercise=$exercise)",
+            )
+            // Live workout (performed != null) or single-training (training != null) →
+            // backing store is `training_exercise_table.plan_sets` keyed by
+            // (trainingUuid, exerciseUuid). Live-workout's adhoc branch passes
+            // performed != null with training == null, in which case the editor falls
+            // back to `last_adhoc_sets`.
+            performed != null || !training.isNullOrBlank() -> State.Mode.PerformedExercise(
+                performedExerciseUuid = performed,
+                exerciseUuid = exercise,
+                trainingUuid = training,
+            )
+            // Exercise-detail Edit plan: no live session, no training association — saves
+            // to the exercise's own `last_adhoc_sets` row plus `exercise_table.type`.
+            else -> State.Mode.Exercise(exerciseUuid = exercise)
+        }
     }
+
+    is Screen.PlanEditor.Draft -> State.Mode.Draft
+}
+
+internal fun Screen.PlanEditor.toInitialState(): State {
+    val mode = toMode()
+    val seedType = when (this) {
+        is Screen.PlanEditor.Draft -> initialType
+        // Existing modes seed type as WEIGHTED until CommonHandler.Init loads the real
+        // value from disk. The Composable doesn't render the toggle until
+        // `state.isLoading == false`, so the user never sees the placeholder.
+        is Screen.PlanEditor.Existing -> ExerciseTypeUiModel.WEIGHTED
+    }
+    val seedPlan = when (this) {
+        is Screen.PlanEditor.Draft ->
+            initialPlanJson
+                ?.let { json ->
+                    Json.decodeFromString(
+                        ListSerializer(PlanSetUiModel.serializer()),
+                        json,
+                    )
+                }
+                ?.toImmutableList()
+                ?: persistentListOf()
+
+        is Screen.PlanEditor.Existing -> persistentListOf()
+    }
+    return State.init(mode = mode, seedType = seedType, seedPlan = seedPlan)
 }

--- a/feature/plan-editor/src/main/res/values-ru/strings.xml
+++ b/feature/plan-editor/src/main/res/values-ru/strings.xml
@@ -15,4 +15,12 @@
 
     <string name="core_ui_plan_editor_error_load">Не удалось загрузить план.</string>
     <string name="core_ui_plan_editor_error_save">Не удалось сохранить план.</string>
+
+    <string name="feature_plan_editor_label_type">Тип</string>
+    <string name="feature_plan_editor_action_done">Готово</string>
+
+    <string name="feature_plan_editor_type_change_weightless_title">Переключить на без веса?</string>
+    <string name="feature_plan_editor_type_change_weightless_body">Значения веса из планов этого упражнения будут очищены. Это нельзя отменить.</string>
+    <string name="feature_plan_editor_type_change_weightless_impact">Все веса в планах очищены</string>
+    <string name="feature_plan_editor_type_change_weightless_confirm">Переключить</string>
 </resources>

--- a/feature/plan-editor/src/main/res/values/strings.xml
+++ b/feature/plan-editor/src/main/res/values/strings.xml
@@ -15,4 +15,12 @@
 
     <string name="core_ui_plan_editor_error_load">Failed to load the plan.</string>
     <string name="core_ui_plan_editor_error_save">Failed to save the plan.</string>
+
+    <string name="feature_plan_editor_label_type">Type</string>
+    <string name="feature_plan_editor_action_done">Done</string>
+
+    <string name="feature_plan_editor_type_change_weightless_title">Switch to weightless?</string>
+    <string name="feature_plan_editor_type_change_weightless_body">Weight values from this exercise’s plans will be cleared. This cannot be undone.</string>
+    <string name="feature_plan_editor_type_change_weightless_impact">All plan weights cleared</string>
+    <string name="feature_plan_editor_type_change_weightless_confirm">Switch</string>
 </resources>

--- a/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/mvi/handler/ClickHandlerTest.kt
+++ b/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/mvi/handler/ClickHandlerTest.kt
@@ -1,42 +1,81 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.plan_editor.mvi.handler
 
+import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanDraftResult
 import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.plan_editor.di.PlanEditorHandlerStore
 import io.github.stslex.workeeper.feature.plan_editor.domain.PlanEditorInteractor
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler.ClickHandler
+import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class ClickHandlerTest {
 
     private val interactor = mockk<PlanEditorInteractor>(relaxed = true)
-    private val initialState = State.init(State.Mode.Exercise(exerciseUuid = "exercise-1"))
-    private val stateFlow = MutableStateFlow(initialState)
-
-    private val store = mockk<PlanEditorHandlerStore>(relaxed = true).apply {
-        every { state } returns stateFlow
-        every { updateState(any()) } answers {
-            val update = firstArg<(State) -> State>()
-            stateFlow.value = update(stateFlow.value)
-        }
+    private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true).apply {
+        every { getString(any()) } returns "label"
+        every { getString(any(), *anyVararg()) } returns "label"
     }
 
-    private val handler = ClickHandler(interactor = interactor, store = store)
+    private fun setup(initialState: State): TestSetup {
+        val stateFlow = MutableStateFlow(initialState)
+        val store = mockk<PlanEditorHandlerStore>(relaxed = true).apply {
+            every { state } returns stateFlow
+            every { updateState(any()) } answers {
+                val update = firstArg<(State) -> State>()
+                stateFlow.value = update(stateFlow.value)
+            }
+        }
+        return TestSetup(
+            stateFlow = stateFlow,
+            store = store,
+            handler = ClickHandler(
+                interactor = interactor,
+                resourceWrapper = resourceWrapper,
+                store = store,
+            ),
+        )
+    }
+
+    private fun existingExerciseInitial(): State = State.init(
+        mode = State.Mode.Exercise(exerciseUuid = "exercise-1"),
+        seedType = ExerciseTypeUiModel.WEIGHTED,
+        seedPlan = persistentListOf(),
+    )
+
+    private fun draftInitial(): State = State.init(
+        mode = State.Mode.Draft,
+        seedType = ExerciseTypeUiModel.WEIGHTED,
+        seedPlan = persistentListOf(),
+    )
+
+    private data class TestSetup(
+        val stateFlow: MutableStateFlow<State>,
+        val store: PlanEditorHandlerStore,
+        val handler: ClickHandler,
+    )
 
     @Test
     fun `OnAddSet appends a new work set with default reps when draft is empty`() {
+        val (stateFlow, _, handler) = setup(existingExerciseInitial())
         handler.invoke(Action.Click.OnAddSet)
 
         assertEquals(1, stateFlow.value.draft.size)
@@ -46,8 +85,11 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnAddSet copies reps from previous set when draft has rows`() {
-        stateFlow.value = stateFlow.value.copy(
-            draft = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WARMUP)).toImmutableList(),
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                draft = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WARMUP))
+                    .toImmutableList(),
+            ),
         )
 
         handler.invoke(Action.Click.OnAddSet)
@@ -62,12 +104,14 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnSetRemove drops the row at the given index`() {
-        stateFlow.value = stateFlow.value.copy(
-            draft = listOf(
-                PlanSetUiModel(60.0, 10, SetTypeUiModel.WARMUP),
-                PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
-                PlanSetUiModel(100.0, 5, SetTypeUiModel.WORK),
-            ).toImmutableList(),
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                draft = listOf(
+                    PlanSetUiModel(60.0, 10, SetTypeUiModel.WARMUP),
+                    PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
+                    PlanSetUiModel(100.0, 5, SetTypeUiModel.WORK),
+                ).toImmutableList(),
+            ),
         )
 
         handler.invoke(Action.Click.OnSetRemove(index = 1))
@@ -80,7 +124,7 @@ internal class ClickHandlerTest {
     @Test
     fun `OnSetRemove with out-of-bounds index leaves draft unchanged`() {
         val draft = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK)).toImmutableList()
-        stateFlow.value = stateFlow.value.copy(draft = draft)
+        val (stateFlow, _, handler) = setup(existingExerciseInitial().copy(draft = draft))
 
         handler.invoke(Action.Click.OnSetRemove(index = 5))
 
@@ -89,11 +133,13 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnSetTypeChange updates the type of the row at the given index`() {
-        stateFlow.value = stateFlow.value.copy(
-            draft = listOf(
-                PlanSetUiModel(60.0, 10, SetTypeUiModel.WORK),
-                PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
-            ).toImmutableList(),
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                draft = listOf(
+                    PlanSetUiModel(60.0, 10, SetTypeUiModel.WORK),
+                    PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
+                ).toImmutableList(),
+            ),
         )
 
         handler.invoke(
@@ -105,11 +151,127 @@ internal class ClickHandlerTest {
     }
 
     @Test
+    fun `OnTypeToggle to same type is no-op`() {
+        val (stateFlow, store, handler) = setup(existingExerciseInitial())
+        handler.invoke(Action.Click.OnTypeToggle(ExerciseTypeUiModel.WEIGHTED))
+
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
+        verify(exactly = 0) { store.sendEvent(any()) }
+    }
+
+    @Test
+    fun `OnTypeToggle with empty draft applies new type silently without dialog`() {
+        val (stateFlow, _, handler) = setup(existingExerciseInitial())
+
+        handler.invoke(Action.Click.OnTypeToggle(ExerciseTypeUiModel.WEIGHTLESS))
+
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.type)
+        assertTrue(stateFlow.value.dialogState is DialogState.Hidden)
+        assertNull(stateFlow.value.pendingTypeChange)
+    }
+
+    @Test
+    fun `OnTypeToggle WEIGHTED to WEIGHTLESS with weighted draft opens confirm dialog`() {
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                draft = listOf(
+                    PlanSetUiModel(weight = 50.0, reps = 8, type = SetTypeUiModel.WORK),
+                ).toImmutableList(),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnTypeToggle(ExerciseTypeUiModel.WEIGHTLESS))
+
+        assertTrue(stateFlow.value.dialogState is DialogState.TypeChangeConfirm)
+        // Type stays WEIGHTED until the user confirms — pending lives in
+        // `pendingTypeChange` and is committed by `OnTypeChangeConfirm`.
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.pendingTypeChange)
+    }
+
+    @Test
+    fun `OnTypeToggle WEIGHTLESS to WEIGHTED applies new type silently regardless of draft`() {
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                type = ExerciseTypeUiModel.WEIGHTLESS,
+                initialType = ExerciseTypeUiModel.WEIGHTLESS,
+                draft = listOf(
+                    PlanSetUiModel(weight = null, reps = 8, type = SetTypeUiModel.WORK),
+                ).toImmutableList(),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnTypeToggle(ExerciseTypeUiModel.WEIGHTED))
+
+        // Going weightless → weighted never strands data — no confirm needed.
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
+        assertTrue(stateFlow.value.dialogState is DialogState.Hidden)
+    }
+
+    @Test
+    fun `OnTypeChangeConfirm wipes weights from draft, applies type, hides dialog`() {
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS,
+                dialogState = DialogState.TypeChangeConfirm(
+                    title = "t",
+                    body = "b",
+                    impactSummary = "i",
+                    confirmLabel = "c",
+                ),
+                draft = listOf(
+                    PlanSetUiModel(50.0, 8, SetTypeUiModel.WORK),
+                    PlanSetUiModel(60.0, 6, SetTypeUiModel.FAILURE),
+                ).toImmutableList(),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnTypeChangeConfirm)
+
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, stateFlow.value.type)
+        assertNull(stateFlow.value.pendingTypeChange)
+        assertTrue(stateFlow.value.dialogState is DialogState.Hidden)
+        assertTrue(stateFlow.value.draft.all { it.weight == null })
+    }
+
+    @Test
+    fun `OnTypeChangeDismiss clears pending and hides dialog without changing type`() {
+        val (stateFlow, _, handler) = setup(
+            existingExerciseInitial().copy(
+                pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS,
+                dialogState = DialogState.TypeChangeConfirm("t", "b", "i", "c"),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnTypeChangeDismiss)
+
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, stateFlow.value.type)
+        assertNull(stateFlow.value.pendingTypeChange)
+        assertTrue(stateFlow.value.dialogState is DialogState.Hidden)
+    }
+
+    @Test
+    fun `OnBackClick with open dialog dismisses dialog before propagating`() {
+        val (stateFlow, store, handler) = setup(
+            existingExerciseInitial().copy(
+                pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS,
+                dialogState = DialogState.TypeChangeConfirm("t", "b", "i", "c"),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnBackClick)
+
+        assertTrue(stateFlow.value.dialogState is DialogState.Hidden)
+        assertNull(stateFlow.value.pendingTypeChange)
+        verify(exactly = 0) { store.consume(Action.Navigation.Back) }
+    }
+
+    @Test
     fun `OnBackClick on clean state dispatches Navigation Back`() {
+        val (_, store, handler) = setup(existingExerciseInitial())
         handler.invoke(Action.Click.OnBackClick)
 
         verify(exactly = 1) { store.consume(Action.Navigation.Back) }
-        assertFalse(stateFlow.value.confirmDiscardOpen)
     }
 
     @Test
@@ -118,7 +280,9 @@ internal class ClickHandlerTest {
         val dirtyDraft = listOf(
             PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
         ).toImmutableList()
-        stateFlow.value = stateFlow.value.copy(draft = dirtyDraft)
+        val (stateFlow, store, handler) = setup(
+            existingExerciseInitial().copy(draft = dirtyDraft),
+        )
 
         handler.invoke(Action.Click.OnBackClick)
 
@@ -128,7 +292,9 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnDismissDiscard closes the dialog without navigating`() {
-        stateFlow.value = stateFlow.value.copy(confirmDiscardOpen = true)
+        val (stateFlow, store, handler) = setup(
+            existingExerciseInitial().copy(confirmDiscardOpen = true),
+        )
 
         handler.invoke(Action.Click.OnDismissDiscard)
 
@@ -138,7 +304,9 @@ internal class ClickHandlerTest {
 
     @Test
     fun `OnConfirmDiscard closes dialog and navigates back without persisting`() {
-        stateFlow.value = stateFlow.value.copy(confirmDiscardOpen = true)
+        val (stateFlow, store, handler) = setup(
+            existingExerciseInitial().copy(confirmDiscardOpen = true),
+        )
 
         handler.invoke(Action.Click.OnConfirmDiscard)
 
@@ -149,7 +317,9 @@ internal class ClickHandlerTest {
     @Test
     fun `state is dirty when draft differs from initialDraft`() {
         val initial = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK)).toImmutableList()
-        stateFlow.value = stateFlow.value.copy(initialDraft = initial, draft = initial)
+        val (stateFlow, _, _) = setup(
+            existingExerciseInitial().copy(initialDraft = initial, draft = initial),
+        )
         assertFalse(stateFlow.value.isDirty)
 
         stateFlow.value = stateFlow.value.copy(
@@ -160,11 +330,21 @@ internal class ClickHandlerTest {
     }
 
     @Test
+    fun `state is dirty when type differs from initialType even with stable draft`() {
+        val (stateFlow, _, _) = setup(existingExerciseInitial())
+        assertFalse(stateFlow.value.isDirty)
+
+        stateFlow.value = stateFlow.value.copy(type = ExerciseTypeUiModel.WEIGHTLESS)
+        assertTrue(stateFlow.value.isDirty)
+    }
+
+    @Test
     fun `interceptBack disabled while discard dialog is shown`() {
-        stateFlow.value = stateFlow.value.copy(
-            initialDraft = persistentListOf(),
-            draft = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK)).toImmutableList(),
-            confirmDiscardOpen = true,
+        val (stateFlow, _, _) = setup(
+            existingExerciseInitial().copy(
+                draft = listOf(PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK)).toImmutableList(),
+                confirmDiscardOpen = true,
+            ),
         )
 
         // Dirty + dialog open → interceptBack is false so Dialog's own dismiss handles
@@ -172,5 +352,45 @@ internal class ClickHandlerTest {
         // anyway, but we explicitly de-arm BackHandler so the system gesture is a no-op
         // beyond closing the dialog).
         assertFalse(stateFlow.value.interceptBack)
+    }
+
+    @Test
+    fun `interceptBack stays enabled when type-change confirm dialog is open`() {
+        val (stateFlow, _, _) = setup(
+            existingExerciseInitial().copy(
+                pendingTypeChange = ExerciseTypeUiModel.WEIGHTLESS,
+                dialogState = DialogState.TypeChangeConfirm("t", "b", "i", "c"),
+            ),
+        )
+
+        // Type-change confirm uses BackHandler interception so the system back gesture
+        // routes through `OnBackClick` → dialog dismiss before propagating to a pop.
+        assertTrue(stateFlow.value.interceptBack)
+    }
+
+    @Test
+    fun `OnSave in Draft mode encodes plan and pops with BackAfterDraftSave`() {
+        val draft = listOf(
+            PlanSetUiModel(80.0, 8, SetTypeUiModel.WORK),
+            PlanSetUiModel(90.0, 5, SetTypeUiModel.WORK),
+        )
+        val (_, store, handler) = setup(
+            draftInitial().copy(
+                draft = draft.toImmutableList(),
+            ),
+        )
+
+        handler.invoke(Action.Click.OnSave)
+
+        // Mode.Draft never persists to DB — interactor is untouched.
+        coVerify(exactly = 0) {
+            interactor.savePlan(any(), any(), any(), any())
+        }
+
+        val captured = slot<Action.Navigation.BackAfterDraftSave>()
+        verify { store.consume(capture(captured)) }
+        val decoded = Json.decodeFromString<PlanDraftResult>(captured.captured.resultJson)
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, decoded.type)
+        assertEquals(draft, decoded.plan)
     }
 }

--- a/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/mvi/handler/NavigationHandlerTest.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.plan_editor.mvi.handler
 
 import io.github.stslex.workeeper.core.ui.navigation.Navigator
+import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorDraftResultAttr
 import io.github.stslex.workeeper.core.ui.navigation.Screen.PlanEditor.Companion.planEditorSavedAttr
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.handler.NavigationHandler
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.Action
@@ -25,6 +26,15 @@ internal class NavigationHandlerTest {
         handler.invoke(Action.Navigation.BackAfterSave)
         verify(exactly = 1) {
             navigator.popBack(planEditorSavedAttr.toPairValue(true))
+        }
+    }
+
+    @Test
+    fun `BackAfterDraftSave pops with the draft-result attribute carrying the JSON payload`() {
+        val payload = "{\"type\":\"WEIGHTED\",\"plan\":[]}"
+        handler.invoke(Action.Navigation.BackAfterDraftSave(resultJson = payload))
+        verify(exactly = 1) {
+            navigator.popBack(planEditorDraftResultAttr.toPairValue(payload))
         }
     }
 }

--- a/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStateRouteArgTest.kt
+++ b/feature/plan-editor/src/test/kotlin/io/github/stslex/workeeper/feature/plan_editor/ui/mvi/store/PlanEditorStateRouteArgTest.kt
@@ -2,26 +2,35 @@
 package io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store
 
 import io.github.stslex.workeeper.core.ui.navigation.Screen
+import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
+import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.plan_editor.ui.mvi.store.PlanEditorStore.State
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
  * Verifies the `Screen.PlanEditor` route → `State.Mode` mapping that
  * `PlanEditorStoreImpl` uses to seed initial state. The Store calls
- * `State.init(screen.toMode())` with the assisted-injected screen, so this test
- * pins the routing branches:
+ * `screen.toInitialState()` with the assisted-injected screen, so this test pins the
+ * routing branches:
  *
- *   - `performedExerciseUuid != null` OR `trainingUuid` non-blank → `Mode.PerformedExercise`.
+ *   - [Screen.PlanEditor.Existing] with `performedExerciseUuid != null` OR `trainingUuid`
+ *     non-blank → `Mode.PerformedExercise`.
  *   - Otherwise (`exerciseUuid` only) → `Mode.Exercise`.
  *   - `exerciseUuid == null` is invalid input — the helper throws `IllegalStateException`.
+ *   - [Screen.PlanEditor.Draft] → `Mode.Draft`; the seed `(initialType, initialPlanJson)`
+ *     hydrates the working draft so the editor renders without a DB load.
  */
 internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `live workout entry maps to PerformedExercise mode`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = "performed-1",
             exerciseUuid = "ex-1",
             trainingUuid = "training-1",
@@ -41,7 +50,7 @@ internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `single-training edit entry maps to PerformedExercise mode without performed uuid`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = null,
             exerciseUuid = "ex-1",
             trainingUuid = "training-1",
@@ -61,7 +70,7 @@ internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `live workout adhoc entry maps to PerformedExercise mode without training uuid`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = "performed-1",
             exerciseUuid = "ex-1",
             trainingUuid = null,
@@ -81,7 +90,7 @@ internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `exercise default plan entry maps to Exercise mode`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = null,
             exerciseUuid = "ex-1",
             trainingUuid = null,
@@ -94,7 +103,7 @@ internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `null exerciseUuid is rejected because the editor needs an exercise to load against`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = "performed-1",
             exerciseUuid = null,
             trainingUuid = "training-1",
@@ -105,7 +114,7 @@ internal class PlanEditorStateRouteArgTest {
 
     @Test
     fun `blank trainingUuid falls through to Exercise mode rather than PerformedExercise`() {
-        val screen = Screen.PlanEditor(
+        val screen = Screen.PlanEditor.Existing(
             performedExerciseUuid = null,
             exerciseUuid = "ex-1",
             trainingUuid = "",
@@ -114,5 +123,41 @@ internal class PlanEditorStateRouteArgTest {
         val mode = screen.toMode()
 
         assertEquals(State.Mode.Exercise(exerciseUuid = "ex-1"), mode)
+    }
+
+    @Test
+    fun `Draft route maps to Mode Draft and hydrates seed type`() {
+        val screen = Screen.PlanEditor.Draft(
+            initialType = ExerciseTypeUiModel.WEIGHTLESS,
+            initialPlanJson = null,
+        )
+
+        val state = screen.toInitialState()
+
+        assertEquals(State.Mode.Draft, state.mode)
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, state.type)
+        assertEquals(ExerciseTypeUiModel.WEIGHTLESS, state.initialType)
+        assertTrue(state.draft.isEmpty())
+        // Draft mode skips the DB load — the editor renders immediately.
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `Draft route hydrates seed plan when initialPlanJson is present`() {
+        val seed = listOf(
+            PlanSetUiModel(weight = 70.0, reps = 8, type = SetTypeUiModel.WORK),
+            PlanSetUiModel(weight = 80.0, reps = 5, type = SetTypeUiModel.WORK),
+        )
+        val screen = Screen.PlanEditor.Draft(
+            initialType = ExerciseTypeUiModel.WEIGHTED,
+            initialPlanJson = Json.encodeToString(seed),
+        )
+
+        val state = screen.toInitialState()
+
+        assertEquals(State.Mode.Draft, state.mode)
+        assertEquals(seed, state.draft.toList())
+        assertEquals(seed, state.initialDraft.toList())
+        assertEquals(ExerciseTypeUiModel.WEIGHTED, state.type)
     }
 }

--- a/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandler.kt
+++ b/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandler.kt
@@ -30,7 +30,7 @@ internal class NavigationHandler @Inject constructor(
             )
 
             is Action.Navigation.OpenPlanEditor -> navigator.navTo(
-                Screen.PlanEditor(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = null,
                     exerciseUuid = action.exerciseUuid,
                     trainingUuid = action.trainingUuid,

--- a/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandlerTest.kt
+++ b/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/mvi/handler/NavigationHandlerTest.kt
@@ -59,7 +59,7 @@ internal class NavigationHandlerTest {
     }
 
     @Test
-    fun `OpenPlanEditor navigates to Screen PlanEditor with the training scope`() {
+    fun `OpenPlanEditor navigates to Screen PlanEditor Existing with the training scope`() {
         handler.invoke(
             Action.Navigation.OpenPlanEditor(
                 trainingUuid = "training-1",
@@ -68,7 +68,7 @@ internal class NavigationHandlerTest {
         )
         verify(exactly = 1) {
             navigator.navTo(
-                Screen.PlanEditor(
+                Screen.PlanEditor.Existing(
                     performedExerciseUuid = null,
                     exerciseUuid = "ex-1",
                     trainingUuid = "training-1",


### PR DESCRIPTION
…ponents

refactor: enhance plan editor with draft mode and type handling

Summary:
This commit relocates the WEIGHTED / WEIGHTLESS type toggle from the exercise form to the plan editor, allowing for better management of exercise types. It also introduces a draft mode for the plan editor, enabling users to edit plans without immediate persistence to the database.

Key changes:
- **Plan Editor:**
    - Moved type toggle functionality to the plan editor.
    - Added support for draft mode in the plan editor, allowing unsaved changes.
    - Updated navigation handling to accommodate new plan editor routes.
- **Data Models:**
    - Introduced `ExerciseTypeDomain` and `ExerciseTypeUiModel` for better type management.
    - Updated repository methods to handle type changes and ensure weights are cleared when switching to WEIGHTLESS.
- **UI Components:**
    - Refactored UI components to reflect the new type handling and draft functionality.
    - Updated string resources for type labels and confirmation dialogs.