### PR TITLE
refactor: remove bulk delete action and streamline FAB click handling

### DIFF
--- a/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/ClickHandler.kt
+++ b/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/ClickHandler.kt
@@ -32,7 +32,6 @@ internal class ClickHandler @Inject constructor(
             is Action.Click.OnTagFilterToggle -> processTagFilterToggle(action)
             is Action.Click.OnSelectionToggle -> processSelectionToggle(action)
             Action.Click.OnSelectionExit -> processSelectionExit()
-            Action.Click.OnBulkDelete -> processBulkDelete()
             Action.Click.OnBulkDeleteConfirm -> processBulkDeleteConfirm()
             Action.Click.OnBulkDeleteDismiss -> processBulkDeleteDismiss()
         }
@@ -62,8 +61,19 @@ internal class ClickHandler @Inject constructor(
     }
 
     private fun processFabClick() {
-        sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
-        consume(Action.Navigation.OpenCreate)
+        val selectedUuid: Set<String> = (state.value.selectionMode as? SelectionMode.On)
+            ?.selectedUuids
+            .orEmpty()
+
+        if (selectedUuid.isEmpty()) {
+            sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
+            consume(Action.Navigation.OpenCreate)
+        } else {
+            sendEvent(Event.HapticClick(HapticFeedbackType.LongPress))
+            updateState { current ->
+                current.copy(pendingBulkDelete = PendingBulkDelete(count = selectedUuid.size))
+            }
+        }
     }
 
     private fun processTagFilterToggle(action: Action.Click.OnTagFilterToggle) {
@@ -101,20 +111,6 @@ internal class ClickHandler @Inject constructor(
         if (!state.value.isSelecting) return
         sendEvent(Event.HapticClick(HapticFeedbackType.ContextClick))
         updateState { it.copy(selectionMode = SelectionMode.Off) }
-    }
-
-    /**
-     * Bulk-delete FAB → confirm dialog whenever at least one row is selected. The
-     * underlying call is `archiveTrainings` (soft-delete) — permanent delete remains a
-     * single-row action accessed from the training detail menu.
-     */
-    private fun processBulkDelete() {
-        val mode = state.value.selectionMode as? SelectionMode.On ?: return
-        if (mode.selectedUuids.isEmpty()) return
-        sendEvent(Event.HapticClick(HapticFeedbackType.LongPress))
-        updateState { current ->
-            current.copy(pendingBulkDelete = PendingBulkDelete(count = mode.selectedUuids.size))
-        }
     }
 
     private fun processBulkDeleteConfirm() {

--- a/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/store/AllTrainingsStore.kt
+++ b/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/store/AllTrainingsStore.kt
@@ -86,8 +86,6 @@ internal interface AllTrainingsStore : Store<State, Action, Event> {
 
             data object OnSelectionExit : Click
 
-            data object OnBulkDelete : Click
-
             data object OnBulkDeleteConfirm : Click
 
             data object OnBulkDeleteDismiss : Click

--- a/feature/all-trainings/src/test/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/ClickHandlerTest.kt
+++ b/feature/all-trainings/src/test/kotlin/io/github/stslex/workeeper/feature/all_trainings/mvi/handler/ClickHandlerTest.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -87,6 +86,21 @@ internal class ClickHandlerTest {
     }
 
     @Test
+    fun `OnFabClick with selection emits LongPress haptic and sets pendingBulkDelete`() {
+        stateFlow.value = stateFlow.value.copy(
+            selectionMode = State.SelectionMode.On(
+                selectedUuids = persistentSetOf("uuid-1", "uuid-2"),
+            ),
+        )
+        handler.invoke(Action.Click.OnFabClick)
+        val captured = slot<Event>()
+        verify { store.sendEvent(capture(captured)) }
+        assertHaptic(captured.captured, HapticFeedbackType.LongPress)
+        verify(exactly = 0) { store.consume(any()) }
+        assertEquals(2, stateFlow.value.pendingBulkDelete?.count)
+    }
+
+    @Test
     fun `OnTagFilterToggle adds tag when not selected`() {
         handler.invoke(Action.Click.OnTagFilterToggle("tag-1"))
         assertEquals(setOf("tag-1"), stateFlow.value.activeTagFilter.toSet())
@@ -106,19 +120,6 @@ internal class ClickHandlerTest {
         )
         handler.invoke(Action.Click.OnSelectionExit)
         assertTrue(stateFlow.value.selectionMode is State.SelectionMode.Off)
-    }
-
-    @Test
-    fun `OnBulkDelete with selection opens confirm dialog`() {
-        stateFlow.value = stateFlow.value.copy(
-            selectionMode = State.SelectionMode.On(
-                selectedUuids = persistentSetOf("uuid-1", "uuid-2"),
-            ),
-        )
-        handler.invoke(Action.Click.OnBulkDelete)
-        val pending = stateFlow.value.pendingBulkDelete
-        assertNotNull(pending, "expected pendingBulkDelete to be set")
-        assertEquals(2, pending!!.count)
     }
 
     @Test


### PR DESCRIPTION
This commit removes the bulk delete action from the ClickHandler and updates the FAB click handling logic to manage pending bulk delete state based on selection. The changes enhance clarity and maintainability of the click handling process.