### PR TITLE
feat: AI-readable Drive snapshot export

### DIFF
--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/BackupAuth.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/BackupAuth.kt
@@ -6,6 +6,7 @@ import io.github.stslex.workeeper.core.data.backup.api.model.Account
 import io.github.stslex.workeeper.core.data.backup.api.model.AuthState
 import io.github.stslex.workeeper.core.data.backup.api.model.SignInResult
 import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -31,6 +32,22 @@ interface BackupAuth {
      * sign-in could not be attempted.
      */
     suspend fun signIn(): SignInResult
+
+    /**
+     * Hot stream of whether the optional `drive.file` (visible-Drive) scope is currently
+     * granted. Drives the AI-export toggle's enabled state and gates the export runner.
+     * Re-derived on every authorize, so a later revocation flips it back to `false`.
+     */
+    fun observeDriveFileGranted(): Flow<Boolean>
+
+    /**
+     * Requests the optional `drive.file` scope on the already-connected account (incremental
+     * grant for AI export). Same [SignInResult] contract as [signIn]: [SignInResult.Success]
+     * if already granted, [SignInResult.NeedsResolution] to launch the consent flow (forward
+     * the result via [completeSignIn]), or [SignInResult.Failure]. Does NOT start a fresh
+     * sign-in — it adds a scope to the existing session.
+     */
+    suspend fun requestDriveFileAccess(): SignInResult
 
     /**
      * Completes a sign-in that previously returned [SignInResult.NeedsResolution].

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotConstants.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotConstants.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.api
+
+/**
+ * Constants for the AI-readable JSON snapshot uploaded to a *visible* Drive folder
+ * (sibling of the binary backup; see `drive-ai-export.md`). The retention cap is shared
+ * with the binary path via [BackupConstants.MAX_BACKUPS] — deliberately NOT a copy.
+ */
+object SnapshotConstants {
+
+    /** Visible Drive folder the snapshot is written into (created at My Drive root). */
+    const val FOLDER_NAME: String = "Workeeper"
+
+    /** Filename prefix of every uploaded snapshot (`workeeper_export_<epochMs>.json`). */
+    const val FILE_PREFIX: String = "workeeper_export_"
+
+    /** Filename suffix of every uploaded snapshot. */
+    const val FILE_SUFFIX: String = ".json"
+}

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
@@ -30,4 +30,16 @@ interface SnapshotExportRunner {
      * unless the toggle is on AND `drive.file` is granted.
      */
     suspend fun runIfEligibleAwaiting()
+
+    /**
+     * Deletes all previously-exported snapshots from the visible folder, serialized against
+     * [runIfEligible] / [runIfEligibleAwaiting] through the same in-process lock so a delete can
+     * never race a concurrent upload. SUSPENDS until done. Call when the user withdraws consent
+     * (AI-export toggle OFF) and BEFORE sign-out revokes `drive.file` — once the grant is gone the
+     * app can no longer see its visible files to remove them. Fully best-effort: gated on the
+     * `drive.file` grant (no-op without it) and the body is swallowed so it never throws. Unlike
+     * the export paths this does NOT gate on the toggle — it is invoked precisely when the toggle
+     * is going off.
+     */
+    suspend fun clearSnapshots()
 }

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.api
+
+/**
+ * Orchestration seam for the AI-readable JSON snapshot. Invoked after the binary backup on
+ * both trigger points (auto worker + manual). Fully best-effort and decoupled: it gates on
+ * the user toggle AND the `drive.file` grant, and its entire body is swallowed so it can
+ * never block, delay, or fail the binary backup.
+ */
+interface SnapshotExportRunner {
+
+    /**
+     * No-op unless the AI-export toggle is on AND `drive.file` is granted. When eligible,
+     * builds the JSON snapshot and uploads it. Never throws: unexpected errors are recorded
+     * as Crashlytics non-fatals, transient ones are logged only.
+     */
+    suspend fun runIfEligible()
+}

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
@@ -10,9 +10,12 @@ package io.github.stslex.workeeper.core.data.backup.api
 interface SnapshotExportRunner {
 
     /**
-     * No-op unless the AI-export toggle is on AND `drive.file` is granted. When eligible,
-     * builds the JSON snapshot and uploads it. Never throws: unexpected errors are recorded
-     * as Crashlytics non-fatals, transient ones are logged only.
+     * Fire-and-forget: launches the export on an app-scoped coroutine and returns immediately,
+     * so it never blocks or delays the binary backup (D2) — the manual UI and the worker
+     * `Result` no longer wait on visible-Drive latency. No-op unless the AI-export toggle is on
+     * AND `drive.file` is granted. Best-effort: the detached work never throws (unexpected errors
+     * → Crashlytics non-fatal, transient ones log-only), and if the process dies before it
+     * finishes the next backup re-exports.
      */
-    suspend fun runIfEligible()
+    fun runIfEligible()
 }

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotExportRunner.kt
@@ -11,11 +11,23 @@ interface SnapshotExportRunner {
 
     /**
      * Fire-and-forget: launches the export on an app-scoped coroutine and returns immediately,
-     * so it never blocks or delays the binary backup (D2) — the manual UI and the worker
-     * `Result` no longer wait on visible-Drive latency. No-op unless the AI-export toggle is on
-     * AND `drive.file` is granted. Best-effort: the detached work never throws (unexpected errors
-     * → Crashlytics non-fatal, transient ones log-only), and if the process dies before it
-     * finishes the next backup re-exports.
+     * so it never blocks or delays the binary backup (D2). Correct for the FOREGROUND manual path
+     * (`BackupInteractorImpl.createBackup`), whose UI must not wait on visible-Drive latency.
+     * No-op unless the AI-export toggle is on AND `drive.file` is granted. Best-effort: the
+     * detached work never throws (unexpected errors → Crashlytics non-fatal, transient ones
+     * log-only), and if the process dies before it finishes the next backup re-exports.
      */
     fun runIfEligible()
+
+    /**
+     * Like [runIfEligible] but SUSPENDS until the export completes. For the auto-backup WORKER,
+     * which already holds a wakelock/execution window: a detached launch would forfeit that window
+     * (`doWork()` returns, the process becomes reclaim-eligible) and the snapshot would race
+     * process death on every periodic run. Awaiting keeps the window alive until the upload
+     * finishes. MUST be called only AFTER the binary-backup result is computed, so D2 holds — the
+     * binary upload is already done and only the worker's `Result` reporting is held slightly
+     * longer. Still fully best-effort: the body is swallowed internally and never throws. No-op
+     * unless the toggle is on AND `drive.file` is granted.
+     */
+    suspend fun runIfEligibleAwaiting()
 }

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotStorage.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotStorage.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.api
+
+import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+
+/**
+ * Upload contract for the AI-readable JSON snapshot. Mirrors [BackupStorage] but for the
+ * visible-folder, text artifact, so the orchestration seam depends on this api rather than
+ * the Drive impl.
+ *
+ * The snapshot is a read-only projection that the app never restores, so the surface is
+ * upload-only — folder management and rotation are the impl's concern. Best-effort by
+ * policy: a [BackupResult.Failure] here is non-fatal and must never affect the binary
+ * backup (the orchestration seam swallows it).
+ */
+interface SnapshotStorage {
+
+    /**
+     * Uploads [content] (UTF-8 JSON) as a new snapshot file in the visible folder, then
+     * prunes older snapshots beyond the retention cap. Best-effort.
+     */
+    suspend fun uploadSnapshot(content: ByteArray): BackupResult<Unit>
+}

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotStorage.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/SnapshotStorage.kt
@@ -20,4 +20,14 @@ interface SnapshotStorage {
      * prunes older snapshots beyond the retention cap. Best-effort.
      */
     suspend fun uploadSnapshot(content: ByteArray): BackupResult<Unit>
+
+    /**
+     * Deletes every snapshot file from the visible folder, leaving the (now-empty) folder.
+     * Invoked when the user withdraws AI-export consent (toggle OFF) and BEFORE sign-out revokes
+     * `drive.file` — after revocation the app can no longer see its own visible files, so they
+     * would be stranded permanently. Best-effort: a no-op when `drive.file` is not granted (the
+     * scope is required to enumerate/delete the visible files), and a [BackupResult.Failure] here
+     * is non-fatal.
+     */
+    suspend fun deleteAllSnapshots(): BackupResult<Unit>
 }

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/scheduling/BackupPreferences.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/scheduling/BackupPreferences.kt
@@ -24,6 +24,13 @@ data class BackupPreferences(
     val lastSuccessAtEpochMs: Long,
     val lastError: BackupErrorCode?,
     val autoBackupBootstrapped: Boolean,
+    /**
+     * Whether the user enabled the AI-readable JSON snapshot export. Off by default and
+     * flipped on only via the Settings toggle after the `drive.file` grant is confirmed
+     * (pessimistic / opt-in). The export runner gates on this AND the actual `drive.file`
+     * grant, so it stays inert until both hold.
+     */
+    val aiExportEnabled: Boolean = false,
 ) {
 
     companion object {
@@ -35,6 +42,7 @@ data class BackupPreferences(
             lastSuccessAtEpochMs = 0L,
             lastError = null,
             autoBackupBootstrapped = false,
+            aiExportEnabled = false,
         )
     }
 }

--- a/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/scheduling/BackupPreferencesRepository.kt
+++ b/core/data/backup/api/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/api/scheduling/BackupPreferencesRepository.kt
@@ -28,4 +28,6 @@ interface BackupPreferencesRepository {
     suspend fun setLastError(error: BackupErrorCode?)
 
     suspend fun setAutoBackupBootstrapped(bootstrapped: Boolean)
+
+    suspend fun setAiExportEnabled(enabled: Boolean)
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.google_drive
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.core.logger.Log
+import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
+import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
+import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferencesRepository
+import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Default [SnapshotExportRunner]: gate on toggle + `drive.file` grant, then export the JSON
+ * and upload it. The whole body is wrapped so it never throws to the caller (D2). Only
+ * UNEXPECTED failures (serialization / IO bugs) are recorded as Crashlytics non-fatals (via
+ * [Log.e]); transient typed [BackupError]s (network / auth / quota / not-authenticated) are
+ * logged only (via [Log.w], which does not record a non-fatal).
+ */
+@Singleton
+internal class SnapshotExportRunnerImpl @Inject constructor(
+    private val preferences: BackupPreferencesRepository,
+    private val backupAuth: BackupAuth,
+    private val exporter: DatabaseJsonExporter,
+    private val snapshotStorage: SnapshotStorage,
+    @ApplicationContext private val context: Context,
+    @IODispatcher private val dispatcher: CoroutineDispatcher,
+) : SnapshotExportRunner {
+
+    private val logger = Log.tag(TAG)
+
+    override suspend fun runIfEligible() {
+        withContext(dispatcher) {
+            runCatching {
+                if (!isEligible()) return@runCatching
+                val json = exporter.export(
+                    appVersion = readVersionName(),
+                    deviceModel = Build.MODEL,
+                    exportedAtEpochMs = System.currentTimeMillis(),
+                )
+                when (val result = snapshotStorage.uploadSnapshot(json)) {
+                    is BackupResult.Success -> Unit
+                    is BackupResult.Failure -> handleFailure(result.error)
+                }
+            }.onFailure { t ->
+                // Unexpected throwable (e.g. serialization / DB-read bug). Record + swallow.
+                logger.e(t, "AI snapshot export threw")
+            }
+        }
+    }
+
+    private suspend fun isEligible(): Boolean = preferences.observe().first().aiExportEnabled &&
+        backupAuth.observeDriveFileGranted().first()
+
+    private fun handleFailure(error: BackupError) {
+        if (error.isTransient()) {
+            logger.w { "AI snapshot export skipped (transient): $error" }
+        } else {
+            logger.e(error.toThrowable(), "AI snapshot export failed")
+        }
+    }
+
+    private fun BackupError.isTransient(): Boolean = when (this) {
+        BackupError.NetworkUnavailable,
+        BackupError.AuthRevoked,
+        BackupError.StorageQuotaExceeded,
+        BackupError.NotAuthenticated,
+        -> true
+
+        else -> false
+    }
+
+    private fun BackupError.toThrowable(): Throwable = when (this) {
+        is BackupError.Io -> cause
+        is BackupError.Unknown -> cause
+        else -> IllegalStateException("AI snapshot export error: $this")
+    }
+
+    private fun readVersionName(): String {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.PackageInfoFlags.of(0),
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(context.packageName, 0)
+        }
+        return info.versionName.orEmpty()
+    }
+
+    private companion object {
+        const val TAG = "SnapshotExportRunner"
+    }
+}

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
@@ -15,8 +15,10 @@ import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
 import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferencesRepository
 import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,23 +41,31 @@ internal class SnapshotExportRunnerImpl @Inject constructor(
 
     private val logger = Log.tag(TAG)
 
-    override suspend fun runIfEligible() {
-        withContext(dispatcher) {
-            runCatching {
-                if (!isEligible()) return@runCatching
-                val json = exporter.export(
-                    appVersion = readVersionName(),
-                    deviceModel = Build.MODEL,
-                    exportedAtEpochMs = System.currentTimeMillis(),
-                )
-                when (val result = snapshotStorage.uploadSnapshot(json)) {
-                    is BackupResult.Success -> Unit
-                    is BackupResult.Failure -> handleFailure(result.error)
-                }
-            }.onFailure { t ->
-                // Unexpected throwable (e.g. serialization / DB-read bug). Record + swallow.
-                logger.e(t, "AI snapshot export threw")
+    // App-lifetime scope so the export runs DETACHED from the binary backup: the trigger
+    // (manual createBackup / BackupWorker.doWork) returns immediately and is never delayed by
+    // the DB-export + visible-Drive upload. Best-effort — if the process is reclaimed before it
+    // finishes, the next backup re-exports (losing a snapshot loses nothing recoverable).
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    override fun runIfEligible() {
+        scope.launch { runExport() }
+    }
+
+    private suspend fun runExport() {
+        runCatching {
+            if (!isEligible()) return@runCatching
+            val json = exporter.export(
+                appVersion = readVersionName(),
+                deviceModel = Build.MODEL,
+                exportedAtEpochMs = System.currentTimeMillis(),
+            )
+            when (val result = snapshotStorage.uploadSnapshot(json)) {
+                is BackupResult.Success -> Unit
+                is BackupResult.Failure -> handleFailure(result.error)
             }
+        }.onFailure { t ->
+            // Unexpected throwable (e.g. serialization / DB-read bug). Record + swallow.
+            logger.e(t, "AI snapshot export threw")
         }
     }
 

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
@@ -13,12 +13,15 @@ import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
 import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
 import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferencesRepository
+import io.github.stslex.workeeper.core.data.backup.google_drive.manifest.ManifestPropertiesMapper
 import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,27 +44,41 @@ internal class SnapshotExportRunnerImpl @Inject constructor(
 
     private val logger = Log.tag(TAG)
 
-    // App-lifetime scope so the export runs DETACHED from the binary backup: the trigger
-    // (manual createBackup / BackupWorker.doWork) returns immediately and is never delayed by
-    // the DB-export + visible-Drive upload. Best-effort — if the process is reclaimed before it
-    // finishes, the next backup re-exports (losing a snapshot loses nothing recoverable).
+    // App-lifetime scope for the FOREGROUND fire-and-forget path so the manual backup returns
+    // immediately and is never delayed by the DB-export + visible-Drive upload (D2). The worker
+    // instead awaits via runIfEligibleAwaiting() to keep its wakelock window. Best-effort — if the
+    // process is reclaimed before it finishes, the next backup re-exports (losing a snapshot loses
+    // nothing recoverable).
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    // Serializes the export's Drive mutation across the manual + worker triggers (both funnel
+    // through this singleton). Without it, two overlapping runs could create duplicate Workeeper/
+    // folders (resolveFolderId is check-then-act) or violate the rotation cap (list-then-delete).
+    // In-process is sufficient: WorkManager runs the worker in the app process.
+    private val exportMutex = Mutex()
 
     override fun runIfEligible() {
         scope.launch { runExport() }
     }
 
+    override suspend fun runIfEligibleAwaiting() {
+        runExport()
+    }
+
     private suspend fun runExport() {
         runCatching {
             if (!isEligible()) return@runCatching
-            val json = exporter.export(
-                appVersion = readVersionName(),
-                deviceModel = Build.MODEL,
-                exportedAtEpochMs = System.currentTimeMillis(),
-            )
-            when (val result = snapshotStorage.uploadSnapshot(json)) {
-                is BackupResult.Success -> Unit
-                is BackupResult.Failure -> handleFailure(result.error)
+            exportMutex.withLock {
+                val json = exporter.export(
+                    appVersion = readVersionName(),
+                    // Cap to match the binary manifest (spec §3); a >100-char model is truncated.
+                    deviceModel = Build.MODEL.take(ManifestPropertiesMapper.DEVICE_MODEL_MAX_LEN),
+                    exportedAtEpochMs = System.currentTimeMillis(),
+                )
+                when (val result = snapshotStorage.uploadSnapshot(json)) {
+                    is BackupResult.Success -> Unit
+                    is BackupResult.Failure -> handleFailure(result.error)
+                }
             }
         }.onFailure { t ->
             // Unexpected throwable (e.g. serialization / DB-read bug). Record + swallow.

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImpl.kt
@@ -65,6 +65,22 @@ internal class SnapshotExportRunnerImpl @Inject constructor(
         runExport()
     }
 
+    override suspend fun clearSnapshots() {
+        runCatching {
+            // Serialize with the export paths: deleting while an upload is mid-rotation could
+            // delete the wrong set or race the folder lookup. The storage gates on the grant.
+            exportMutex.withLock {
+                when (val result = snapshotStorage.deleteAllSnapshots()) {
+                    is BackupResult.Success -> Unit
+                    is BackupResult.Failure -> handleFailure(result.error)
+                }
+            }
+        }.onFailure { t ->
+            // Unexpected throwable. Record + swallow — deletion is best-effort housekeeping.
+            logger.e(t, "AI snapshot deletion threw")
+        }
+    }
+
     private suspend fun runExport() {
         runCatching {
             if (!isEligible()) return@runCatching

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
@@ -20,6 +20,9 @@ internal interface AccountDataStore {
     /** Hot stream of the persisted account. Emits `null` when no account is stored. */
     fun observeAccount(): Flow<Account?>
 
+    /** One-shot read of the persisted account, or `null` when none is stored. */
+    suspend fun account(): Account?
+
     /** Persists [account]. Overwrites any prior value. */
     suspend fun setAccount(account: Account)
 

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
@@ -57,4 +57,17 @@ internal interface AccountDataStore {
 
     /** Caches the snapshot folder id; pass `null` to drop a stale id (e.g. after a 404). */
     suspend fun setSnapshotFolderId(id: String?)
+
+    /** Hot stream of whether `drive.file` is currently granted (drives the AI-export toggle UI). */
+    fun observeDriveFileGranted(): Flow<Boolean>
+
+    /** One-shot read of the `drive.file` grant flag (used by the export runner + silent refresh). */
+    suspend fun isDriveFileGranted(): Boolean
+
+    /**
+     * Persists the `drive.file` grant flag. Re-derived from `AuthorizationResult.grantedScopes`
+     * on every authorize (sign-in, explicit grant, AND silent refresh) so a later revocation
+     * flips it back to `false`.
+     */
+    suspend fun setDriveFileGranted(granted: Boolean)
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStore.kt
@@ -46,4 +46,15 @@ internal interface AccountDataStore {
 
     /** Removes only the stored token. No-op when no token is stored. */
     suspend fun clearToken()
+
+    /**
+     * The cached id of the visible-Drive `Workeeper/` folder used by the AI snapshot,
+     * or `null` if not yet resolved. Cached here (rather than a new component) because
+     * this is already the singleton Drive-state store; [clear] drops it with everything
+     * else on sign-out.
+     */
+    suspend fun snapshotFolderId(): String?
+
+    /** Caches the snapshot folder id; pass `null` to drop a stale id (e.g. after a 404). */
+    suspend fun setSnapshotFolderId(id: String?)
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
@@ -31,6 +31,8 @@ internal class AccountDataStoreImpl @Inject constructor(
 
     override fun observeAccount(): Flow<Account?> = dataStore.data.map(::accountFromPrefs)
 
+    override suspend fun account(): Account? = accountFromPrefs(dataStore.data.first())
+
     override suspend fun setAccount(account: Account) {
         dataStore.edit { prefs ->
             prefs[KEY_EMAIL] = account.email

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
@@ -67,6 +67,18 @@ internal class AccountDataStoreImpl @Inject constructor(
         }
     }
 
+    override suspend fun snapshotFolderId(): String? = dataStore.data.first()[KEY_SNAPSHOT_FOLDER_ID]
+
+    override suspend fun setSnapshotFolderId(id: String?) {
+        dataStore.edit { prefs ->
+            if (id == null) {
+                prefs.remove(KEY_SNAPSHOT_FOLDER_ID)
+            } else {
+                prefs[KEY_SNAPSHOT_FOLDER_ID] = id
+            }
+        }
+    }
+
     private fun accountFromPrefs(prefs: Preferences): Account? {
         val email = prefs[KEY_EMAIL] ?: return null
         return Account(email = email, displayName = prefs[KEY_DISPLAY_NAME])
@@ -78,5 +90,6 @@ internal class AccountDataStoreImpl @Inject constructor(
         val KEY_DISPLAY_NAME = stringPreferencesKey("display_name")
         val KEY_TOKEN = stringPreferencesKey("access_token")
         val KEY_TOKEN_EXPIRES_AT = longPreferencesKey("access_token_expires_at")
+        val KEY_SNAPSHOT_FOLDER_ID = stringPreferencesKey("snapshot_folder_id")
     }
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/AccountDataStoreImpl.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -79,6 +80,16 @@ internal class AccountDataStoreImpl @Inject constructor(
         }
     }
 
+    override fun observeDriveFileGranted(): Flow<Boolean> =
+        dataStore.data.map { it[KEY_DRIVE_FILE_GRANTED] ?: false }
+
+    override suspend fun isDriveFileGranted(): Boolean =
+        dataStore.data.first()[KEY_DRIVE_FILE_GRANTED] ?: false
+
+    override suspend fun setDriveFileGranted(granted: Boolean) {
+        dataStore.edit { it[KEY_DRIVE_FILE_GRANTED] = granted }
+    }
+
     private fun accountFromPrefs(prefs: Preferences): Account? {
         val email = prefs[KEY_EMAIL] ?: return null
         return Account(email = email, displayName = prefs[KEY_DISPLAY_NAME])
@@ -91,5 +102,6 @@ internal class AccountDataStoreImpl @Inject constructor(
         val KEY_TOKEN = stringPreferencesKey("access_token")
         val KEY_TOKEN_EXPIRES_AT = longPreferencesKey("access_token_expires_at")
         val KEY_SNAPSHOT_FOLDER_ID = stringPreferencesKey("snapshot_folder_id")
+        val KEY_DRIVE_FILE_GRANTED = booleanPreferencesKey("drive_file_granted")
     }
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthScopes.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthScopes.kt
@@ -4,15 +4,23 @@ package io.github.stslex.workeeper.core.data.backup.google_drive.auth
 import com.google.android.gms.common.api.Scope
 
 /**
- * Scopes requested by every `AuthorizationRequest` / `RevokeAccessRequest` in this
- * module. Keeping them in one place is load-bearing: `setRequestedScopes` on
- * sign-in, silent refresh, and revoke MUST match exactly — a mismatch breaks
- * silent token reuse (GMS treats the request as new and re-prompts) and leaves
- * `userinfo`-derived identity behind on revoke.
+ * OAuth scopes for the backup feature. Two request sets exist deliberately:
  *
- * `drive.appdata` is the data scope used for the backup file; the two `userinfo`
- * scopes are needed to call `oauth2/v3/userinfo` for email + display name after a
- * successful authorize — `AuthorizationResult` itself does not surface them.
+ * - [ALL] — the base set (`drive.appdata` + the two `userinfo` scopes). Used by regular
+ *   sign-in, by silent refresh for accounts that have NOT granted `drive.file`, and as the
+ *   binary backup's only requirement. This set is unchanged from v1.
+ * - [ALL_WITH_DRIVE_FILE] — [ALL] plus the visible-Drive `drive.file` scope. Used ONLY by the
+ *   explicit AI-export grant flow, by silent refresh for accounts that already granted
+ *   `drive.file`, and by revoke (revoke everything).
+ *
+ * Why two sets (not one static set): `AuthorizationClient.authorize()` raises a resolution
+ * (no silent token) whenever a *requested* scope is ungranted. Requesting `drive.file` on the
+ * silent/binary path for an appdata-only user would therefore break silent token refresh. By
+ * requesting only the already-granted set on silent refresh, the appdata-only path requests
+ * exactly [ALL] — identical to v1 — so it can never trip a resolution.
+ *
+ * `drive.appdata` is the data scope for the binary backup; the two `userinfo` scopes back the
+ * `oauth2/v3/userinfo` identity lookup (`AuthorizationResult` does not surface them).
  */
 internal object DriveAuthScopes {
 
@@ -20,22 +28,28 @@ internal object DriveAuthScopes {
     const val USERINFO_EMAIL = "https://www.googleapis.com/auth/userinfo.email"
     const val USERINFO_PROFILE = "https://www.googleapis.com/auth/userinfo.profile"
 
+    /**
+     * Visible-Drive scope for the AI snapshot. OPTIONAL: requested only via
+     * [ALL_WITH_DRIVE_FILE] (explicit grant / already-granted silent refresh / revoke), never
+     * on regular sign-in — so appdata-only users never see it and their silent refresh stays
+     * resolution-free.
+     */
+    const val DRIVE_FILE = "https://www.googleapis.com/auth/drive.file"
+
     val ALL: List<Scope> = listOf(
         Scope(DRIVE_APPDATA),
         Scope(USERINFO_EMAIL),
         Scope(USERINFO_PROFILE),
     )
 
+    /** [ALL] plus [DRIVE_FILE]. */
+    val ALL_WITH_DRIVE_FILE: List<Scope> = ALL + Scope(DRIVE_FILE)
+
     /**
-     * Scopes the backup feature cannot operate without. Userinfo scopes are NOT
-     * here — declining them only degrades account display (handled in
-     * `DriveBackupAuth.toAccount` via the placeholder email fallback), but the
-     * feature still works. Only `drive.appdata` blocks all storage operations,
-     * so partial-grant detection in `DriveBackupAuth` checks for its absence.
-     *
-     * Kept as an explicit constant rather than derived (e.g. `ALL.first()`) so
-     * the required set is obvious at the call site and future scopes can be
-     * promoted to required without touching ordering.
+     * Scopes the backup feature cannot operate without. Userinfo + `drive.file` are NOT here —
+     * declining userinfo only degrades account display, and `drive.file` only gates the
+     * optional AI snapshot. Only `drive.appdata` blocks all storage operations, so
+     * partial-grant detection in `DriveBackupAuth` checks for its absence.
      */
     val REQUIRED: List<String> = listOf(DRIVE_APPDATA)
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProvider.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProvider.kt
@@ -3,6 +3,7 @@ package io.github.stslex.workeeper.core.data.backup.google_drive.auth
 
 import com.google.android.gms.auth.api.identity.AuthorizationClient
 import com.google.android.gms.auth.api.identity.AuthorizationRequest
+import com.google.android.gms.common.api.Scope
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.core.logger.Log
 import io.github.stslex.workeeper.core.data.backup.google_drive.network.AuthTokenProvider
@@ -44,15 +45,40 @@ internal class DriveAuthTokenProvider @Inject constructor(
     }
 
     private suspend fun refreshTokenFromGms(): String? {
-        val request = AuthorizationRequest.builder()
-            .setRequestedScopes(DriveAuthScopes.ALL)
-            .build()
-        val result = try {
-            authorizationClient.authorize(request).await()
+        // Request ONLY the scopes the account already granted: base, plus drive.file only if
+        // it was previously granted. Appdata-only users therefore request exactly
+        // DriveAuthScopes.ALL (identical to v1) and never trip an authorize() resolution.
+        val includeDriveFile = accountStore.isDriveFileGranted()
+        val scopes = if (includeDriveFile) {
+            DriveAuthScopes.ALL_WITH_DRIVE_FILE
+        } else {
+            DriveAuthScopes.ALL
+        }
+        return try {
+            // If we requested drive.file but got no token, it was revoked (the flag is
+            // re-derived to false in authorizeFor); retry with base scopes so the binary
+            // backup token stays available.
+            authorizeFor(scopes)
+                ?: if (includeDriveFile) authorizeFor(DriveAuthScopes.ALL) else null
         } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
             Log.tag(KtorLogger.TAG).e(t, "authorize() threw")
-            return null
+            null
         }
+    }
+
+    /**
+     * Authorizes [scopes], re-derives + persists the `drive.file` grant from the result's
+     * granted scopes (so a revocation flips the flag off on the very next refresh), caches a
+     * non-null token, and returns the token (or `null` when resolution is required).
+     */
+    private suspend fun authorizeFor(scopes: List<Scope>): String? {
+        val request = AuthorizationRequest.builder()
+            .setRequestedScopes(scopes)
+            .build()
+        val result = authorizationClient.authorize(request).await()
+        accountStore.setDriveFileGranted(
+            result.grantedScopes.orEmpty().contains(DriveAuthScopes.DRIVE_FILE),
+        )
         val token = result.accessToken
         if (token != null) {
             accountStore.setToken(

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProvider.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProvider.kt
@@ -6,6 +6,7 @@ import com.google.android.gms.auth.api.identity.AuthorizationRequest
 import com.google.android.gms.common.api.Scope
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.core.logger.Log
+import io.github.stslex.workeeper.core.core.utils.CommonExt.runIf
 import io.github.stslex.workeeper.core.data.backup.google_drive.network.AuthTokenProvider
 import io.github.stslex.workeeper.core.data.backup.google_drive.utils.KtorLogger
 import kotlinx.coroutines.CoroutineDispatcher
@@ -44,27 +45,23 @@ internal class DriveAuthTokenProvider @Inject constructor(
         refreshTokenFromGms()
     }
 
-    private suspend fun refreshTokenFromGms(): String? {
-        // Request ONLY the scopes the account already granted: base, plus drive.file only if
-        // it was previously granted. Appdata-only users therefore request exactly
-        // DriveAuthScopes.ALL (identical to v1) and never trip an authorize() resolution.
+    // Request ONLY the scopes the account already granted: base, plus drive.file only if
+    // it was previously granted. Appdata-only users therefore request exactly
+    // DriveAuthScopes.ALL (identical to v1) and never trip an authorize() resolution.
+    private suspend fun refreshTokenFromGms(): String? = runCatching {
         val includeDriveFile = accountStore.isDriveFileGranted()
         val scopes = if (includeDriveFile) {
             DriveAuthScopes.ALL_WITH_DRIVE_FILE
         } else {
             DriveAuthScopes.ALL
         }
-        return try {
-            // If we requested drive.file but got no token, it was revoked (the flag is
-            // re-derived to false in authorizeFor); retry with base scopes so the binary
-            // backup token stays available.
-            authorizeFor(scopes)
-                ?: if (includeDriveFile) authorizeFor(DriveAuthScopes.ALL) else null
-        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-            Log.tag(KtorLogger.TAG).e(t, "authorize() threw")
-            null
-        }
+        authorizeFor(scopes)
+            ?: runIf(includeDriveFile) {
+                authorizeFor(DriveAuthScopes.ALL)
+            }
     }
+        .onFailure { t -> Log.tag(KtorLogger.TAG).e(t, "authorize() threw") }
+        .getOrNull()
 
     /**
      * Authorizes [scopes], re-derives + persists the `drive.file` grant from the result's
@@ -77,7 +74,7 @@ internal class DriveAuthTokenProvider @Inject constructor(
             .build()
         val result = authorizationClient.authorize(request).await()
         accountStore.setDriveFileGranted(
-            result.grantedScopes.orEmpty().contains(DriveAuthScopes.DRIVE_FILE),
+            result.grantedScopes.contains(DriveAuthScopes.DRIVE_FILE),
         )
         val token = result.accessToken
         if (token != null) {

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
@@ -16,6 +16,7 @@ import io.github.stslex.workeeper.core.data.backup.api.model.Account
 import io.github.stslex.workeeper.core.data.backup.api.model.AuthState
 import io.github.stslex.workeeper.core.data.backup.api.model.SignInResult
 import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import io.github.stslex.workeeper.core.data.backup.google_drive.auth.DriveBackupAuth.Companion.PLACEHOLDER_EMAIL
 import io.github.stslex.workeeper.core.data.backup.google_drive.error.DriveErrorMapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -167,8 +168,9 @@ internal class DriveBackupAuth @Inject constructor(
      * [DriveAuthTokenProvider] to refresh a `drive.file`-capable token on the next Drive call.
      */
     private suspend fun persistTokenAndGrant(result: AuthorizationResult) {
-        val driveFileGranted = result.isDriveFileGranted()
-        accountStore.setDriveFileGranted(driveFileGranted)
+        val driveFileGranted = result.isDriveFileGranted().also { granted ->
+            accountStore.setDriveFileGranted(granted)
+        }
         val freshToken = result.accessToken
         when {
             freshToken != null -> accountStore.setToken(

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
@@ -124,8 +124,7 @@ internal class DriveBackupAuth @Inject constructor(
                             clearTokenBestEffort(result.accessToken)
                             BackupResult.Failure(BackupError.MissingRequiredScope)
                         } else {
-                            captureAccessToken(result)
-                            accountStore.setDriveFileGranted(result.isDriveFileGranted())
+                            persistTokenAndGrant(result)
                             val account = result.toAccount(fetchUserInfo(result.accessToken))
                             accountStore.setAccount(account)
                             BackupResult.Success(account)
@@ -156,12 +155,29 @@ internal class DriveBackupAuth @Inject constructor(
         BackupResult.Success(Unit)
     }
 
-    private suspend fun captureAccessToken(result: AuthorizationResult) {
-        val token = result.accessToken ?: return
-        accountStore.setToken(
-            token = token,
-            expiresAtEpochMs = System.currentTimeMillis() + TOKEN_TTL_MS,
-        )
+    /**
+     * Persists the authorize result's `drive.file` grant and access token consistently.
+     *
+     * A success result can carry a newly granted scope but no fresh access token (GMS returns a
+     * null token when it deems a cached credential sufficient). The grant is written FIRST, so a
+     * concurrent [DriveAuthTokenProvider] refresh that misses the token cache requests the correct
+     * scope set. Then: cache a fresh token if one came back; otherwise, if `drive.file` is now
+     * granted, drop any cached token — it predates the grant and may be appdata-only, so serving
+     * it would 403 the visible-Drive upload until its ~50-min TTL expires. Dropping it forces
+     * [DriveAuthTokenProvider] to refresh a `drive.file`-capable token on the next Drive call.
+     */
+    private suspend fun persistTokenAndGrant(result: AuthorizationResult) {
+        val driveFileGranted = result.isDriveFileGranted()
+        accountStore.setDriveFileGranted(driveFileGranted)
+        val freshToken = result.accessToken
+        when {
+            freshToken != null -> accountStore.setToken(
+                token = freshToken,
+                expiresAtEpochMs = System.currentTimeMillis() + TOKEN_TTL_MS,
+            )
+
+            driveFileGranted -> accountStore.clearToken()
+        }
     }
 
     private suspend fun fetchUserInfo(accessToken: String?): UserInfo? {
@@ -185,8 +201,7 @@ internal class DriveBackupAuth @Inject constructor(
             clearTokenBestEffort(result.accessToken)
             return SignInResult.PartialGrant(missing)
         }
-        captureAccessToken(result)
-        accountStore.setDriveFileGranted(result.isDriveFileGranted())
+        persistTokenAndGrant(result)
         val account = result.toAccount(fetchUserInfo(result.accessToken))
         accountStore.setAccount(account)
         return SignInResult.Success(account)

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
@@ -125,7 +125,7 @@ internal class DriveBackupAuth @Inject constructor(
                             BackupResult.Failure(BackupError.MissingRequiredScope)
                         } else {
                             persistTokenAndGrant(result)
-                            val account = result.toAccount(fetchUserInfo(result.accessToken))
+                            val account = resolveAccount(result)
                             accountStore.setAccount(account)
                             BackupResult.Success(account)
                         }
@@ -202,10 +202,25 @@ internal class DriveBackupAuth @Inject constructor(
             return SignInResult.PartialGrant(missing)
         }
         persistTokenAndGrant(result)
-        val account = result.toAccount(fetchUserInfo(result.accessToken))
+        val account = resolveAccount(result)
         accountStore.setAccount(account)
         return SignInResult.Success(account)
     }
+
+    /**
+     * Resolves the account to persist for a successful authorize result.
+     *
+     * A real identity (userinfo email, else the `GoogleSignInAccount` email) always wins. When the
+     * result carries neither — an incremental `drive.file` grant that GMS satisfies with a cached
+     * credential, so `accessToken` is null AND `toGoogleSignInAccount()` is null — falling back to
+     * [PLACEHOLDER_EMAIL] would clobber the already signed-in user's email/display name purely from
+     * enabling the toggle. So in that case the existing stored account is preserved. Only a truly
+     * first-time sign-in with no derivable identity and no prior account reaches the placeholder.
+     */
+    private suspend fun resolveAccount(result: AuthorizationResult): Account =
+        result.toAccountOrNull(fetchUserInfo(result.accessToken))
+            ?: accountStore.account()
+            ?: Account(email = PLACEHOLDER_EMAIL, displayName = null)
 
     private fun AuthorizationResult.missingRequiredScopes(): List<String> {
         val granted: List<String> = grantedScopes.orEmpty()
@@ -226,12 +241,15 @@ internal class DriveBackupAuth @Inject constructor(
         }
     }
 
-    private fun AuthorizationResult.toAccount(userInfo: UserInfo?): Account {
+    /**
+     * Builds an [Account] from a real identity source, or `null` when none is available (no
+     * userinfo email and no `GoogleSignInAccount` email). The placeholder fallback lives in
+     * [resolveAccount] so callers can first preserve an existing stored identity.
+     */
+    private fun AuthorizationResult.toAccountOrNull(userInfo: UserInfo?): Account? {
         val gsa = toGoogleSignInAccount()
-        return Account(
-            email = userInfo?.email ?: gsa?.email ?: PLACEHOLDER_EMAIL,
-            displayName = userInfo?.name ?: gsa?.displayName,
-        )
+        val email = userInfo?.email ?: gsa?.email ?: return null
+        return Account(email = email, displayName = userInfo?.name ?: gsa?.displayName)
     }
 
     private companion object {

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuth.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.auth.api.identity.AuthorizationRequest
 import com.google.android.gms.auth.api.identity.AuthorizationResult
 import com.google.android.gms.auth.api.identity.ClearTokenRequest
 import com.google.android.gms.auth.api.identity.RevokeAccessRequest
+import com.google.android.gms.common.api.Scope
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.core.logger.Log
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
@@ -19,6 +20,7 @@ import io.github.stslex.workeeper.core.data.backup.google_drive.error.DriveError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -71,15 +73,27 @@ internal class DriveBackupAuth @Inject constructor(
             .launchIn(authScope)
     }
 
-    override suspend fun signIn(): SignInResult = withContext(dispatcher) {
+    override suspend fun signIn(): SignInResult = authorizeWith(DriveAuthScopes.ALL)
+
+    override suspend fun requestDriveFileAccess(): SignInResult =
+        authorizeWith(DriveAuthScopes.ALL_WITH_DRIVE_FILE)
+
+    override fun observeDriveFileGranted(): Flow<Boolean> = accountStore.observeDriveFileGranted()
+
+    /**
+     * Shared interactive authorize. [signIn] requests the base [DriveAuthScopes.ALL];
+     * [requestDriveFileAccess] adds `drive.file`. Both resolve through [resolveSignIn], which
+     * re-derives the `drive.file` grant from the result.
+     */
+    private suspend fun authorizeWith(scopes: List<Scope>): SignInResult = withContext(dispatcher) {
         runCatching {
             val request = AuthorizationRequest.builder()
-                .setRequestedScopes(DriveAuthScopes.ALL)
+                .setRequestedScopes(scopes)
                 .build()
             authorizationClient.authorize(request).await()
         }
             .onFailure { e ->
-                logger.e(e, "signIn failed")
+                logger.e(e, "authorize failed")
             }
             .fold(
                 onSuccess = { result -> resolveSignIn(result) },
@@ -111,6 +125,7 @@ internal class DriveBackupAuth @Inject constructor(
                             BackupResult.Failure(BackupError.MissingRequiredScope)
                         } else {
                             captureAccessToken(result)
+                            accountStore.setDriveFileGranted(result.isDriveFileGranted())
                             val account = result.toAccount(fetchUserInfo(result.accessToken))
                             accountStore.setAccount(account)
                             BackupResult.Success(account)
@@ -129,7 +144,7 @@ internal class DriveBackupAuth @Inject constructor(
      */
     override suspend fun signOut(): BackupResult<Unit> = withContext(dispatcher) {
         val revokeRequest = RevokeAccessRequest.builder()
-            .setScopes(DriveAuthScopes.ALL)
+            .setScopes(DriveAuthScopes.ALL_WITH_DRIVE_FILE)
             .build()
         runCatching {
             authorizationClient.revokeAccess(revokeRequest).await()
@@ -171,6 +186,7 @@ internal class DriveBackupAuth @Inject constructor(
             return SignInResult.PartialGrant(missing)
         }
         captureAccessToken(result)
+        accountStore.setDriveFileGranted(result.isDriveFileGranted())
         val account = result.toAccount(fetchUserInfo(result.accessToken))
         accountStore.setAccount(account)
         return SignInResult.Success(account)
@@ -180,6 +196,9 @@ internal class DriveBackupAuth @Inject constructor(
         val granted: List<String> = grantedScopes.orEmpty()
         return DriveAuthScopes.REQUIRED.filterNot { granted.contains(it) }
     }
+
+    private fun AuthorizationResult.isDriveFileGranted(): Boolean =
+        grantedScopes.orEmpty().contains(DriveAuthScopes.DRIVE_FILE)
 
     private suspend fun clearTokenBestEffort(badToken: String?) {
         if (badToken == null) return

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/di/AuthBindingsModule.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/di/AuthBindingsModule.kt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
+import io.github.stslex.workeeper.core.data.backup.google_drive.SnapshotExportRunnerImpl
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStore
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStoreImpl
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.DriveAuthTokenProvider
@@ -34,6 +36,10 @@ internal interface AuthBindingsModule {
     @Binds
     @Singleton
     fun bindSnapshotStorage(impl: DriveSnapshotStorage): SnapshotStorage
+
+    @Binds
+    @Singleton
+    fun bindSnapshotExportRunner(impl: SnapshotExportRunnerImpl): SnapshotExportRunner
 
     @Binds
     @Singleton

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/di/AuthBindingsModule.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/di/AuthBindingsModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStore
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStoreImpl
 import io.github.stslex.workeeper.core.data.backup.google_drive.auth.DriveAuthTokenProvider
@@ -19,6 +20,7 @@ import io.github.stslex.workeeper.core.data.backup.google_drive.network.AuthToke
 import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveApi
 import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveApiImpl
 import io.github.stslex.workeeper.core.data.backup.google_drive.storage.DriveBackupStorage
+import io.github.stslex.workeeper.core.data.backup.google_drive.storage.DriveSnapshotStorage
 import javax.inject.Singleton
 
 @Module
@@ -28,6 +30,10 @@ internal interface AuthBindingsModule {
     @Binds
     @Singleton
     fun bindBackupStorage(impl: DriveBackupStorage): BackupStorage
+
+    @Binds
+    @Singleton
+    fun bindSnapshotStorage(impl: DriveSnapshotStorage): SnapshotStorage
 
     @Binds
     @Singleton

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApi.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApi.kt
@@ -4,40 +4,51 @@ package io.github.stslex.workeeper.core.data.backup.google_drive.network
 import java.io.File
 
 /**
- * Thin Drive REST surface used by `DriveBackupStorage`. Each method maps to a
- * single Drive endpoint, scoped to `drive.appdata`. Errors are surfaced as
- * thrown exceptions and translated into
+ * Thin Drive REST surface. Each method maps to a single Drive endpoint. Errors are
+ * surfaced as thrown exceptions and translated into
  * [io.github.stslex.workeeper.core.data.backup.api.error.BackupError] variants by
  * `DriveErrorMapper`.
  *
- * Authorization headers are injected by the configured `HttpClient` (see
- * `NetworkModule`); callers do not pass tokens.
+ * The surface is **space-aware**: callers pass the Drive `spaces` and parent ids they
+ * target, so the same client serves both the binary backup path (`appDataFolder`) and
+ * the snapshot path (visible `drive`). Authorization headers are injected by the
+ * configured `HttpClient` (see `NetworkModule`); callers do not pass tokens.
  */
 internal interface DriveApi {
 
     /**
-     * `GET /drive/v3/files` against `appDataFolder` for entries with our naming
-     * prefix. Returns the parsed file rows; pagination is not used in v1 (we cap at
-     * MAX_BACKUPS = 3, so the request always fits in a single page).
+     * `GET /drive/v3/files` matching [query] within [spaces]. Returns the parsed file
+     * rows; pagination is not used in v1 (callers cap their result sets). The binary
+     * backup path passes `spaces = "appDataFolder"`; the snapshot path passes
+     * `spaces = "drive"`.
      */
-    suspend fun listFiles(): List<DriveFileDto>
+    suspend fun listFiles(spaces: String, query: String): List<DriveFileDto>
 
     /**
      * `POST /upload/drive/v3/files?uploadType=multipart` with a `multipart/related`
-     * body containing the JSON metadata and the binary db payload. Returns the
-     * created Drive file row.
-     *
-     * Caller owns [content]; impl reads but does not delete it.
+     * body containing the JSON [metadata] and the binary payload read from [content].
+     * Returns the created Drive file row. Caller owns [content]; impl reads but does
+     * not delete it.
      */
-    suspend fun uploadMultipart(
-        metadata: DriveFileMetadataDto,
-        content: File,
-    ): DriveFileDto
+    suspend fun uploadMultipart(metadata: DriveFileMetadataDto, content: File): DriveFileDto
 
     /**
-     * `GET /drive/v3/files/{fileId}?alt=media`. Streams the response body into
-     * [target], overwriting it. Returns bytes written for size verification by the
-     * caller.
+     * In-memory [ByteArray] overload of [uploadMultipart] — same multipart upload for
+     * payloads already in memory (e.g. the JSON snapshot). [DriveFileMetadataDto.parents]
+     * decides the destination; [DriveFileMetadataDto.mimeType] the content type.
+     */
+    suspend fun uploadMultipart(metadata: DriveFileMetadataDto, content: ByteArray): DriveFileDto
+
+    /**
+     * `POST /drive/v3/files` creating an empty folder named [name] in the user's visible
+     * Drive (My Drive root). Used by the snapshot storage to create its `Workeeper/`
+     * folder. Returns the created folder row.
+     */
+    suspend fun createFolder(name: String): DriveFileDto
+
+    /**
+     * `GET /drive/v3/files/{fileId}?alt=media`. Streams the response body into [target],
+     * overwriting it. Returns bytes written for size verification by the caller.
      */
     suspend fun downloadFile(fileId: String, target: File): Long
 

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApiImpl.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApiImpl.kt
@@ -20,13 +20,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Ktor-backed `DriveApi` for Drive v3 `appdata`-scoped endpoints. All requests run
- * on [dispatcher]; Authorization headers are injected by `DriveAuthPlugin` on the
- * shared `HttpClient`.
+ * Ktor-backed `DriveApi` for Drive v3 endpoints. All requests run on [dispatcher];
+ * Authorization headers are injected by `DriveAuthPlugin` on the shared `HttpClient`.
  *
- * Upload + download buffer the db file fully in memory. v1 backups are bounded by
- * `MAX_BACKUPS = 3` and typical workout-app db sizes (single-digit MB), so the
- * trade-off favors implementation simplicity over streaming.
+ * Upload + download buffer the payload fully in memory. v1 backups/snapshots are
+ * bounded by `MAX_BACKUPS = 3` and small db/JSON sizes, so the trade-off favors
+ * implementation simplicity over streaming.
  */
 @Singleton
 internal class DriveApiImpl @Inject constructor(
@@ -39,38 +38,37 @@ internal class DriveApiImpl @Inject constructor(
         ignoreUnknownKeys = true
     }
 
-    override suspend fun listFiles(): List<DriveFileDto> = withContext(dispatcher) {
-        httpClient
-            .get(DRIVE_FILES_URL) {
-                parameter("spaces", APP_DATA_FOLDER)
-                parameter("q", "name contains '$BACKUP_FILE_PREFIX' and trashed=false")
-                parameter("fields", "files(id,name,createdTime,size,appProperties)")
-                parameter("pageSize", PAGE_SIZE)
-            }
-            .body<DriveFileListDto>()
-            .files
-    }
+    override suspend fun listFiles(spaces: String, query: String): List<DriveFileDto> =
+        withContext(dispatcher) {
+            httpClient
+                .get(DRIVE_FILES_URL) {
+                    parameter("spaces", spaces)
+                    parameter("q", query)
+                    parameter("fields", "files(id,name,createdTime,size,appProperties)")
+                    parameter("pageSize", PAGE_SIZE)
+                }
+                .body<DriveFileListDto>()
+                .files
+        }
 
     override suspend fun uploadMultipart(
         metadata: DriveFileMetadataDto,
         content: File,
-    ): DriveFileDto = withContext(dispatcher) {
-        val boundary = "workeeper-${System.currentTimeMillis()}"
-        val metadataPart = (
-            "--$boundary\r\n" +
-                "Content-Type: application/json; charset=UTF-8\r\n\r\n" +
-                metadataJson.encodeToString(metadata) +
-                "\r\n--$boundary\r\n" +
-                "Content-Type: ${metadata.mimeType}\r\n\r\n"
-            ).toByteArray(Charsets.UTF_8)
-        val closingPart = "\r\n--$boundary--\r\n".toByteArray(Charsets.UTF_8)
-        val body = metadataPart + content.readBytes() + closingPart
+    ): DriveFileDto = withContext(dispatcher) { postMultipart(metadata, content.readBytes()) }
 
+    override suspend fun uploadMultipart(
+        metadata: DriveFileMetadataDto,
+        content: ByteArray,
+    ): DriveFileDto = withContext(dispatcher) { postMultipart(metadata, content) }
+
+    override suspend fun createFolder(name: String): DriveFileDto = withContext(dispatcher) {
+        val body = metadataJson
+            .encodeToString(DriveFolderRequestDto(name = name, mimeType = FOLDER_MIME_TYPE))
+            .toByteArray(Charsets.UTF_8)
         httpClient
-            .post(DRIVE_UPLOAD_URL) {
-                parameter("uploadType", "multipart")
-                parameter("fields", "id,name,createdTime,size,appProperties")
-                contentType(ContentType.parse("multipart/related; boundary=$boundary"))
+            .post(DRIVE_FILES_URL) {
+                parameter("fields", "id,name,createdTime")
+                contentType(ContentType.Application.Json)
                 setBody(body)
             }
             .body<DriveFileDto>()
@@ -93,11 +91,40 @@ internal class DriveApiImpl @Inject constructor(
         }
     }
 
+    /**
+     * Builds a `multipart/related` body (JSON metadata part + raw payload) and POSTs it.
+     * Shared by both [uploadMultipart] overloads; the binary path reads its file into
+     * [content] first, so its on-the-wire request is byte-for-byte what it was before.
+     */
+    private suspend fun postMultipart(
+        metadata: DriveFileMetadataDto,
+        content: ByteArray,
+    ): DriveFileDto {
+        val boundary = "workeeper-${System.currentTimeMillis()}"
+        val metadataPart = (
+            "--$boundary\r\n" +
+                "Content-Type: application/json; charset=UTF-8\r\n\r\n" +
+                metadataJson.encodeToString(metadata) +
+                "\r\n--$boundary\r\n" +
+                "Content-Type: ${metadata.mimeType}\r\n\r\n"
+            ).toByteArray(Charsets.UTF_8)
+        val closingPart = "\r\n--$boundary--\r\n".toByteArray(Charsets.UTF_8)
+        val body = metadataPart + content + closingPart
+
+        return httpClient
+            .post(DRIVE_UPLOAD_URL) {
+                parameter("uploadType", "multipart")
+                parameter("fields", "id,name,createdTime,size,appProperties")
+                contentType(ContentType.parse("multipart/related; boundary=$boundary"))
+                setBody(body)
+            }
+            .body<DriveFileDto>()
+    }
+
     private companion object {
         const val DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files"
         const val DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files"
-        const val APP_DATA_FOLDER = "appDataFolder"
-        const val BACKUP_FILE_PREFIX = "app_"
         const val PAGE_SIZE = "100"
+        const val FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
     }
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveDtos.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveDtos.kt
@@ -36,3 +36,13 @@ internal data class DriveFileMetadataDto(
     @SerialName("mimeType") val mimeType: String,
     @SerialName("appProperties") val appProperties: Map<String, String>,
 )
+
+/**
+ * Metadata-only body for the create-folder endpoint (`POST /drive/v3/files` with no
+ * media). No `parents` — the folder is created at the visible My Drive root.
+ */
+@Serializable
+internal data class DriveFolderRequestDto(
+    @SerialName("name") val name: String,
+    @SerialName("mimeType") val mimeType: String,
+)

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorage.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorage.kt
@@ -44,7 +44,7 @@ internal class DriveBackupStorage @Inject constructor(
 
     override suspend fun listBackups(): BackupResult<List<BackupRef>> = withContext(dispatcher) {
         runCatching {
-            withTokenRefreshOn401 { driveApi.listFiles() }
+            withTokenRefreshOn401 { driveApi.listFiles(spaces = APP_DATA_FOLDER, query = LIST_QUERY) }
                 .mapNotNull(DriveFileMapper::toBackupRef)
                 .sortedByDescending { it.manifest.createdAtEpochMs }
         }.fold(
@@ -104,7 +104,7 @@ internal class DriveBackupStorage @Inject constructor(
      */
     private suspend fun rotate() {
         runCatching {
-            val current = withTokenRefreshOn401 { driveApi.listFiles() }
+            val current = withTokenRefreshOn401 { driveApi.listFiles(spaces = APP_DATA_FOLDER, query = LIST_QUERY) }
                 .mapNotNull(DriveFileMapper::toBackupRef)
             val toDelete = RotationPolicy.refsToDelete(current, BackupConstants.MAX_BACKUPS)
             toDelete.forEach { ref ->
@@ -151,5 +151,8 @@ internal class DriveBackupStorage @Inject constructor(
         const val APP_DATA_FOLDER = "appDataFolder"
         const val SQLITE_MIME_TYPE = "application/x-sqlite3"
         const val SIZE_TOLERANCE_BYTES = 16L
+
+        /** `appDataFolder` listing query for our backup files (mirrors the upload naming). */
+        const val LIST_QUERY = "name contains '${BackupConstants.FILE_PREFIX}' and trashed=false"
     }
 }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorage.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorage.kt
@@ -106,7 +106,9 @@ internal class DriveBackupStorage @Inject constructor(
         runCatching {
             val current = withTokenRefreshOn401 { driveApi.listFiles(spaces = APP_DATA_FOLDER, query = LIST_QUERY) }
                 .mapNotNull(DriveFileMapper::toBackupRef)
-            val toDelete = RotationPolicy.refsToDelete(current, BackupConstants.MAX_BACKUPS)
+            val toDelete = RotationPolicy.refsToDelete(current, BackupConstants.MAX_BACKUPS) {
+                it.manifest.createdAtEpochMs
+            }
             toDelete.forEach { ref ->
                 runCatching { withTokenRefreshOn401 { driveApi.deleteFile(ref.remoteId) } }
                     .onFailure { logger.e(it, "rotation: delete ${ref.remoteId} failed") }

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorage.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorage.kt
@@ -55,17 +55,46 @@ internal class DriveSnapshotStorage @Inject constructor(
             )
         }
 
+    /**
+     * Deletes every snapshot file in the visible folder (consent withdrawal / sign-out cleanup).
+     * No-op when `drive.file` is not granted (can't see the visible files without the scope) or
+     * when no folder exists yet — and it never CREATES a folder, unlike [resolveFolderId]. The
+     * empty folder is left in place; only `workeeper_export_*` files are removed. Per-file delete
+     * failures are swallowed (best-effort); a list failure surfaces as a typed [BackupResult].
+     */
+    override suspend fun deleteAllSnapshots(): BackupResult<Unit> = withContext(dispatcher) {
+        if (!accountStore.isDriveFileGranted()) return@withContext BackupResult.Success(Unit)
+        runCatching {
+            val folderId = existingFolderId() ?: return@runCatching
+            val files = withTokenRefreshOn401 {
+                driveApi.listFiles(spaces = DRIVE_SPACE, query = exportQuery(folderId))
+            }
+            files.forEach { file ->
+                runCatching { withTokenRefreshOn401 { driveApi.deleteFile(file.id) } }
+                    .onFailure { logger.e(it, "deleteAllSnapshots: delete ${file.id} failed") }
+            }
+        }.fold(
+            onSuccess = { BackupResult.Success(Unit) },
+            onFailure = { BackupResult.Failure(DriveErrorMapper.toBackupError(it)) },
+        )
+    }
+
     /** Cached id if present; else find the oldest existing `Workeeper/` folder, else create one. */
     private suspend fun resolveFolderId(): String {
         accountStore.snapshotFolderId()?.let { return it }
-        val existing = withTokenRefreshOn401 {
-            driveApi.listFiles(spaces = DRIVE_SPACE, query = FOLDER_QUERY)
-        }.minByOrNull { it.createdTime.orEmpty() }
-        val id = existing?.id
+        val id = findFolderInDrive()?.id
             ?: withTokenRefreshOn401 { driveApi.createFolder(SnapshotConstants.FOLDER_NAME) }.id
         accountStore.setSnapshotFolderId(id)
         return id
     }
+
+    /** Cached id, else the oldest existing `Workeeper/` folder in Drive, else `null` (no create). */
+    private suspend fun existingFolderId(): String? =
+        accountStore.snapshotFolderId() ?: findFolderInDrive()?.id
+
+    private suspend fun findFolderInDrive(): DriveFileDto? = withTokenRefreshOn401 {
+        driveApi.listFiles(spaces = DRIVE_SPACE, query = FOLDER_QUERY)
+    }.minByOrNull { it.createdTime.orEmpty() }
 
     /**
      * Uploads to [folderId]; if the folder is gone (`404`, e.g. user trashed it), drops the

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorage.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorage.kt
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.google_drive.storage
+
+import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.core.logger.Log
+import io.github.stslex.workeeper.core.data.backup.api.BackupConstants
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotConstants
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
+import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStore
+import io.github.stslex.workeeper.core.data.backup.google_drive.auth.TokenInvalidator
+import io.github.stslex.workeeper.core.data.backup.google_drive.error.DriveErrorMapper
+import io.github.stslex.workeeper.core.data.backup.google_drive.error.DriveException
+import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveApi
+import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveFileDto
+import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveFileMetadataDto
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * `SnapshotStorage` impl over Drive v3 files in the *visible* `drive` space — the sibling
+ * of `DriveBackupStorage` (which targets the hidden `appDataFolder`). It owns the
+ * `Workeeper/` folder lifecycle (create-or-lookup + id cache), uploads the JSON bytes, and
+ * prunes old snapshots via the shared [RotationPolicy].
+ *
+ * 401 handling mirrors `DriveBackupStorage` ([withTokenRefreshOn401]); a stale cached
+ * folder id surfaces as a `404` on upload, which is recovered once (recreate + retry).
+ */
+@Singleton
+internal class DriveSnapshotStorage @Inject constructor(
+    private val driveApi: DriveApi,
+    private val accountStore: AccountDataStore,
+    private val tokenInvalidator: TokenInvalidator,
+    @IODispatcher private val dispatcher: CoroutineDispatcher,
+) : SnapshotStorage {
+
+    private val logger = Log.tag("DriveSnapshotStorage")
+
+    override suspend fun uploadSnapshot(content: ByteArray): BackupResult<Unit> =
+        withContext(dispatcher) {
+            runCatching {
+                val name = SnapshotConstants.FILE_PREFIX +
+                    System.currentTimeMillis() +
+                    SnapshotConstants.FILE_SUFFIX
+                val folderId = resolveFolderId()
+                val effectiveFolderId = uploadWithFolderRecovery(name, content, folderId)
+                rotate(effectiveFolderId)
+            }.fold(
+                onSuccess = { BackupResult.Success(Unit) },
+                onFailure = { BackupResult.Failure(DriveErrorMapper.toBackupError(it)) },
+            )
+        }
+
+    /** Cached id if present; else find the oldest existing `Workeeper/` folder, else create one. */
+    private suspend fun resolveFolderId(): String {
+        accountStore.snapshotFolderId()?.let { return it }
+        val existing = withTokenRefreshOn401 {
+            driveApi.listFiles(spaces = DRIVE_SPACE, query = FOLDER_QUERY)
+        }.minByOrNull { it.createdTime.orEmpty() }
+        val id = existing?.id
+            ?: withTokenRefreshOn401 { driveApi.createFolder(SnapshotConstants.FOLDER_NAME) }.id
+        accountStore.setSnapshotFolderId(id)
+        return id
+    }
+
+    /**
+     * Uploads to [folderId]; if the folder is gone (`404`, e.g. user trashed it), drops the
+     * cached id, recreates the folder, and retries once. Returns the folder id actually
+     * uploaded into, so rotation prunes the right folder.
+     */
+    private suspend fun uploadWithFolderRecovery(
+        name: String,
+        content: ByteArray,
+        folderId: String,
+    ): String = try {
+        withTokenRefreshOn401 { driveApi.uploadMultipart(metadata(name, folderId), content) }
+        folderId
+    } catch (notFound: ClientRequestException) {
+        if (notFound.response.status != HttpStatusCode.NotFound) throw notFound
+        logger.w(notFound) { "snapshot folder $folderId missing — recreating and retrying once" }
+        accountStore.setSnapshotFolderId(null)
+        val newId = withTokenRefreshOn401 { driveApi.createFolder(SnapshotConstants.FOLDER_NAME) }.id
+        accountStore.setSnapshotFolderId(newId)
+        withTokenRefreshOn401 { driveApi.uploadMultipart(metadata(name, newId), content) }
+        newId
+    }
+
+    /**
+     * Best-effort rotation: list snapshots in [folderId] and delete the oldest beyond
+     * [BackupConstants.MAX_BACKUPS]. Failures never propagate — the upload already
+     * succeeded and leftover files are non-blocking housekeeping.
+     */
+    private suspend fun rotate(folderId: String) {
+        runCatching {
+            val files = withTokenRefreshOn401 {
+                driveApi.listFiles(spaces = DRIVE_SPACE, query = exportQuery(folderId))
+            }
+            RotationPolicy.refsToDelete(files, BackupConstants.MAX_BACKUPS) { it.createdAtEpochMs() }
+                .forEach { file ->
+                    runCatching { withTokenRefreshOn401 { driveApi.deleteFile(file.id) } }
+                        .onFailure { logger.e(it, "snapshot rotation: delete ${file.id} failed") }
+                }
+        }.onFailure { logger.e(it, "snapshot rotation: list failed") }
+    }
+
+    private fun metadata(name: String, folderId: String): DriveFileMetadataDto =
+        DriveFileMetadataDto(
+            name = name,
+            parents = listOf(folderId),
+            mimeType = JSON_MIME_TYPE,
+            appProperties = emptyMap(),
+        )
+
+    /** Recovers the creation epoch from the `workeeper_export_<epochMs>.json` name. */
+    private fun DriveFileDto.createdAtEpochMs(): Long = name
+        .removePrefix(SnapshotConstants.FILE_PREFIX)
+        .removeSuffix(SnapshotConstants.FILE_SUFFIX)
+        .toLongOrNull() ?: 0L
+
+    private suspend fun <T> withTokenRefreshOn401(block: suspend () -> T): T = try {
+        block()
+    } catch (firstFailure: DriveException.AuthRevoked) {
+        logger.w(firstFailure) { "401 — invalidating token and retrying once" }
+        tokenInvalidator.invalidate()
+        block()
+    }
+
+    private companion object {
+        const val DRIVE_SPACE = "drive"
+        const val JSON_MIME_TYPE = "application/json"
+
+        val FOLDER_QUERY = "mimeType='application/vnd.google-apps.folder' and " +
+            "name='${SnapshotConstants.FOLDER_NAME}' and trashed=false"
+
+        fun exportQuery(folderId: String): String = "'$folderId' in parents and " +
+            "name contains '${SnapshotConstants.FILE_PREFIX}' and trashed=false"
+    }
+}

--- a/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/RotationPolicy.kt
+++ b/core/data/backup/google-drive/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/RotationPolicy.kt
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.core.data.backup.google_drive.storage
 
-import io.github.stslex.workeeper.core.data.backup.api.model.BackupRef
-
 /**
- * Pure rotation logic. Given the full set of remote backups and a retention
- * cap, decides which refs to delete (oldest first by `manifest.createdAtEpochMs`).
- * Stateless; tests live in `RotationPolicyTest`.
+ * Pure rotation logic. Given the full set of remote files and a retention cap, decides
+ * which to delete (oldest first by [createdAtEpochMs]). Generic over the ref type so the
+ * binary backup (`BackupRef`) and the JSON snapshot (`DriveFileDto`) paths share one
+ * policy. Stateless; tests live in `RotationPolicyTest`.
  */
 internal object RotationPolicy {
 
-    fun refsToDelete(refs: List<BackupRef>, max: Int): List<BackupRef> {
+    fun <T> refsToDelete(refs: List<T>, max: Int, createdAtEpochMs: (T) -> Long): List<T> {
         if (refs.size <= max) return emptyList()
         return refs
-            .sortedBy { it.manifest.createdAtEpochMs }
+            .sortedBy(createdAtEpochMs)
             .take(refs.size - max)
     }
 }

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
@@ -3,6 +3,8 @@ package io.github.stslex.workeeper.core.data.backup.google_drive
 
 import android.app.Application
 import android.content.Context
+import io.github.stslex.workeeper.core.core.logger.Log
+import io.github.stslex.workeeper.core.core.logger.Logger
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
 import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
@@ -14,10 +16,15 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
@@ -36,6 +43,21 @@ internal class SnapshotExportRunnerImplTest {
     private val exporter = mockk<DatabaseJsonExporter>(relaxed = true)
     private val snapshotStorage = mockk<SnapshotStorage>(relaxed = true)
     private val context = mockk<Context>(relaxed = true)
+    private val logger = mockk<Logger>(relaxed = true)
+
+    @BeforeEach
+    fun setUpLogger() {
+        // The runner builds its logger via Log.tag(TAG) at construction; stub it so the
+        // transient-vs-non-fatal classification (w vs e) is observable and the real Crashlytics
+        // facade isn't touched.
+        mockkObject(Log)
+        every { Log.tag(any()) } returns logger
+    }
+
+    @AfterEach
+    fun tearDownLogger() {
+        unmockkObject(Log)
+    }
 
     private fun runner() = SnapshotExportRunnerImpl(
         preferences = preferences,
@@ -96,15 +118,62 @@ internal class SnapshotExportRunnerImplTest {
     }
 
     @Test
-    fun `swallows transient and unexpected upload failures and never throws`() = runTest {
+    fun `transient NetworkUnavailable upload failure is logged as warning, not a non-fatal`() =
+        runTest {
+            markEligible()
+            coEvery { snapshotStorage.uploadSnapshot(any()) } returns
+                BackupResult.Failure(BackupError.NetworkUnavailable)
+
+            runner().runIfEligible() // must not throw
+
+            // Transient -> logger.w (no Crashlytics non-fatal); never logger.e.
+            verify(exactly = 1) { logger.w(any<() -> String>()) }
+            verify(exactly = 0) { logger.e(any(), any()) }
+        }
+
+    @Test
+    fun `transient AuthRevoked upload failure is logged as warning, not a non-fatal`() = runTest {
         markEligible()
         coEvery { snapshotStorage.uploadSnapshot(any()) } returns
-            BackupResult.Failure(BackupError.NetworkUnavailable) andThen
+            BackupResult.Failure(BackupError.AuthRevoked)
+
+        runner().runIfEligible() // must not throw
+
+        verify(exactly = 1) { logger.w(any<() -> String>()) }
+        verify(exactly = 0) { logger.e(any(), any()) }
+    }
+
+    @Test
+    fun `unexpected Io upload failure is recorded as a non-fatal via the error log`() = runTest {
+        markEligible()
+        coEvery { snapshotStorage.uploadSnapshot(any()) } returns
             BackupResult.Failure(BackupError.Io(IOException("disk")))
 
-        runner().runIfEligible() // transient -> log-only, no throw
-        runner().runIfEligible() // unexpected -> non-fatal, no throw
+        runner().runIfEligible() // must not throw
 
-        coVerify(exactly = 2) { snapshotStorage.uploadSnapshot(any()) }
+        // Unexpected -> logger.e (records a Crashlytics non-fatal); never the transient warning.
+        verify(exactly = 1) { logger.e(any(), any()) }
+        verify(exactly = 0) { logger.w(any<() -> String>()) }
+    }
+
+    @Test
+    fun `runIfEligibleAwaiting exports and uploads when toggle on and drive_file granted`() =
+        runTest {
+            markEligible()
+
+            runner().runIfEligibleAwaiting()
+
+            coVerify(exactly = 1) { exporter.export(any(), any(), any()) }
+            coVerify(exactly = 1) { snapshotStorage.uploadSnapshot(any()) }
+        }
+
+    @Test
+    fun `runIfEligibleAwaiting is a no-op when the toggle is disabled`() = runTest {
+        every { preferences.observe() } returns flowOf(BackupPreferences.DEFAULT.copy(aiExportEnabled = false))
+
+        runner().runIfEligibleAwaiting()
+
+        coVerify(exactly = 0) { exporter.export(any(), any(), any()) }
+        coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
     }
 }

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.google_drive
+
+import android.app.Application
+import android.content.Context
+import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotStorage
+import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
+import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferences
+import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferencesRepository
+import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+@Config(application = SnapshotExportRunnerImplTest.TestApplication::class, sdk = [33])
+internal class SnapshotExportRunnerImplTest {
+
+    class TestApplication : Application()
+
+    private val preferences = mockk<BackupPreferencesRepository>(relaxed = true)
+    private val backupAuth = mockk<BackupAuth>(relaxed = true)
+    private val exporter = mockk<DatabaseJsonExporter>(relaxed = true)
+    private val snapshotStorage = mockk<SnapshotStorage>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+
+    private fun runner() = SnapshotExportRunnerImpl(
+        preferences = preferences,
+        backupAuth = backupAuth,
+        exporter = exporter,
+        snapshotStorage = snapshotStorage,
+        context = context,
+        dispatcher = UnconfinedTestDispatcher(),
+    )
+
+    private fun markEligible() {
+        every { preferences.observe() } returns flowOf(BackupPreferences.DEFAULT.copy(aiExportEnabled = true))
+        every { backupAuth.observeDriveFileGranted() } returns flowOf(true)
+        coEvery { exporter.export(any(), any(), any()) } returns "{}".toByteArray()
+        coEvery { snapshotStorage.uploadSnapshot(any()) } returns BackupResult.Success(Unit)
+    }
+
+    @Test
+    fun `no-op when the toggle is disabled`() = runTest {
+        every { preferences.observe() } returns flowOf(BackupPreferences.DEFAULT.copy(aiExportEnabled = false))
+
+        runner().runIfEligible()
+
+        coVerify(exactly = 0) { exporter.export(any(), any(), any()) }
+        coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
+    }
+
+    @Test
+    fun `no-op when drive_file is not granted`() = runTest {
+        every { preferences.observe() } returns flowOf(BackupPreferences.DEFAULT.copy(aiExportEnabled = true))
+        every { backupAuth.observeDriveFileGranted() } returns flowOf(false)
+
+        runner().runIfEligible()
+
+        coVerify(exactly = 0) { exporter.export(any(), any(), any()) }
+        coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
+    }
+
+    @Test
+    fun `exports and uploads when toggle on and drive_file granted`() = runTest {
+        markEligible()
+
+        runner().runIfEligible()
+
+        coVerify(exactly = 1) { exporter.export(any(), any(), any()) }
+        coVerify(exactly = 1) { snapshotStorage.uploadSnapshot(any()) }
+    }
+
+    @Test
+    fun `swallows exporter exception and never throws`() = runTest {
+        every { preferences.observe() } returns flowOf(BackupPreferences.DEFAULT.copy(aiExportEnabled = true))
+        every { backupAuth.observeDriveFileGranted() } returns flowOf(true)
+        coEvery { exporter.export(any(), any(), any()) } throws RuntimeException("boom")
+
+        runner().runIfEligible() // must not throw
+
+        coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
+    }
+
+    @Test
+    fun `swallows transient and unexpected upload failures and never throws`() = runTest {
+        markEligible()
+        coEvery { snapshotStorage.uploadSnapshot(any()) } returns
+            BackupResult.Failure(BackupError.NetworkUnavailable) andThen
+            BackupResult.Failure(BackupError.Io(IOException("disk")))
+
+        runner().runIfEligible() // transient -> log-only, no throw
+        runner().runIfEligible() // unexpected -> non-fatal, no throw
+
+        coVerify(exactly = 2) { snapshotStorage.uploadSnapshot(any()) }
+    }
+}

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/SnapshotExportRunnerImplTest.kt
@@ -176,4 +176,35 @@ internal class SnapshotExportRunnerImplTest {
         coVerify(exactly = 0) { exporter.export(any(), any(), any()) }
         coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
     }
+
+    @Test
+    fun `clearSnapshots delegates to storage deleteAllSnapshots (no toggle gate)`() = runTest {
+        // No eligibility stubbing: deletion must run even though the toggle is off (it is invoked
+        // precisely on consent withdrawal). The grant gate lives in the storage layer.
+        coEvery { snapshotStorage.deleteAllSnapshots() } returns BackupResult.Success(Unit)
+
+        runner().clearSnapshots()
+
+        coVerify(exactly = 1) { snapshotStorage.deleteAllSnapshots() }
+        coVerify(exactly = 0) { snapshotStorage.uploadSnapshot(any()) }
+    }
+
+    @Test
+    fun `clearSnapshots swallows a storage failure and never throws`() = runTest {
+        coEvery { snapshotStorage.deleteAllSnapshots() } returns
+            BackupResult.Failure(BackupError.Io(IOException("disk")))
+
+        runner().clearSnapshots() // must not throw
+
+        coVerify(exactly = 1) { snapshotStorage.deleteAllSnapshots() }
+    }
+
+    @Test
+    fun `clearSnapshots swallows a thrown exception and never throws`() = runTest {
+        coEvery { snapshotStorage.deleteAllSnapshots() } throws RuntimeException("boom")
+
+        runner().clearSnapshots() // must not throw
+
+        coVerify(exactly = 1) { snapshotStorage.deleteAllSnapshots() }
+    }
 }

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProviderTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveAuthTokenProviderTest.kt
@@ -3,8 +3,10 @@ package io.github.stslex.workeeper.core.data.backup.google_drive.auth
 
 import android.app.Application
 import com.google.android.gms.auth.api.identity.AuthorizationClient
+import com.google.android.gms.auth.api.identity.AuthorizationRequest
 import com.google.android.gms.auth.api.identity.AuthorizationResult
 import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.Scope
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.tasks.Tasks
 import io.github.stslex.workeeper.core.data.backup.api.model.Account
@@ -141,5 +143,92 @@ internal class DriveAuthTokenProviderTest {
 
         assertEquals("first-token", token)
         coVerify(exactly = 1) { accountStore.setToken("first-token", any()) }
+    }
+
+    @Test
+    fun `appdata-only refresh requests only the base scopes and never drive_file`() = runTest {
+        coEvery { accountStore.token() } returns null
+        coEvery { accountStore.isDriveFileGranted() } returns false
+        val authResult = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { accessToken } returns "fresh"
+            every { grantedScopes } returns listOf(DriveAuthScopes.DRIVE_APPDATA)
+        }
+        val captured = slot<AuthorizationRequest>()
+        every { authorizationClient.authorize(capture(captured)) } returns Tasks.forResult(authResult)
+
+        newProvider().currentToken()
+
+        val scopes = captured.captured.requestedScopes.map(Scope::getScopeUri).toSet()
+        assertTrue(
+            DriveAuthScopes.DRIVE_FILE !in scopes,
+            "appdata-only silent refresh must not request drive.file (would force resolution): $scopes",
+        )
+        assertTrue(DriveAuthScopes.DRIVE_APPDATA in scopes)
+    }
+
+    @Test
+    fun `drive_file-granted refresh requests drive_file and re-persists the grant`() = runTest {
+        coEvery { accountStore.token() } returns null
+        coEvery { accountStore.isDriveFileGranted() } returns true
+        val authResult = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { accessToken } returns "fresh"
+            every { grantedScopes } returns listOf(
+                DriveAuthScopes.DRIVE_APPDATA,
+                DriveAuthScopes.DRIVE_FILE,
+            )
+        }
+        val captured = slot<AuthorizationRequest>()
+        every { authorizationClient.authorize(capture(captured)) } returns Tasks.forResult(authResult)
+
+        newProvider().currentToken()
+
+        val scopes = captured.captured.requestedScopes.map(Scope::getScopeUri).toSet()
+        assertTrue(DriveAuthScopes.DRIVE_FILE in scopes, "expected drive.file requested: $scopes")
+        coVerify { accountStore.setDriveFileGranted(true) }
+    }
+
+    @Test
+    fun `refresh re-derives driveFileGranted to false when result omits drive_file`() = runTest {
+        coEvery { accountStore.token() } returns null
+        coEvery { accountStore.isDriveFileGranted() } returns false
+        val authResult = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { accessToken } returns "fresh"
+            every { grantedScopes } returns listOf(DriveAuthScopes.DRIVE_APPDATA)
+        }
+        every { authorizationClient.authorize(any()) } returns Tasks.forResult(authResult)
+
+        newProvider().currentToken()
+
+        coVerify { accountStore.setDriveFileGranted(false) }
+    }
+
+    @Test
+    fun `refresh retries with base scopes when drive_file was revoked`() = runTest {
+        coEvery { accountStore.token() } returns null
+        coEvery { accountStore.isDriveFileGranted() } returns true
+        val revoked = mockk<AuthorizationResult> {
+            every { hasResolution() } returns true
+            every { accessToken } returns null
+            every { grantedScopes } returns listOf(DriveAuthScopes.DRIVE_APPDATA)
+        }
+        val base = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { accessToken } returns "base-token"
+            every { grantedScopes } returns listOf(DriveAuthScopes.DRIVE_APPDATA)
+        }
+        val requests = mutableListOf<AuthorizationRequest>()
+        every { authorizationClient.authorize(capture(requests)) } returns
+            Tasks.forResult(revoked) andThen Tasks.forResult(base)
+
+        val token = newProvider().currentToken()
+
+        assertEquals("base-token", token)
+        assertEquals(2, requests.size)
+        assertTrue(DriveAuthScopes.DRIVE_FILE in requests[0].requestedScopes.map(Scope::getScopeUri))
+        assertTrue(DriveAuthScopes.DRIVE_FILE !in requests[1].requestedScopes.map(Scope::getScopeUri))
+        coVerify { accountStore.setDriveFileGranted(false) }
     }
 }

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
@@ -521,7 +521,38 @@ internal class DriveBackupAuthTest {
         val scopes = captured.captured.requestedScopes.map(Scope::getScopeUri).toSet()
         assertTrue(scopes.contains(DriveAuthScopes.DRIVE_FILE), "expected drive.file requested, got $scopes")
         coVerify { accountStore.setDriveFileGranted(true) }
+        // Fresh token present -> cache it, never clear.
+        coVerify(exactly = 1) { accountStore.setToken(token = "tok", expiresAtEpochMs = any()) }
+        coVerify(exactly = 0) { accountStore.clearToken() }
     }
+
+    @Test
+    fun `requestDriveFileAccess clears stale cached token when drive_file granted with no fresh token`() =
+        runTest {
+            // GMS can return a Success that grants drive.file but carries no access token (it
+            // deems a cached credential sufficient). The cached token predates the grant and may
+            // be appdata-only, so it must be dropped to force a drive.file-capable refresh rather
+            // than 403 the visible-Drive upload until its TTL expires.
+            val authResult = mockk<AuthorizationResult> {
+                every { hasResolution() } returns false
+                every { grantedScopes } returns listOf(
+                    DriveAuthScopes.DRIVE_APPDATA,
+                    DriveAuthScopes.USERINFO_EMAIL,
+                    DriveAuthScopes.USERINFO_PROFILE,
+                    DriveAuthScopes.DRIVE_FILE,
+                )
+                every { toGoogleSignInAccount() } returns null
+                every { accessToken } returns null
+            }
+            every { authorizationClient.authorize(any()) } returns Tasks.forResult(authResult)
+
+            val result = newAuth().requestDriveFileAccess()
+
+            assertTrue(result is SignInResult.Success, "expected Success, got $result")
+            coVerify { accountStore.setDriveFileGranted(true) }
+            coVerify(exactly = 1) { accountStore.clearToken() }
+            coVerify(exactly = 0) { accountStore.setToken(any(), any()) }
+        }
 
     @Test
     fun `completeSignIn persists driveFileGranted true when drive_file granted`() = runTest {

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
@@ -46,6 +46,7 @@ internal class DriveBackupAuthTest {
     private val accountFlow = MutableStateFlow<Account?>(null)
     private val accountStore = mockk<AccountDataStore>(relaxed = true).also {
         every { it.observeAccount() } returns accountFlow
+        coEvery { it.account() } coAnswers { accountFlow.value }
         coEvery { it.setAccount(any()) } coAnswers {
             accountFlow.value = firstArg()
         }
@@ -552,6 +553,40 @@ internal class DriveBackupAuthTest {
             coVerify { accountStore.setDriveFileGranted(true) }
             coVerify(exactly = 1) { accountStore.clearToken() }
             coVerify(exactly = 0) { accountStore.setToken(any(), any()) }
+        }
+
+    @Test
+    fun `requestDriveFileAccess preserves existing account when grant carries no fresh identity`() =
+        runTest {
+            // Already signed in with a real identity. Enabling AI export drives an incremental
+            // drive.file grant that GMS satisfies with a cached credential: success, but no fresh
+            // accessToken and no GoogleSignInAccount. The placeholder must NOT clobber the stored
+            // email/display name.
+            accountFlow.value = Account(email = "real@example.com", displayName = "Real User")
+            val authResult = mockk<AuthorizationResult> {
+                every { hasResolution() } returns false
+                every { grantedScopes } returns listOf(
+                    DriveAuthScopes.DRIVE_APPDATA,
+                    DriveAuthScopes.USERINFO_EMAIL,
+                    DriveAuthScopes.USERINFO_PROFILE,
+                    DriveAuthScopes.DRIVE_FILE,
+                )
+                every { toGoogleSignInAccount() } returns null
+                every { accessToken } returns null
+            }
+            every { authorizationClient.authorize(any()) } returns Tasks.forResult(authResult)
+
+            val result = newAuth().requestDriveFileAccess()
+
+            assertTrue(result is SignInResult.Success, "expected Success, got $result")
+            assertEquals(
+                Account(email = "real@example.com", displayName = "Real User"),
+                (result as SignInResult.Success).account,
+            )
+            coVerify { accountStore.setDriveFileGranted(true) }
+            coVerify(exactly = 0) {
+                accountStore.setAccount(Account(email = "drive_account", displayName = null))
+            }
         }
 
     @Test

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/auth/DriveBackupAuthTest.kt
@@ -367,6 +367,7 @@ internal class DriveBackupAuthTest {
                 DriveAuthScopes.DRIVE_APPDATA,
                 DriveAuthScopes.USERINFO_EMAIL,
                 DriveAuthScopes.USERINFO_PROFILE,
+                DriveAuthScopes.DRIVE_FILE,
             ),
             scopes,
         )
@@ -477,6 +478,69 @@ internal class DriveBackupAuthTest {
         assertTrue(result is SignInResult.PartialGrant, "expected PartialGrant, got $result")
         coVerify(exactly = 0) { accountStore.setAccount(any()) }
         coVerify(exactly = 0) { accountStore.setToken(any(), any()) }
+    }
+
+    @Test
+    fun `signIn persists driveFileGranted false when drive_file not granted`() = runTest {
+        val authResult = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { grantedScopes } returns listOf(
+                DriveAuthScopes.DRIVE_APPDATA,
+                DriveAuthScopes.USERINFO_EMAIL,
+                DriveAuthScopes.USERINFO_PROFILE,
+            )
+            every { toGoogleSignInAccount() } returns null
+            every { accessToken } returns "tok"
+        }
+        every { authorizationClient.authorize(any()) } returns Tasks.forResult(authResult)
+
+        newAuth().signIn()
+
+        coVerify { accountStore.setDriveFileGranted(false) }
+    }
+
+    @Test
+    fun `requestDriveFileAccess requests drive_file and persists the grant on success`() = runTest {
+        val authResult = mockk<AuthorizationResult> {
+            every { hasResolution() } returns false
+            every { grantedScopes } returns listOf(
+                DriveAuthScopes.DRIVE_APPDATA,
+                DriveAuthScopes.USERINFO_EMAIL,
+                DriveAuthScopes.USERINFO_PROFILE,
+                DriveAuthScopes.DRIVE_FILE,
+            )
+            every { toGoogleSignInAccount() } returns null
+            every { accessToken } returns "tok"
+        }
+        val captured = slot<com.google.android.gms.auth.api.identity.AuthorizationRequest>()
+        every { authorizationClient.authorize(capture(captured)) } returns Tasks.forResult(authResult)
+
+        val result = newAuth().requestDriveFileAccess()
+
+        assertTrue(result is SignInResult.Success, "expected Success, got $result")
+        val scopes = captured.captured.requestedScopes.map(Scope::getScopeUri).toSet()
+        assertTrue(scopes.contains(DriveAuthScopes.DRIVE_FILE), "expected drive.file requested, got $scopes")
+        coVerify { accountStore.setDriveFileGranted(true) }
+    }
+
+    @Test
+    fun `completeSignIn persists driveFileGranted true when drive_file granted`() = runTest {
+        val intent = mockk<Intent>()
+        val authResult = mockk<AuthorizationResult> {
+            every { grantedScopes } returns listOf(
+                DriveAuthScopes.DRIVE_APPDATA,
+                DriveAuthScopes.USERINFO_EMAIL,
+                DriveAuthScopes.USERINFO_PROFILE,
+                DriveAuthScopes.DRIVE_FILE,
+            )
+            every { toGoogleSignInAccount() } returns null
+            every { accessToken } returns "tok"
+        }
+        every { authorizationClient.getAuthorizationResultFromIntent(intent) } returns authResult
+
+        newAuth().completeSignIn(intent)
+
+        coVerify { accountStore.setDriveFileGranted(true) }
     }
 
     @Test

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApiImplTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/network/DriveApiImplTest.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.google_drive.network
+
+import android.app.Application
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.io.File
+
+/**
+ * Wire-level tests over a ktor [MockEngine]. The first test is the C2.1 binary
+ * regression guard: after `DriveApi` was made space-aware, the appDataFolder list
+ * request must still carry `spaces=appDataFolder` + the `app_` name query. The rest
+ * cover the new snapshot-facing surface (byte upload + folder create).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+@Config(application = DriveApiImplTest.TestApplication::class, sdk = [33])
+internal class DriveApiImplTest {
+
+    class TestApplication : Application()
+
+    private val fileJson = """{"id":"fid","name":"app_1.db"}"""
+
+    private fun client(handler: MockRequestHandler): HttpClient =
+        HttpClient(MockEngine(handler)) {
+            expectSuccess = true
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+    private fun api(httpClient: HttpClient) = DriveApiImpl(
+        httpClient = httpClient,
+        dispatcher = UnconfinedTestDispatcher(),
+    )
+
+    @Test
+    fun `listFiles wires the given spaces and query into the request (binary regression)`() = runTest {
+        var spaces: String? = null
+        var query: String? = null
+        var path: String? = null
+        val api = api(
+            client { request ->
+                spaces = request.url.parameters["spaces"]
+                query = request.url.parameters["q"]
+                path = request.url.encodedPath
+                respond(
+                    content = """{"files":[]}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+
+        api.listFiles(spaces = "appDataFolder", query = "name contains 'app_' and trashed=false")
+
+        assertEquals("appDataFolder", spaces)
+        assertEquals("/drive/v3/files", path)
+        assertTrue(query?.contains("app_") == true, "expected app_ prefix query, got $query")
+    }
+
+    @Test
+    fun `uploadMultipart sends a multipart request carrying metadata parents and payload`() = runTest {
+        var path: String? = null
+        var uploadType: String? = null
+        var body: String? = null
+        val api = api(
+            client { request ->
+                path = request.url.encodedPath
+                uploadType = request.url.parameters["uploadType"]
+                body = (request.body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                respond(
+                    content = fileJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val metadata = DriveFileMetadataDto(
+            name = "app_1.db",
+            parents = listOf("appDataFolder"),
+            mimeType = "application/x-sqlite3",
+            appProperties = mapOf("app_version" to "1.0"),
+        )
+
+        api.uploadMultipart(metadata, "db-bytes".toByteArray())
+
+        assertEquals("/upload/drive/v3/files", path)
+        assertEquals("multipart", uploadType)
+        assertTrue(body?.contains("appDataFolder") == true, "metadata parents missing: $body")
+        assertTrue(body?.contains("db-bytes") == true, "payload missing: $body")
+    }
+
+    @Test
+    fun `uploadMultipart file overload reads the file bytes into the request`() = runTest {
+        var body: String? = null
+        val api = api(
+            client { request ->
+                body = (request.body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                respond(
+                    content = fileJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val dbFile = File.createTempFile("drive-api-test", ".db").apply { writeText("file-payload") }
+        val metadata = DriveFileMetadataDto(
+            name = "app_1.db",
+            parents = listOf("appDataFolder"),
+            mimeType = "application/x-sqlite3",
+            appProperties = emptyMap(),
+        )
+
+        try {
+            api.uploadMultipart(metadata, dbFile)
+        } finally {
+            dbFile.delete()
+        }
+
+        assertTrue(body?.contains("file-payload") == true, "file bytes missing: $body")
+    }
+
+    @Test
+    fun `createFolder posts folder metadata to the files endpoint`() = runTest {
+        var path: String? = null
+        var body: String? = null
+        val api = api(
+            client { request ->
+                path = request.url.encodedPath
+                body = (request.body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                respond(
+                    content = """{"id":"folder-id","name":"Workeeper"}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+
+        val result = api.createFolder("Workeeper")
+
+        assertEquals("folder-id", result.id)
+        assertEquals("/drive/v3/files", path)
+        assertFalse(path?.contains("upload") == true, "createFolder must not hit the upload endpoint: $path")
+        assertTrue(body?.contains("application/vnd.google-apps.folder") == true, "folder mimeType missing: $body")
+        assertTrue(body?.contains("Workeeper") == true, "folder name missing: $body")
+    }
+}

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorageTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveBackupStorageTest.kt
@@ -64,7 +64,7 @@ internal class DriveBackupStorageTest {
             driveFileWithManifest("b", manifestAt(300L)),
             driveFileWithManifest("c", manifestAt(200L)),
         )
-        coEvery { driveApi.listFiles() } returns files
+        coEvery { driveApi.listFiles(any(), any()) } returns files
 
         val result = storage.listBackups()
 
@@ -76,7 +76,7 @@ internal class DriveBackupStorageTest {
     @Test
     fun `listBackups maps appProperties manifest into BackupRef manifest`() = runTest {
         val manifest = manifestAt(42L).copy(deviceModel = "Pixel 9")
-        coEvery { driveApi.listFiles() } returns listOf(driveFileWithManifest("x", manifest))
+        coEvery { driveApi.listFiles(any(), any()) } returns listOf(driveFileWithManifest("x", manifest))
 
         val result = storage.listBackups()
 
@@ -84,6 +84,21 @@ internal class DriveBackupStorageTest {
         val refs = (result as BackupResult.Success).data
         assertEquals(1, refs.size)
         assertEquals(manifest, refs.single().manifest)
+    }
+
+    @Test
+    fun `binary list still queries appDataFolder space with the app_ name prefix`() = runTest {
+        // Regression: making DriveApi space-aware must not change the binary backup path.
+        coEvery { driveApi.listFiles(any(), any()) } returns emptyList()
+
+        storage.listBackups()
+
+        coVerify {
+            driveApi.listFiles(
+                spaces = "appDataFolder",
+                query = match { it.contains("'${BackupConstants.FILE_PREFIX}'") && it.contains("trashed=false") },
+            )
+        }
     }
 
     @Test
@@ -95,7 +110,7 @@ internal class DriveBackupStorageTest {
 
         coEvery { driveApi.uploadMultipart(any(), eq(dbFile)) } returns
             driveFileDto(id = "uploaded-id")
-        coEvery { driveApi.listFiles() } returns emptyList()
+        coEvery { driveApi.listFiles(any(), any()) } returns emptyList()
 
         val result = storage.uploadBackup(dbFile, manifest)
 
@@ -131,8 +146,8 @@ internal class DriveBackupStorageTest {
             driveFileWithManifest("old3", manifestAt(300L)),
         )
         val withNew = existingFiles + driveFileWithManifest("new", newManifest)
-        coEvery { driveApi.uploadMultipart(any(), any()) } returns driveFileDto(id = "new")
-        coEvery { driveApi.listFiles() } returns withNew
+        coEvery { driveApi.uploadMultipart(any(), any<File>()) } returns driveFileDto(id = "new")
+        coEvery { driveApi.listFiles(any(), any()) } returns withNew
         coEvery { driveApi.deleteFile(any()) } just Runs
 
         val result = storage.uploadBackup(dbFile, newManifest)
@@ -153,8 +168,8 @@ internal class DriveBackupStorageTest {
             driveFileWithManifest("old2", manifestAt(200L)),
             driveFileWithManifest("new", newManifest),
         )
-        coEvery { driveApi.uploadMultipart(any(), any()) } returns driveFileDto(id = "new")
-        coEvery { driveApi.listFiles() } returns withNew
+        coEvery { driveApi.uploadMultipart(any(), any<File>()) } returns driveFileDto(id = "new")
+        coEvery { driveApi.listFiles(any(), any()) } returns withNew
 
         val result = storage.uploadBackup(dbFile, newManifest)
 
@@ -166,8 +181,8 @@ internal class DriveBackupStorageTest {
     fun `uploadBackup rotation list failure does not fail upload`() = runTest {
         val newManifest = manifestAt(400L)
         val dbFile = tempFile()
-        coEvery { driveApi.uploadMultipart(any(), any()) } returns driveFileDto(id = "new")
-        coEvery { driveApi.listFiles() } throws IOException("rotation list failed")
+        coEvery { driveApi.uploadMultipart(any(), any<File>()) } returns driveFileDto(id = "new")
+        coEvery { driveApi.listFiles(any(), any()) } throws IOException("rotation list failed")
 
         val result = storage.uploadBackup(dbFile, newManifest)
 
@@ -214,7 +229,7 @@ internal class DriveBackupStorageTest {
 
     @Test
     fun `network IOException during list maps to NetworkUnavailable`() = runTest {
-        coEvery { driveApi.listFiles() } throws IOException("offline")
+        coEvery { driveApi.listFiles(any(), any()) } throws IOException("offline")
 
         val result = storage.listBackups()
 
@@ -226,23 +241,23 @@ internal class DriveBackupStorageTest {
     fun `uploadBackup retries once after 401 and succeeds on second call`() = runTest {
         val manifest = manifestAt(1_000L)
         val dbFile = tempFile()
-        coEvery { driveApi.uploadMultipart(any(), any()) } throws
+        coEvery { driveApi.uploadMultipart(any(), any<File>()) } throws
             DriveException.AuthRevoked("first 401") andThen driveFileDto(id = "fresh-id")
-        coEvery { driveApi.listFiles() } returns emptyList()
+        coEvery { driveApi.listFiles(any(), any()) } returns emptyList()
 
         val result = storage.uploadBackup(dbFile, manifest)
 
         assertTrue(result is BackupResult.Success, "upload must succeed on retry; got $result")
         assertEquals("fresh-id", (result as BackupResult.Success).data.remoteId)
         coVerify(exactly = 1) { tokenInvalidator.invalidate() }
-        coVerify(exactly = 2) { driveApi.uploadMultipart(any(), any()) }
+        coVerify(exactly = 2) { driveApi.uploadMultipart(any(), any<File>()) }
     }
 
     @Test
     fun `uploadBackup second 401 propagates as AuthRevoked`() = runTest {
         val manifest = manifestAt(1_000L)
         val dbFile = tempFile()
-        coEvery { driveApi.uploadMultipart(any(), any()) } throws
+        coEvery { driveApi.uploadMultipart(any(), any<File>()) } throws
             DriveException.AuthRevoked("first 401") andThenThrows
             DriveException.AuthRevoked("second 401")
 
@@ -251,12 +266,12 @@ internal class DriveBackupStorageTest {
         assertTrue(result is BackupResult.Failure)
         assertEquals(BackupError.AuthRevoked, (result as BackupResult.Failure).error)
         coVerify(exactly = 1) { tokenInvalidator.invalidate() }
-        coVerify(exactly = 2) { driveApi.uploadMultipart(any(), any()) }
+        coVerify(exactly = 2) { driveApi.uploadMultipart(any(), any<File>()) }
     }
 
     @Test
     fun `listBackups retries once after 401 and succeeds on second call`() = runTest {
-        coEvery { driveApi.listFiles() } throws DriveException.AuthRevoked("401") andThen
+        coEvery { driveApi.listFiles(any(), any()) } throws DriveException.AuthRevoked("401") andThen
             listOf(driveFileWithManifest("a", manifestAt(100L)))
 
         val result = storage.listBackups()
@@ -264,7 +279,7 @@ internal class DriveBackupStorageTest {
         assertTrue(result is BackupResult.Success)
         assertEquals(1, (result as BackupResult.Success).data.size)
         coVerify(exactly = 1) { tokenInvalidator.invalidate() }
-        coVerify(exactly = 2) { driveApi.listFiles() }
+        coVerify(exactly = 2) { driveApi.listFiles(any(), any()) }
     }
 
     @Test

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.backup.google_drive.storage
+
+import android.app.Application
+import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
+import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
+import io.github.stslex.workeeper.core.data.backup.google_drive.auth.AccountDataStore
+import io.github.stslex.workeeper.core.data.backup.google_drive.auth.TokenInvalidator
+import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveApi
+import io.github.stslex.workeeper.core.data.backup.google_drive.network.DriveFileDto
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.http.HttpStatusCode
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+@Config(application = DriveSnapshotStorageTest.TestApplication::class, sdk = [33])
+internal class DriveSnapshotStorageTest {
+
+    class TestApplication : Application()
+
+    private lateinit var driveApi: DriveApi
+    private lateinit var accountStore: AccountDataStore
+    private lateinit var tokenInvalidator: TokenInvalidator
+    private lateinit var storage: DriveSnapshotStorage
+
+    @BeforeEach
+    fun setup() {
+        driveApi = mockk(relaxed = false)
+        accountStore = mockk(relaxed = true)
+        tokenInvalidator = mockk(relaxed = true)
+        storage = DriveSnapshotStorage(
+            driveApi = driveApi,
+            accountStore = accountStore,
+            tokenInvalidator = tokenInvalidator,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+    }
+
+    @Test
+    fun `creates the folder when none is cached or present and caches its id`() = runTest {
+        coEvery { accountStore.snapshotFolderId() } returns null
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isFolderQuery() }) } returns emptyList()
+        coEvery { driveApi.createFolder(FOLDER) } returns folder("new-folder")
+        coEvery { driveApi.uploadMultipart(match { it.parents == listOf("new-folder") }, any<ByteArray>()) } returns
+            snapshot("up", 1L)
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(snapshot("up", 1L))
+
+        val result = storage.uploadSnapshot("{}".toByteArray())
+
+        assertTrue(result is BackupResult.Success)
+        coVerify(exactly = 1) { driveApi.createFolder(FOLDER) }
+        coVerify { accountStore.setSnapshotFolderId("new-folder") }
+    }
+
+    @Test
+    fun `reuses the cached folder id without listing or creating`() = runTest {
+        coEvery { accountStore.snapshotFolderId() } returns "cached-folder"
+        coEvery { driveApi.uploadMultipart(any(), any<ByteArray>()) } returns snapshot("up", 1L)
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(snapshot("up", 1L))
+
+        val result = storage.uploadSnapshot("{}".toByteArray())
+
+        assertTrue(result is BackupResult.Success)
+        coVerify(exactly = 0) { driveApi.createFolder(any()) }
+        coVerify { driveApi.uploadMultipart(match { it.parents == listOf("cached-folder") }, any<ByteArray>()) }
+    }
+
+    @Test
+    fun `reuses the oldest existing folder when several exist and none is cached`() = runTest {
+        coEvery { accountStore.snapshotFolderId() } returns null
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isFolderQuery() }) } returns listOf(
+            folder("newer", createdTime = "2026-02-01T00:00:00Z"),
+            folder("older", createdTime = "2026-01-01T00:00:00Z"),
+        )
+        coEvery { driveApi.uploadMultipart(any(), any<ByteArray>()) } returns snapshot("up", 1L)
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(snapshot("up", 1L))
+
+        storage.uploadSnapshot("{}".toByteArray())
+
+        coVerify(exactly = 0) { driveApi.createFolder(any()) }
+        coVerify { accountStore.setSnapshotFolderId("older") }
+        coVerify { driveApi.uploadMultipart(match { it.parents == listOf("older") }, any<ByteArray>()) }
+    }
+
+    @Test
+    fun `recreates the folder and retries once when the cached id 404s`() = runTest {
+        val notFound = mockk<ClientRequestException>(relaxed = true)
+        every { notFound.response } returns mockk(relaxed = true) {
+            every { status } returns HttpStatusCode.NotFound
+        }
+        coEvery { accountStore.snapshotFolderId() } returns "stale-folder"
+        coEvery { driveApi.uploadMultipart(match { it.parents == listOf("stale-folder") }, any<ByteArray>()) } throws
+            notFound
+        coEvery { driveApi.createFolder(FOLDER) } returns folder("fresh-folder")
+        coEvery { driveApi.uploadMultipart(match { it.parents == listOf("fresh-folder") }, any<ByteArray>()) } returns
+            snapshot("up", 1L)
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(snapshot("up", 1L))
+
+        val result = storage.uploadSnapshot("{}".toByteArray())
+
+        assertTrue(result is BackupResult.Success)
+        coVerify { accountStore.setSnapshotFolderId(null) }
+        coVerify { driveApi.createFolder(FOLDER) }
+        coVerify { driveApi.uploadMultipart(match { it.parents == listOf("fresh-folder") }, any<ByteArray>()) }
+    }
+
+    @Test
+    fun `rotation deletes the oldest snapshots beyond the cap after upload`() = runTest {
+        coEvery { accountStore.snapshotFolderId() } returns "folder"
+        coEvery { driveApi.uploadMultipart(any(), any<ByteArray>()) } returns snapshot("new", 500L)
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(
+            snapshot("e1", 100L),
+            snapshot("e2", 200L),
+            snapshot("e3", 300L),
+            snapshot("e4", 400L),
+        )
+        coEvery { driveApi.deleteFile(any()) } just Runs
+
+        storage.uploadSnapshot("{}".toByteArray())
+
+        coVerify(exactly = 1) { driveApi.deleteFile("e1") }
+        coVerify(exactly = 0) { driveApi.deleteFile("e2") }
+        coVerify(exactly = 0) { driveApi.deleteFile("new") }
+    }
+
+    @Test
+    fun `upload failure surfaces as a typed Failure (best-effort, never throws)`() = runTest {
+        coEvery { accountStore.snapshotFolderId() } returns "folder"
+        coEvery { driveApi.uploadMultipart(any(), any<ByteArray>()) } throws IOException("offline")
+
+        val result = storage.uploadSnapshot("{}".toByteArray())
+
+        assertTrue(result is BackupResult.Failure)
+        assertEquals(BackupError.NetworkUnavailable, (result as BackupResult.Failure).error)
+    }
+
+    private fun folder(id: String, createdTime: String? = null): DriveFileDto = DriveFileDto(
+        id = id,
+        name = FOLDER,
+        createdTime = createdTime,
+        size = null,
+        appProperties = null,
+    )
+
+    private fun snapshot(id: String, epochMs: Long): DriveFileDto = DriveFileDto(
+        id = id,
+        name = "workeeper_export_$epochMs.json",
+        createdTime = null,
+        size = null,
+        appProperties = null,
+    )
+
+    private fun String.isFolderQuery(): Boolean = contains("mimeType=") && contains("name='$FOLDER'")
+
+    private fun String.isExportQuery(): Boolean = contains("in parents")
+
+    private companion object {
+        const val DRIVE = "drive"
+        const val FOLDER = "Workeeper"
+    }
+}

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
@@ -158,6 +158,82 @@ internal class DriveSnapshotStorageTest {
         assertEquals(BackupError.NetworkUnavailable, (result as BackupResult.Failure).error)
     }
 
+    @Test
+    fun `deleteAllSnapshots is a no-op when drive_file is not granted`() = runTest {
+        coEvery { accountStore.isDriveFileGranted() } returns false
+
+        val result = storage.deleteAllSnapshots()
+
+        assertTrue(result is BackupResult.Success)
+        coVerify(exactly = 0) { driveApi.listFiles(any(), any()) }
+        coVerify(exactly = 0) { driveApi.deleteFile(any()) }
+    }
+
+    @Test
+    fun `deleteAllSnapshots deletes every export file in the cached folder`() = runTest {
+        coEvery { accountStore.isDriveFileGranted() } returns true
+        coEvery { accountStore.snapshotFolderId() } returns "folder"
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(
+            snapshot("e1", 100L),
+            snapshot("e2", 200L),
+            snapshot("e3", 300L),
+        )
+        coEvery { driveApi.deleteFile(any()) } just Runs
+
+        val result = storage.deleteAllSnapshots()
+
+        assertTrue(result is BackupResult.Success)
+        coVerify(exactly = 1) { driveApi.deleteFile("e1") }
+        coVerify(exactly = 1) { driveApi.deleteFile("e2") }
+        coVerify(exactly = 1) { driveApi.deleteFile("e3") }
+        coVerify(exactly = 0) { driveApi.createFolder(any()) }
+    }
+
+    @Test
+    fun `deleteAllSnapshots never creates a folder and deletes nothing when none exists`() =
+        runTest {
+            coEvery { accountStore.isDriveFileGranted() } returns true
+            coEvery { accountStore.snapshotFolderId() } returns null
+            coEvery { driveApi.listFiles(eq(DRIVE), match { it.isFolderQuery() }) } returns emptyList()
+
+            val result = storage.deleteAllSnapshots()
+
+            assertTrue(result is BackupResult.Success)
+            coVerify(exactly = 0) { driveApi.createFolder(any()) }
+            coVerify(exactly = 0) { driveApi.deleteFile(any()) }
+        }
+
+    @Test
+    fun `deleteAllSnapshots surfaces a typed Failure when the list call fails`() = runTest {
+        coEvery { accountStore.isDriveFileGranted() } returns true
+        coEvery { accountStore.snapshotFolderId() } returns "folder"
+        coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } throws
+            IOException("offline")
+
+        val result = storage.deleteAllSnapshots()
+
+        assertTrue(result is BackupResult.Failure)
+        assertEquals(BackupError.NetworkUnavailable, (result as BackupResult.Failure).error)
+    }
+
+    @Test
+    fun `deleteAllSnapshots swallows a per-file delete failure and still returns Success`() =
+        runTest {
+            coEvery { accountStore.isDriveFileGranted() } returns true
+            coEvery { accountStore.snapshotFolderId() } returns "folder"
+            coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(
+                snapshot("e1", 100L),
+                snapshot("e2", 200L),
+            )
+            coEvery { driveApi.deleteFile("e1") } throws IOException("offline")
+            coEvery { driveApi.deleteFile("e2") } just Runs
+
+            val result = storage.deleteAllSnapshots()
+
+            assertTrue(result is BackupResult.Success)
+            coVerify(exactly = 1) { driveApi.deleteFile("e2") }
+        }
+
     private fun folder(id: String, createdTime: String? = null): DriveFileDto = DriveFileDto(
         id = id,
         name = FOLDER,

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/DriveSnapshotStorageTest.kt
@@ -125,18 +125,25 @@ internal class DriveSnapshotStorageTest {
     fun `rotation deletes the oldest snapshots beyond the cap after upload`() = runTest {
         coEvery { accountStore.snapshotFolderId() } returns "folder"
         coEvery { driveApi.uploadMultipart(any(), any<ByteArray>()) } returns snapshot("new", 500L)
+        // rotate() re-lists AFTER the upload commits, so the realistic post-upload state contains
+        // the just-uploaded file too: e1..e4 + new (5 files). With MAX_BACKUPS = 3 this is the
+        // meaningful 5-keep-3 case (delete the 2 oldest), and proves the freshest snapshot ("new")
+        // is never pruned -- the data-loss regression this test guards against.
         coEvery { driveApi.listFiles(eq(DRIVE), match { it.isExportQuery() }) } returns listOf(
             snapshot("e1", 100L),
             snapshot("e2", 200L),
             snapshot("e3", 300L),
             snapshot("e4", 400L),
+            snapshot("new", 500L),
         )
         coEvery { driveApi.deleteFile(any()) } just Runs
 
         storage.uploadSnapshot("{}".toByteArray())
 
         coVerify(exactly = 1) { driveApi.deleteFile("e1") }
-        coVerify(exactly = 0) { driveApi.deleteFile("e2") }
+        coVerify(exactly = 1) { driveApi.deleteFile("e2") }
+        coVerify(exactly = 0) { driveApi.deleteFile("e3") }
+        coVerify(exactly = 0) { driveApi.deleteFile("e4") }
         coVerify(exactly = 0) { driveApi.deleteFile("new") }
     }
 

--- a/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/RotationPolicyTest.kt
+++ b/core/data/backup/google-drive/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/google_drive/storage/RotationPolicyTest.kt
@@ -12,13 +12,13 @@ internal class RotationPolicyTest {
     @Test
     fun `refsToDelete returns empty when size is below cap`() {
         val refs = listOf(ref("a", 100L), ref("b", 200L))
-        assertTrue(RotationPolicy.refsToDelete(refs, max = 3).isEmpty())
+        assertTrue(RotationPolicy.refsToDelete(refs, max = 3) { it.manifest.createdAtEpochMs }.isEmpty())
     }
 
     @Test
     fun `refsToDelete returns empty when size equals cap`() {
         val refs = listOf(ref("a", 100L), ref("b", 200L), ref("c", 300L))
-        assertTrue(RotationPolicy.refsToDelete(refs, max = 3).isEmpty())
+        assertTrue(RotationPolicy.refsToDelete(refs, max = 3) { it.manifest.createdAtEpochMs }.isEmpty())
     }
 
     @Test
@@ -29,7 +29,7 @@ internal class RotationPolicyTest {
             ref("c", 300L),
             ref("d", 400L),
         )
-        val toDelete = RotationPolicy.refsToDelete(refs, max = 3)
+        val toDelete = RotationPolicy.refsToDelete(refs, max = 3) { it.manifest.createdAtEpochMs }
         assertEquals(listOf("a"), toDelete.map { it.remoteId })
     }
 
@@ -42,7 +42,7 @@ internal class RotationPolicyTest {
             ref("d", 400L),
             ref("e", 500L),
         )
-        val toDelete = RotationPolicy.refsToDelete(refs, max = 3)
+        val toDelete = RotationPolicy.refsToDelete(refs, max = 3) { it.manifest.createdAtEpochMs }
         assertEquals(listOf("a", "b"), toDelete.map { it.remoteId })
     }
 

--- a/core/data/backup/scheduling/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/scheduling/BackupPreferencesRepositoryImpl.kt
+++ b/core/data/backup/scheduling/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/scheduling/BackupPreferencesRepositoryImpl.kt
@@ -63,6 +63,10 @@ internal class BackupPreferencesRepositoryImpl @Inject constructor(
         dataStore.edit { it[KEY_AUTO_BACKUP_BOOTSTRAPPED] = bootstrapped }
     }
 
+    override suspend fun setAiExportEnabled(enabled: Boolean) {
+        dataStore.edit { it[KEY_AI_EXPORT_ENABLED] = enabled }
+    }
+
     private fun fromPrefs(prefs: Preferences): BackupPreferences {
         val default = BackupPreferences.DEFAULT
         val schedule = prefs[KEY_SCHEDULE]
@@ -79,6 +83,7 @@ internal class BackupPreferencesRepositoryImpl @Inject constructor(
             lastError = lastError,
             autoBackupBootstrapped = prefs[KEY_AUTO_BACKUP_BOOTSTRAPPED]
                 ?: default.autoBackupBootstrapped,
+            aiExportEnabled = prefs[KEY_AI_EXPORT_ENABLED] ?: default.aiExportEnabled,
         )
     }
 
@@ -91,5 +96,6 @@ internal class BackupPreferencesRepositoryImpl @Inject constructor(
         val KEY_LAST_SUCCESS = longPreferencesKey("last_success_at")
         val KEY_LAST_ERROR = stringPreferencesKey("last_error")
         val KEY_AUTO_BACKUP_BOOTSTRAPPED = booleanPreferencesKey("auto_backup_bootstrapped")
+        val KEY_AI_EXPORT_ENABLED = booleanPreferencesKey("ai_export_enabled")
     }
 }

--- a/core/data/backup/scheduling/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/scheduling/BackupPreferencesRepositoryImplTest.kt
+++ b/core/data/backup/scheduling/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/scheduling/BackupPreferencesRepositoryImplTest.kt
@@ -52,6 +52,13 @@ internal class BackupPreferencesRepositoryImplTest {
         assertEquals(0L, prefs.lastSuccessAtEpochMs)
         assertNull(prefs.lastError)
         assertFalse(prefs.autoBackupBootstrapped)
+        assertFalse(prefs.aiExportEnabled)
+    }
+
+    @Test
+    fun `setAiExportEnabled true is observable on next collect`() = runTest {
+        repo.setAiExportEnabled(true)
+        assertTrue(repo.observe().first().aiExportEnabled)
     }
 
     @Test

--- a/core/data/backup/worker/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorker.kt
+++ b/core/data/backup/worker/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorker.kt
@@ -63,9 +63,12 @@ internal class BackupWorker @AssistedInject constructor(
         val tempFile = File.createTempFile(TEMP_PREFIX, TEMP_SUFFIX, applicationContext.cacheDir)
         return try {
             val result = executeBackup(tempFile)
-            // Best-effort AI snapshot AFTER the binary backup, independent of its outcome.
-            // Wrapped so a runner fault can never affect the worker Result; D2 decoupling.
-            runCatching { snapshotExportRunner.runIfEligible() }
+            // The binary-backup Result is already computed above. AWAIT the best-effort AI snapshot
+            // before returning so WorkManager keeps the wakelock/execution window alive until the
+            // visible-Drive upload finishes — a detached app-scope launch would race process death
+            // on every periodic run. runCatching-wrapped so a runner fault can never change the
+            // Result; D2 holds (the binary upload is done — only Result reporting is held longer).
+            runCatching { snapshotExportRunner.runIfEligibleAwaiting() }
             result
         } finally {
             tempFile.delete()

--- a/core/data/backup/worker/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorker.kt
+++ b/core/data/backup/worker/src/main/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorker.kt
@@ -11,6 +11,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.github.stslex.workeeper.core.core.logger.Log
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
 import io.github.stslex.workeeper.core.data.backup.api.model.BackupManifest
 import io.github.stslex.workeeper.core.data.backup.api.result.BackupResult
@@ -50,6 +51,7 @@ internal class BackupWorker @AssistedInject constructor(
     private val preferences: BackupPreferencesRepository,
     private val autoBackupController: AutoBackupController,
     private val notificationHelper: BackupNotificationHelper,
+    private val snapshotExportRunner: SnapshotExportRunner,
 ) : CoroutineWorker(appContext, workerParams) {
 
     private val logger = Log.tag(TAG)
@@ -60,7 +62,11 @@ internal class BackupWorker @AssistedInject constructor(
 
         val tempFile = File.createTempFile(TEMP_PREFIX, TEMP_SUFFIX, applicationContext.cacheDir)
         return try {
-            executeBackup(tempFile)
+            val result = executeBackup(tempFile)
+            // Best-effort AI snapshot AFTER the binary backup, independent of its outcome.
+            // Wrapped so a runner fault can never affect the worker Result; D2 decoupling.
+            runCatching { snapshotExportRunner.runIfEligible() }
+            result
         } finally {
             tempFile.delete()
         }

--- a/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
+++ b/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
@@ -19,6 +19,7 @@ import io.github.stslex.workeeper.core.data.backup.worker.notification.BackupNot
 import io.github.stslex.workeeper.core.data.database.snapshot.DatabaseSnapshotProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
@@ -82,7 +83,7 @@ internal class BackupWorkerTest {
                 ),
             ),
         )
-        coEvery { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
+        every { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
 
         val result = makeWorker().doWork()
 

--- a/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
+++ b/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
 import androidx.work.testing.TestListenableWorkerBuilder
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
 import io.github.stslex.workeeper.core.data.backup.api.model.BackupManifest
 import io.github.stslex.workeeper.core.data.backup.api.model.BackupRef
@@ -43,6 +44,7 @@ internal class BackupWorkerTest {
         coEvery { observePeriodicStatus() } returns emptyFlow<List<AutoBackupWorkInfo>>()
         coEvery { observeOneTimeStatus() } returns emptyFlow<List<AutoBackupWorkInfo>>()
     }
+    private val snapshotExportRunner = mockk<SnapshotExportRunner>(relaxed = true)
 
     private fun makeWorker(): BackupWorker = TestListenableWorkerBuilder<BackupWorker>(
         ApplicationProvider.getApplicationContext(),
@@ -53,6 +55,7 @@ internal class BackupWorkerTest {
             preferences = preferences,
             autoBackupController = autoBackupController,
             notificationHelper = notificationHelper,
+            snapshotExportRunner = snapshotExportRunner,
         ),
     ).build()
 
@@ -63,6 +66,27 @@ internal class BackupWorkerTest {
             BackupResult.Success(Unit)
         }
         coEvery { snapshotProvider.currentSchemaVersion() } returns 5
+    }
+
+    @Test
+    fun `binary success result is unaffected when the snapshot runner throws`() = runBlocking {
+        coEvery { backupStorage.uploadBackup(any(), any()) } returns BackupResult.Success(
+            BackupRef(
+                remoteId = "id",
+                manifest = BackupManifest(
+                    appVersion = "1.0.0",
+                    dbSchemaVersion = 5,
+                    createdAtEpochMs = 0L,
+                    dbFileSizeBytes = 1L,
+                    deviceModel = null,
+                ),
+            ),
+        )
+        coEvery { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
+
+        val result = makeWorker().doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
     }
 
     @Test

--- a/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
+++ b/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/BackupWorkerTest.kt
@@ -19,7 +19,6 @@ import io.github.stslex.workeeper.core.data.backup.worker.notification.BackupNot
 import io.github.stslex.workeeper.core.data.database.snapshot.DatabaseSnapshotProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
@@ -83,11 +82,34 @@ internal class BackupWorkerTest {
                 ),
             ),
         )
-        every { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
+        coEvery { snapshotExportRunner.runIfEligibleAwaiting() } throws RuntimeException("runner blew up")
 
         val result = makeWorker().doWork()
 
         assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun `worker awaits the snapshot export rather than firing it and forgetting`() = runBlocking {
+        coEvery { backupStorage.uploadBackup(any(), any()) } returns BackupResult.Success(
+            BackupRef(
+                remoteId = "id",
+                manifest = BackupManifest(
+                    appVersion = "1.0.0",
+                    dbSchemaVersion = 5,
+                    createdAtEpochMs = 0L,
+                    dbFileSizeBytes = 1L,
+                    deviceModel = null,
+                ),
+            ),
+        )
+
+        makeWorker().doWork()
+
+        // The worker holds a wakelock window, so it must AWAIT the snapshot (keeps the process
+        // alive for the upload) and never use the detached fire-and-forget path.
+        coVerify(exactly = 1) { snapshotExportRunner.runIfEligibleAwaiting() }
+        coVerify(exactly = 0) { snapshotExportRunner.runIfEligible() }
     }
 
     @Test

--- a/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/WorkerTestFactory.kt
+++ b/core/data/backup/worker/src/test/kotlin/io/github/stslex/workeeper/core/data/backup/worker/WorkerTestFactory.kt
@@ -6,6 +6,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.scheduling.AutoBackupController
 import io.github.stslex.workeeper.core.data.backup.api.scheduling.BackupPreferencesRepository
 import io.github.stslex.workeeper.core.data.backup.worker.notification.BackupNotificationHelper
@@ -22,6 +23,7 @@ internal class WorkerTestFactory(
     private val preferences: BackupPreferencesRepository,
     private val autoBackupController: AutoBackupController,
     private val notificationHelper: BackupNotificationHelper,
+    private val snapshotExportRunner: SnapshotExportRunner,
 ) : WorkerFactory() {
 
     override fun createWorker(
@@ -36,5 +38,6 @@ internal class WorkerTestFactory(
         preferences = preferences,
         autoBackupController = autoBackupController,
         notificationHelper = notificationHelper,
+        snapshotExportRunner = snapshotExportRunner,
     )
 }

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/di/CoreDatabaseBindingsModule.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/di/CoreDatabaseBindingsModule.kt
@@ -5,6 +5,8 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter
+import io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporterImpl
 import io.github.stslex.workeeper.core.data.database.snapshot.DatabaseSnapshotProvider
 import io.github.stslex.workeeper.core.data.database.snapshot.DatabaseSnapshotProviderImpl
 import javax.inject.Singleton
@@ -18,4 +20,10 @@ internal interface CoreDatabaseBindingsModule {
     fun bindDatabaseSnapshotProvider(
         impl: DatabaseSnapshotProviderImpl,
     ): DatabaseSnapshotProvider
+
+    @Binds
+    @Singleton
+    fun bindDatabaseJsonExporter(
+        impl: DatabaseJsonExporterImpl,
+    ): DatabaseJsonExporter
 }

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
@@ -141,7 +141,7 @@ interface ExerciseDao {
      * are referenced by sessions, so omitting them would break referential integrity
      * in the export). Never use this for a user-facing list.
      */
-    @Query("SELECT * FROM exercise_table")
+    @Query("SELECT * FROM exercise_table ORDER BY created_at ASC, uuid ASC")
     suspend fun getAll(): List<ExerciseEntity>
 
     @Query("SELECT uuid, last_adhoc_sets FROM exercise_table WHERE uuid IN (:uuids)")

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDao.kt
@@ -134,6 +134,16 @@ interface ExerciseDao {
     @Query("SELECT * FROM exercise_table WHERE uuid IN (:uuids)")
     suspend fun getByUuids(uuids: List<Uuid>): List<ExerciseEntity>
 
+    /**
+     * Every exercise row, unfiltered — includes `is_adhoc = 1` and `archived = 1`.
+     * Documented exception to the `is_adhoc = 0` list invariant: the sole caller is
+     * the AI-readable snapshot export, which needs the full library (adhoc exercises
+     * are referenced by sessions, so omitting them would break referential integrity
+     * in the export). Never use this for a user-facing list.
+     */
+    @Query("SELECT * FROM exercise_table")
+    suspend fun getAll(): List<ExerciseEntity>
+
     @Query("SELECT uuid, last_adhoc_sets FROM exercise_table WHERE uuid IN (:uuids)")
     suspend fun getAdhocPlansBatch(uuids: List<Uuid>): List<ExerciseAdhocPlanRow>
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporter.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporter.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.export
+
+/**
+ * Produces the AI-readable workout snapshot as UTF-8 JSON bytes (spec `drive-ai-export.md`).
+ * Reads the full Room graph and encodes it; it is **Drive-agnostic** — upload, scheduling,
+ * and the user toggle live in other modules. [appVersion] / [deviceModel] /
+ * [exportedAtEpochMs] are supplied by the caller (the orchestration seam owns package-info
+ * and clock access); the DB schema version is read from the live database.
+ *
+ * Reading entities straight into export DTOs here deliberately **bypasses the domain layer**
+ * (no `*Domain` mapping): the snapshot is a verbatim data-layer projection of the database,
+ * exactly like the binary `.db` copy the backup path makes — so it is not a layering
+ * violation, it is the same "dump the data layer" contract in text form.
+ */
+interface DatabaseJsonExporter {
+
+    suspend fun export(
+        appVersion: String,
+        deviceModel: String?,
+        exportedAtEpochMs: Long,
+    ): ByteArray
+}

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
@@ -16,6 +16,9 @@ import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
 import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
 import io.github.stslex.workeeper.core.data.database.training.TrainingExerciseEntity
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -52,9 +55,9 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
         // an interleaved insert could surface a child row whose parent/name row was not read (e.g.
         // `exerciseNameByUuid` falling back to ""). The transaction pins all reads to one state.
         val snapshot = database.withTransaction {
-            val exercises = database.exerciseDao.getAll()
-            val trainings = database.trainingDao.getAll()
-            val index = buildIndex(exercises)
+            val exercises = async { database.exerciseDao.getAll() }
+            val trainings = async { database.trainingDao.getAll() }
+            val index = async { buildIndex(exercises) }
             WorkoutExportDto(
                 schemaVersion = EXPORT_SCHEMA_VERSION,
                 exportedAt = WorkoutExportMapper.epochToIso(exportedAtEpochMs),
@@ -63,33 +66,63 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
                     dbSchemaVersion = dbSchemaVersion,
                     deviceModel = deviceModel,
                 ),
-                exercises = exercises.map { entity ->
-                    WorkoutExportMapper.exercise(entity, index.tagsByExercise[entity.uuid].orEmpty())
+                exercises = exercises.await().map { entity ->
+                    WorkoutExportMapper.exercise(
+                        entity,
+                        index.await().tagsByExercise[entity.uuid].orEmpty(),
+                    )
                 },
-                trainings = trainings.map { training -> buildTraining(training, index) },
+                trainings = trainings.await()
+                    .map { training -> buildTraining(training, index.await()) },
             )
         }
         // Encode outside the transaction — pure CPU, no DB access; keeps the transaction short.
         json.encodeToString(snapshot).toByteArray(Charsets.UTF_8)
     }
 
-    private suspend fun buildIndex(exercises: List<ExerciseEntity>): ExportIndex = ExportIndex(
-        exerciseNameByUuid = exercises.associate { it.uuid to it.name },
-        // Full-table tag joins (no uuid binding) — cannot hit SQLITE_MAX_VARIABLE_NUMBER, and
-        // consistent with the unfiltered getAll() readers below.
-        tagsByExercise = database.exerciseTagDao.getAllExerciseTagNames()
-            .groupBy({ it.exerciseUuid }, { it.name }),
-        tagsByTraining = database.trainingTagDao.getAllTrainingTagNames()
-            .groupBy({ it.trainingUuid }, { it.name }),
-        planByTraining = database.trainingExerciseDao.getAll().groupBy { it.trainingUuid },
-        sessionsByTraining = database.sessionDao.getAll().groupBy { it.trainingUuid },
-        performedBySession = database.performedExerciseDao.getAll().groupBy { it.sessionUuid },
-        setsByPerformed = database.setDao.getAll().groupBy { it.performedExerciseUuid },
-    )
+    private suspend fun CoroutineScope.buildIndex(exercises: Deferred<List<ExerciseEntity>>): ExportIndex {
+        val tagsByExerciseDeferred = async {
+            database.exerciseTagDao.getAllExerciseTagNames()
+                .groupBy({ it.exerciseUuid }, { it.name })
+        }
+        val tagsByTrainingDeferred = async {
+            database.trainingTagDao.getAllTrainingTagNames()
+                .groupBy({ it.trainingUuid }, { it.name })
+        }
+        val planByTrainingDeferred = async {
+            database.trainingExerciseDao.getAll().groupBy { it.trainingUuid }
+        }
+        val sessionsByTrainingDeferred = async {
+            database.sessionDao.getAll().groupBy { it.trainingUuid }
+        }
+        val performedBySessionDeferred = async {
+            database.performedExerciseDao.getAll().groupBy { it.sessionUuid }
+        }
+        val setsByPerformedDeferred = async {
+            database.setDao.getAll().groupBy { it.performedExerciseUuid }
+        }
+        val exerciseNameByUuidDeferred = async {
+            exercises.await().associate { it.uuid to it.name }
+        }
+        return ExportIndex(
+            exerciseNameByUuid = exerciseNameByUuidDeferred.await(),
+            // Full-table tag joins (no uuid binding) — cannot hit SQLITE_MAX_VARIABLE_NUMBER, and
+            // consistent with the unfiltered getAll() readers below.
+            tagsByExercise = tagsByExerciseDeferred.await(),
+            tagsByTraining = tagsByTrainingDeferred.await(),
+            planByTraining = planByTrainingDeferred.await(),
+            sessionsByTraining = sessionsByTrainingDeferred.await(),
+            performedBySession = performedBySessionDeferred.await(),
+            setsByPerformed = setsByPerformedDeferred.await(),
+        )
+    }
 
     private fun buildTraining(training: TrainingEntity, index: ExportIndex): TrainingExportDto {
         val plan = index.planByTraining[training.uuid].orEmpty().map { row ->
-            WorkoutExportMapper.planExercise(row, index.exerciseNameByUuid[row.exerciseUuid].orEmpty())
+            WorkoutExportMapper.planExercise(
+                row,
+                index.exerciseNameByUuid[row.exerciseUuid].orEmpty(),
+            )
         }
         val sessions = index.sessionsByTraining[training.uuid].orEmpty()
             .sortedWith(compareBy({ it.startedAt }, { it.uuid.toString() }))

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.export
+
+import io.github.stslex.workeeper.core.core.di.IODispatcher
+import io.github.stslex.workeeper.core.data.database.AppDatabase
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.export.mapper.WorkoutExportMapper
+import io.github.stslex.workeeper.core.data.database.export.model.SessionExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SourceExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.TrainingExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.WorkoutExportDto
+import io.github.stslex.workeeper.core.data.database.session.PerformedExerciseEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingExerciseEntity
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.uuid.Uuid
+
+/**
+ * Default [DatabaseJsonExporter]: load every table once (the unfiltered `getAll` / batch
+ * tag readers), assemble the nested graph in memory with `groupBy` (zero N+1), and encode.
+ * `explicitNulls = false` realizes the spec's "omit nullable fields when null"; `prettyPrint`
+ * keeps the artifact human-readable.
+ */
+@Singleton
+internal class DatabaseJsonExporterImpl @Inject constructor(
+    private val database: AppDatabase,
+    @IODispatcher private val dispatcher: CoroutineDispatcher,
+) : DatabaseJsonExporter {
+
+    private val json = Json {
+        explicitNulls = false
+        prettyPrint = true
+    }
+
+    override suspend fun export(
+        appVersion: String,
+        deviceModel: String?,
+        exportedAtEpochMs: Long,
+    ): ByteArray = withContext(dispatcher) {
+        val exercises = database.exerciseDao.getAll()
+        val trainings = database.trainingDao.getAll()
+        val index = buildIndex(exercises, trainings)
+        val snapshot = WorkoutExportDto(
+            schemaVersion = EXPORT_SCHEMA_VERSION,
+            exportedAt = WorkoutExportMapper.epochToIso(exportedAtEpochMs),
+            source = SourceExportDto(
+                appVersion = appVersion,
+                dbSchemaVersion = database.openHelper.readableDatabase.version,
+                deviceModel = deviceModel,
+            ),
+            exercises = exercises.map { entity ->
+                WorkoutExportMapper.exercise(entity, index.tagsByExercise[entity.uuid].orEmpty())
+            },
+            trainings = trainings.map { training -> buildTraining(training, index) },
+        )
+        json.encodeToString(snapshot).toByteArray(Charsets.UTF_8)
+    }
+
+    private suspend fun buildIndex(
+        exercises: List<ExerciseEntity>,
+        trainings: List<TrainingEntity>,
+    ): ExportIndex {
+        val exerciseUuids = exercises.map { it.uuid }
+        val trainingUuids = trainings.map { it.uuid }
+        return ExportIndex(
+            exerciseNameByUuid = exercises.associate { it.uuid to it.name },
+            // Batch readers render `IN ()` for an empty list (SQLite syntax error) — short-circuit.
+            tagsByExercise = if (exerciseUuids.isEmpty()) {
+                emptyMap()
+            } else {
+                database.exerciseTagDao.getTagNamesForExercises(exerciseUuids)
+                    .groupBy({ it.exerciseUuid }, { it.name })
+            },
+            tagsByTraining = if (trainingUuids.isEmpty()) {
+                emptyMap()
+            } else {
+                database.trainingTagDao.getTagNamesForTrainings(trainingUuids)
+                    .groupBy({ it.trainingUuid }, { it.name })
+            },
+            planByTraining = database.trainingExerciseDao.getAll().groupBy { it.trainingUuid },
+            sessionsByTraining = database.sessionDao.getAll().groupBy { it.trainingUuid },
+            performedBySession = database.performedExerciseDao.getAll().groupBy { it.sessionUuid },
+            setsByPerformed = database.setDao.getAll().groupBy { it.performedExerciseUuid },
+        )
+    }
+
+    private fun buildTraining(training: TrainingEntity, index: ExportIndex): TrainingExportDto {
+        val plan = index.planByTraining[training.uuid].orEmpty().map { row ->
+            WorkoutExportMapper.planExercise(row, index.exerciseNameByUuid[row.exerciseUuid].orEmpty())
+        }
+        val sessions = index.sessionsByTraining[training.uuid].orEmpty()
+            .sortedBy { it.startedAt }
+            .map { session -> buildSession(session, index) }
+        return WorkoutExportMapper.training(
+            entity = training,
+            tags = index.tagsByTraining[training.uuid].orEmpty(),
+            plan = plan,
+            sessions = sessions,
+        )
+    }
+
+    private fun buildSession(session: SessionEntity, index: ExportIndex): SessionExportDto {
+        val performed = index.performedBySession[session.uuid].orEmpty().map { entity ->
+            WorkoutExportMapper.performed(
+                entity = entity,
+                exerciseName = index.exerciseNameByUuid[entity.exerciseUuid].orEmpty(),
+                sets = index.setsByPerformed[entity.uuid].orEmpty(),
+            )
+        }
+        return WorkoutExportMapper.session(session, performed)
+    }
+
+    /** In-memory join tables for one export pass: every row pre-grouped by its parent uuid. */
+    private class ExportIndex(
+        val exerciseNameByUuid: Map<Uuid, String>,
+        val tagsByExercise: Map<Uuid, List<String>>,
+        val tagsByTraining: Map<Uuid, List<String>>,
+        val planByTraining: Map<Uuid, List<TrainingExerciseEntity>>,
+        val sessionsByTraining: Map<Uuid, List<SessionEntity>>,
+        val performedBySession: Map<Uuid, List<PerformedExerciseEntity>>,
+        val setsByPerformed: Map<Uuid, List<SetEntity>>,
+    )
+
+    private companion object {
+        /** Export contract version; independent of `APP_DATABASE_VERSION` (spec D7). */
+        const val EXPORT_SCHEMA_VERSION = 1
+    }
+}

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
@@ -54,7 +54,7 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
         val snapshot = database.withTransaction {
             val exercises = database.exerciseDao.getAll()
             val trainings = database.trainingDao.getAll()
-            val index = buildIndex(exercises, trainings)
+            val index = buildIndex(exercises)
             WorkoutExportDto(
                 schemaVersion = EXPORT_SCHEMA_VERSION,
                 exportedAt = WorkoutExportMapper.epochToIso(exportedAtEpochMs),
@@ -73,33 +73,19 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
         json.encodeToString(snapshot).toByteArray(Charsets.UTF_8)
     }
 
-    private suspend fun buildIndex(
-        exercises: List<ExerciseEntity>,
-        trainings: List<TrainingEntity>,
-    ): ExportIndex {
-        val exerciseUuids = exercises.map { it.uuid }
-        val trainingUuids = trainings.map { it.uuid }
-        return ExportIndex(
-            exerciseNameByUuid = exercises.associate { it.uuid to it.name },
-            // Batch readers render `IN ()` for an empty list (SQLite syntax error) — short-circuit.
-            tagsByExercise = if (exerciseUuids.isEmpty()) {
-                emptyMap()
-            } else {
-                database.exerciseTagDao.getTagNamesForExercises(exerciseUuids)
-                    .groupBy({ it.exerciseUuid }, { it.name })
-            },
-            tagsByTraining = if (trainingUuids.isEmpty()) {
-                emptyMap()
-            } else {
-                database.trainingTagDao.getTagNamesForTrainings(trainingUuids)
-                    .groupBy({ it.trainingUuid }, { it.name })
-            },
-            planByTraining = database.trainingExerciseDao.getAll().groupBy { it.trainingUuid },
-            sessionsByTraining = database.sessionDao.getAll().groupBy { it.trainingUuid },
-            performedBySession = database.performedExerciseDao.getAll().groupBy { it.sessionUuid },
-            setsByPerformed = database.setDao.getAll().groupBy { it.performedExerciseUuid },
-        )
-    }
+    private suspend fun buildIndex(exercises: List<ExerciseEntity>): ExportIndex = ExportIndex(
+        exerciseNameByUuid = exercises.associate { it.uuid to it.name },
+        // Full-table tag joins (no uuid binding) — cannot hit SQLITE_MAX_VARIABLE_NUMBER, and
+        // consistent with the unfiltered getAll() readers below.
+        tagsByExercise = database.exerciseTagDao.getAllExerciseTagNames()
+            .groupBy({ it.exerciseUuid }, { it.name }),
+        tagsByTraining = database.trainingTagDao.getAllTrainingTagNames()
+            .groupBy({ it.trainingUuid }, { it.name }),
+        planByTraining = database.trainingExerciseDao.getAll().groupBy { it.trainingUuid },
+        sessionsByTraining = database.sessionDao.getAll().groupBy { it.trainingUuid },
+        performedBySession = database.performedExerciseDao.getAll().groupBy { it.sessionUuid },
+        setsByPerformed = database.setDao.getAll().groupBy { it.performedExerciseUuid },
+    )
 
     private fun buildTraining(training: TrainingEntity, index: ExportIndex): TrainingExportDto {
         val plan = index.planByTraining[training.uuid].orEmpty().map { row ->

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.core.data.database.export
 
+import androidx.room.withTransaction
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.data.database.AppDatabase
 import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
@@ -43,22 +44,32 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
         deviceModel: String?,
         exportedAtEpochMs: Long,
     ): ByteArray = withContext(dispatcher) {
-        val exercises = database.exerciseDao.getAll()
-        val trainings = database.trainingDao.getAll()
-        val index = buildIndex(exercises, trainings)
-        val snapshot = WorkoutExportDto(
-            schemaVersion = EXPORT_SCHEMA_VERSION,
-            exportedAt = WorkoutExportMapper.epochToIso(exportedAtEpochMs),
-            source = SourceExportDto(
-                appVersion = appVersion,
-                dbSchemaVersion = database.openHelper.readableDatabase.version,
-                deviceModel = deviceModel,
-            ),
-            exercises = exercises.map { entity ->
-                WorkoutExportMapper.exercise(entity, index.tagsByExercise[entity.uuid].orEmpty())
-            },
-            trainings = trainings.map { training -> buildTraining(training, index) },
-        )
+        // Process-stable (only changes on migration at open); read once, outside the transaction.
+        val dbSchemaVersion = database.openHelper.readableDatabase.version
+        // One consistent snapshot: every table read + the in-memory index build runs inside a
+        // single Room transaction. The export is fire-and-forget (spec D2) so it can overlap live
+        // workout edits; without the transaction each DAO call would observe its own snapshot and
+        // an interleaved insert could surface a child row whose parent/name row was not read (e.g.
+        // `exerciseNameByUuid` falling back to ""). The transaction pins all reads to one state.
+        val snapshot = database.withTransaction {
+            val exercises = database.exerciseDao.getAll()
+            val trainings = database.trainingDao.getAll()
+            val index = buildIndex(exercises, trainings)
+            WorkoutExportDto(
+                schemaVersion = EXPORT_SCHEMA_VERSION,
+                exportedAt = WorkoutExportMapper.epochToIso(exportedAtEpochMs),
+                source = SourceExportDto(
+                    appVersion = appVersion,
+                    dbSchemaVersion = dbSchemaVersion,
+                    deviceModel = deviceModel,
+                ),
+                exercises = exercises.map { entity ->
+                    WorkoutExportMapper.exercise(entity, index.tagsByExercise[entity.uuid].orEmpty())
+                },
+                trainings = trainings.map { training -> buildTraining(training, index) },
+            )
+        }
+        // Encode outside the transaction — pure CPU, no DB access; keeps the transaction short.
         json.encodeToString(snapshot).toByteArray(Charsets.UTF_8)
     }
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImpl.kt
@@ -95,7 +95,7 @@ internal class DatabaseJsonExporterImpl @Inject constructor(
             WorkoutExportMapper.planExercise(row, index.exerciseNameByUuid[row.exerciseUuid].orEmpty())
         }
         val sessions = index.sessionsByTraining[training.uuid].orEmpty()
-            .sortedBy { it.startedAt }
+            .sortedWith(compareBy({ it.startedAt }, { it.uuid.toString() }))
             .map { session -> buildSession(session, index) }
         return WorkoutExportMapper.training(
             entity = training,

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/mapper/WorkoutExportMapper.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/mapper/WorkoutExportMapper.kt
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.export.mapper
+
+import io.github.stslex.workeeper.core.data.database.converters.PlanSetsConverter
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseTypeEntity
+import io.github.stslex.workeeper.core.data.database.export.model.ExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.ExerciseTypeExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PerformedExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PlanExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PlanSetExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SessionExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SessionStateExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SetExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SetTypeExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.TrainingExportDto
+import io.github.stslex.workeeper.core.data.database.session.PerformedExerciseEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionStateEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetTypeEntity
+import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
+import io.github.stslex.workeeper.core.data.database.sets.SetTypeDataModel
+import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingExerciseEntity
+import java.time.Instant
+
+/**
+ * Pure entity → export-DTO conversions for the AI snapshot (spec §4.1). Keeps mapping
+ * out of [io.github.stslex.workeeper.core.data.database.export.DatabaseJsonExporter],
+ * which only loads + groups. Children/tags are resolved by the exporter and passed in;
+ * the column-stored `planSets` / `lastAdhocSets` JSON is decoded here via
+ * [PlanSetsConverter] (never passed through as a raw string).
+ */
+internal object WorkoutExportMapper {
+
+    /** DB epoch-millis → UTC ISO-8601 (e.g. `2026-06-26T10:42:23Z`). */
+    fun epochToIso(epochMs: Long): String = Instant.ofEpochMilli(epochMs).toString()
+
+    fun exercise(entity: ExerciseEntity, tags: List<String>): ExerciseExportDto = ExerciseExportDto(
+        uuid = entity.uuid.toString(),
+        name = entity.name,
+        type = entity.type.toExport(),
+        description = entity.description,
+        isAdhoc = entity.isAdhoc,
+        archived = entity.archived,
+        createdAt = epochToIso(entity.createdAt),
+        archivedAt = entity.archivedAt?.let(::epochToIso),
+        tags = tags,
+        // imagePath intentionally omitted (device-local path, no value to an LLM; spec §7).
+        lastAdhocSets = planSets(entity.lastAdhocSets)?.takeIf { it.isNotEmpty() },
+    )
+
+    fun training(
+        entity: TrainingEntity,
+        tags: List<String>,
+        plan: List<PlanExerciseExportDto>,
+        sessions: List<SessionExportDto>,
+    ): TrainingExportDto = TrainingExportDto(
+        uuid = entity.uuid.toString(),
+        name = entity.name,
+        description = entity.description,
+        isAdhoc = entity.isAdhoc,
+        archived = entity.archived,
+        createdAt = epochToIso(entity.createdAt),
+        archivedAt = entity.archivedAt?.let(::epochToIso),
+        tags = tags,
+        plan = plan,
+        sessions = sessions,
+    )
+
+    fun planExercise(entity: TrainingExerciseEntity, exerciseName: String): PlanExerciseExportDto =
+        PlanExerciseExportDto(
+            exerciseUuid = entity.exerciseUuid.toString(),
+            exerciseName = exerciseName,
+            position = entity.position,
+            planSets = planSets(entity.planSets).orEmpty(),
+        )
+
+    fun session(
+        entity: SessionEntity,
+        performedExercises: List<PerformedExerciseExportDto>,
+    ): SessionExportDto = SessionExportDto(
+        uuid = entity.uuid.toString(),
+        state = entity.state.toExport(),
+        startedAt = epochToIso(entity.startedAt),
+        finishedAt = entity.finishedAt?.let(::epochToIso),
+        performedExercises = performedExercises,
+    )
+
+    fun performed(
+        entity: PerformedExerciseEntity,
+        exerciseName: String,
+        sets: List<SetEntity>,
+    ): PerformedExerciseExportDto = PerformedExerciseExportDto(
+        exerciseUuid = entity.exerciseUuid.toString(),
+        exerciseName = exerciseName,
+        position = entity.position,
+        skipped = entity.skipped,
+        sets = sets.map(::set),
+    )
+
+    fun set(entity: SetEntity): SetExportDto = SetExportDto(
+        position = entity.position,
+        reps = entity.reps,
+        weight = entity.weight,
+        type = entity.type.toExport(),
+    )
+
+    private fun planSets(json: String?): List<PlanSetExportDto>? =
+        PlanSetsConverter.fromJson(json)?.map { it.toExport() }
+
+    private fun PlanSetDataModel.toExport(): PlanSetExportDto = PlanSetExportDto(
+        reps = reps,
+        weight = weight,
+        type = type.toExportSetType(),
+    )
+
+    private fun ExerciseTypeEntity.toExport(): ExerciseTypeExportDto = when (this) {
+        ExerciseTypeEntity.WEIGHTED -> ExerciseTypeExportDto.WEIGHTED
+        ExerciseTypeEntity.WEIGHTLESS -> ExerciseTypeExportDto.WEIGHTLESS
+    }
+
+    private fun SessionStateEntity.toExport(): SessionStateExportDto = when (this) {
+        SessionStateEntity.IN_PROGRESS -> SessionStateExportDto.IN_PROGRESS
+        SessionStateEntity.FINISHED -> SessionStateExportDto.FINISHED
+    }
+
+    private fun SetTypeEntity.toExport(): SetTypeExportDto = when (this) {
+        SetTypeEntity.WARM -> SetTypeExportDto.WARM
+        SetTypeEntity.WORK -> SetTypeExportDto.WORK
+        SetTypeEntity.FAIL -> SetTypeExportDto.FAIL
+        SetTypeEntity.DROP -> SetTypeExportDto.DROP
+    }
+
+    /**
+     * Plan sets are stored with the `SetTypeDataModel` vocabulary (`WARMUP`/`FAILURE`);
+     * normalize to the performed-set vocabulary (`WARM`/`FAIL`) through the total
+     * `toEntity()` bridge so the export emits one set-type language (spec §3).
+     */
+    private fun SetTypeDataModel.toExportSetType(): SetTypeExportDto = toEntity().toExport()
+}

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/model/WorkoutExportDto.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/export/model/WorkoutExportDto.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.export.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Root envelope of the AI-readable snapshot (spec `drive-ai-export.md` §3). A nested,
+ * denormalized projection of the workout graph: a flat [exercises] library plus
+ * [trainings], each carrying its plan and session history. Timestamps are UTC
+ * ISO-8601 strings; nullable fields are omitted when null (the producer's `Json` sets
+ * `explicitNulls = false`).
+ *
+ * [schemaVersion] is the export contract's own version (independent of the Room
+ * `APP_DATABASE_VERSION`); bump it only when this JSON shape changes.
+ *
+ * All types here are `internal`: the snapshot's public surface is the encoded bytes,
+ * not the Kotlin types. They are `@Serializable`, so the repo-wide
+ * `proguard/kotlinx-serialization.pro` keeps cover them (incl. the enums).
+ */
+@Serializable
+internal data class WorkoutExportDto(
+    val schemaVersion: Int,
+    val exportedAt: String,
+    val source: SourceExportDto,
+    val exercises: List<ExerciseExportDto>,
+    val trainings: List<TrainingExportDto>,
+)
+
+@Serializable
+internal data class SourceExportDto(
+    val appVersion: String,
+    val dbSchemaVersion: Int,
+    val deviceModel: String? = null,
+)
+
+@Serializable
+internal data class ExerciseExportDto(
+    val uuid: String,
+    val name: String,
+    val type: ExerciseTypeExportDto,
+    val description: String? = null,
+    val isAdhoc: Boolean,
+    val archived: Boolean,
+    val createdAt: String,
+    val archivedAt: String? = null,
+    val tags: List<String>,
+    val lastAdhocSets: List<PlanSetExportDto>? = null,
+)
+
+@Serializable
+internal data class TrainingExportDto(
+    val uuid: String,
+    val name: String,
+    val description: String? = null,
+    val isAdhoc: Boolean,
+    val archived: Boolean,
+    val createdAt: String,
+    val archivedAt: String? = null,
+    val tags: List<String>,
+    val plan: List<PlanExerciseExportDto>,
+    val sessions: List<SessionExportDto>,
+)
+
+@Serializable
+internal data class PlanExerciseExportDto(
+    val exerciseUuid: String,
+    val exerciseName: String,
+    val position: Int,
+    val planSets: List<PlanSetExportDto>,
+)
+
+@Serializable
+internal data class PlanSetExportDto(
+    val reps: Int,
+    val weight: Double? = null,
+    val type: SetTypeExportDto,
+)
+
+@Serializable
+internal data class SessionExportDto(
+    val uuid: String,
+    val state: SessionStateExportDto,
+    val startedAt: String,
+    val finishedAt: String? = null,
+    val performedExercises: List<PerformedExerciseExportDto>,
+)
+
+@Serializable
+internal data class PerformedExerciseExportDto(
+    val exerciseUuid: String,
+    val exerciseName: String,
+    val position: Int,
+    val skipped: Boolean,
+    val sets: List<SetExportDto>,
+)
+
+@Serializable
+internal data class SetExportDto(
+    val position: Int,
+    val reps: Int,
+    val weight: Double? = null,
+    val type: SetTypeExportDto,
+)
+
+@Serializable
+internal enum class ExerciseTypeExportDto { WEIGHTED, WEIGHTLESS }
+
+@Serializable
+internal enum class SessionStateExportDto { IN_PROGRESS, FINISHED }
+
+/**
+ * Single canonical set-type vocabulary for the export. Performed sets map 1:1 from
+ * `SetTypeEntity`; plan sets (stored with the `SetTypeDataModel` `WARMUP`/`FAILURE`
+ * vocabulary) are normalized into this one via the existing `SetTypeDataModel.toEntity()`
+ * bridge, so the snapshot speaks one set-type language.
+ */
+@Serializable
+internal enum class SetTypeExportDto { WARM, WORK, FAIL, DROP }

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/PerformedExerciseDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/PerformedExerciseDao.kt
@@ -17,6 +17,19 @@ interface PerformedExerciseDao {
     )
     suspend fun getBySession(sessionUuid: Uuid): List<PerformedExerciseEntity>
 
+    /**
+     * Every performed-exercise row across all sessions, ordered so the snapshot
+     * exporter can `groupBy { sessionUuid }` with each group already in position
+     * order. Unfiltered full-graph read; not for user-facing use.
+     */
+    @Query(
+        """
+        SELECT * FROM performed_exercise_table
+        ORDER BY session_uuid, position ASC
+        """,
+    )
+    suspend fun getAll(): List<PerformedExerciseEntity>
+
     @Insert
     suspend fun insert(rows: List<PerformedExerciseEntity>)
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDao.kt
@@ -113,6 +113,15 @@ interface SessionDao {
     @Query("SELECT * FROM session_table WHERE uuid = :uuid")
     suspend fun getById(uuid: Uuid): SessionEntity?
 
+    /**
+     * Every session row, unfiltered — includes both `IN_PROGRESS` and `FINISHED`.
+     * Bypasses the `state`-filtered list invariant: the only caller is the
+     * AI-readable snapshot export, which dumps the full history. Not for user-facing
+     * reads.
+     */
+    @Query("SELECT * FROM session_table")
+    suspend fun getAll(): List<SessionEntity>
+
     @Query(
         """
         SELECT COUNT(*) FROM session_table

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SetDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SetDao.kt
@@ -32,6 +32,19 @@ interface SetDao {
         performedExerciseUuids: List<Uuid>,
     ): List<SetEntity>
 
+    /**
+     * Every set row across all performed exercises, ordered so the snapshot exporter
+     * can `groupBy { performedExerciseUuid }` with each group already in position
+     * order. Unfiltered full-graph read; not for user-facing use.
+     */
+    @Query(
+        """
+        SELECT * FROM set_table
+        ORDER BY performed_exercise_uuid, position ASC
+        """,
+    )
+    suspend fun getAll(): List<SetEntity>
+
     @Query(
         """
         SELECT * FROM set_table

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagDao.kt
@@ -21,6 +21,23 @@ interface ExerciseTagDao {
     )
     suspend fun getTagNames(exerciseUuid: Uuid): List<String>
 
+    /**
+     * Denormalized tag names for many exercises in one query (snapshot export).
+     * Returns one [ExerciseTagNameRow] per (exercise, tag) pair; the caller groups
+     * by `exerciseUuid` in memory. Mirrors the `getPlanSetsBatch` batch convention;
+     * callers must short-circuit an empty [exerciseUuids] list (Room renders `IN ()`).
+     */
+    @Query(
+        """
+        SELECT et.exercise_uuid AS exercise_uuid, t.name AS name
+        FROM exercise_tag_table et
+        JOIN tag_table t ON t.uuid = et.tag_uuid
+        WHERE et.exercise_uuid IN (:exerciseUuids)
+        ORDER BY t.name COLLATE NOCASE ASC
+        """,
+    )
+    suspend fun getTagNamesForExercises(exerciseUuids: List<Uuid>): List<ExerciseTagNameRow>
+
     @Insert
     suspend fun insert(rows: List<ExerciseTagEntity>)
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagDao.kt
@@ -22,21 +22,21 @@ interface ExerciseTagDao {
     suspend fun getTagNames(exerciseUuid: Uuid): List<String>
 
     /**
-     * Denormalized tag names for many exercises in one query (snapshot export).
-     * Returns one [ExerciseTagNameRow] per (exercise, tag) pair; the caller groups
-     * by `exerciseUuid` in memory. Mirrors the `getPlanSetsBatch` batch convention;
-     * callers must short-circuit an empty [exerciseUuids] list (Room renders `IN ()`).
+     * Every (exercise, tag-name) pair in the database, one [ExerciseTagNameRow] per pair
+     * (snapshot export); the caller groups by `exerciseUuid` in memory. A full-table join
+     * with no uuid binding, so it cannot hit `SQLITE_MAX_VARIABLE_NUMBER` for large libraries
+     * (API 28-30 ship SQLite < 3.32 where the host-variable limit is 999), and it matches the
+     * unfiltered `getAll()` readers the exporter consumes in the same pass.
      */
     @Query(
         """
         SELECT et.exercise_uuid AS exercise_uuid, t.name AS name
         FROM exercise_tag_table et
         JOIN tag_table t ON t.uuid = et.tag_uuid
-        WHERE et.exercise_uuid IN (:exerciseUuids)
-        ORDER BY t.name COLLATE NOCASE ASC
+        ORDER BY et.exercise_uuid, t.name COLLATE NOCASE ASC
         """,
     )
-    suspend fun getTagNamesForExercises(exerciseUuids: List<Uuid>): List<ExerciseTagNameRow>
+    suspend fun getAllExerciseTagNames(): List<ExerciseTagNameRow>
 
     @Insert
     suspend fun insert(rows: List<ExerciseTagEntity>)

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagNameRow.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagNameRow.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.tag
+
+import androidx.room.ColumnInfo
+import kotlin.uuid.Uuid
+
+/**
+ * Batch projection: one (exercise, tag-name) pair. Returned by
+ * [ExerciseTagDao.getTagNamesForExercises] so the snapshot exporter resolves
+ * denormalized tag names for many exercises in a single query, then groups by
+ * [exerciseUuid] in memory. Mirrors the `TrainingExercisePlanRow` batch pattern.
+ */
+data class ExerciseTagNameRow(
+    @ColumnInfo(name = "exercise_uuid") val exerciseUuid: Uuid,
+    @ColumnInfo(name = "name") val name: String,
+)

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagNameRow.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/ExerciseTagNameRow.kt
@@ -6,8 +6,8 @@ import kotlin.uuid.Uuid
 
 /**
  * Batch projection: one (exercise, tag-name) pair. Returned by
- * [ExerciseTagDao.getTagNamesForExercises] so the snapshot exporter resolves
- * denormalized tag names for many exercises in a single query, then groups by
+ * [ExerciseTagDao.getAllExerciseTagNames] so the snapshot exporter resolves
+ * denormalized tag names for every exercise in a single full-table query, then groups by
  * [exerciseUuid] in memory. Mirrors the `TrainingExercisePlanRow` batch pattern.
  */
 data class ExerciseTagNameRow(

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagDao.kt
@@ -21,6 +21,23 @@ interface TrainingTagDao {
     )
     suspend fun getTagNames(trainingUuid: Uuid): List<String>
 
+    /**
+     * Denormalized tag names for many trainings in one query (snapshot export).
+     * Returns one [TrainingTagNameRow] per (training, tag) pair; the caller groups
+     * by `trainingUuid` in memory. Mirrors the `getPlanSetsBatch` batch convention;
+     * callers must short-circuit an empty [trainingUuids] list (Room renders `IN ()`).
+     */
+    @Query(
+        """
+        SELECT tt.training_uuid AS training_uuid, t.name AS name
+        FROM training_tag_table tt
+        JOIN tag_table t ON t.uuid = tt.tag_uuid
+        WHERE tt.training_uuid IN (:trainingUuids)
+        ORDER BY t.name COLLATE NOCASE ASC
+        """,
+    )
+    suspend fun getTagNamesForTrainings(trainingUuids: List<Uuid>): List<TrainingTagNameRow>
+
     @Insert
     suspend fun insert(rows: List<TrainingTagEntity>)
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagDao.kt
@@ -22,21 +22,21 @@ interface TrainingTagDao {
     suspend fun getTagNames(trainingUuid: Uuid): List<String>
 
     /**
-     * Denormalized tag names for many trainings in one query (snapshot export).
-     * Returns one [TrainingTagNameRow] per (training, tag) pair; the caller groups
-     * by `trainingUuid` in memory. Mirrors the `getPlanSetsBatch` batch convention;
-     * callers must short-circuit an empty [trainingUuids] list (Room renders `IN ()`).
+     * Every (training, tag-name) pair in the database, one [TrainingTagNameRow] per pair
+     * (snapshot export); the caller groups by `trainingUuid` in memory. A full-table join
+     * with no uuid binding, so it cannot hit `SQLITE_MAX_VARIABLE_NUMBER` for large libraries
+     * (API 28-30 ship SQLite < 3.32 where the host-variable limit is 999), and it matches the
+     * unfiltered `getAll()` readers the exporter consumes in the same pass.
      */
     @Query(
         """
         SELECT tt.training_uuid AS training_uuid, t.name AS name
         FROM training_tag_table tt
         JOIN tag_table t ON t.uuid = tt.tag_uuid
-        WHERE tt.training_uuid IN (:trainingUuids)
-        ORDER BY t.name COLLATE NOCASE ASC
+        ORDER BY tt.training_uuid, t.name COLLATE NOCASE ASC
         """,
     )
-    suspend fun getTagNamesForTrainings(trainingUuids: List<Uuid>): List<TrainingTagNameRow>
+    suspend fun getAllTrainingTagNames(): List<TrainingTagNameRow>
 
     @Insert
     suspend fun insert(rows: List<TrainingTagEntity>)

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagNameRow.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagNameRow.kt
@@ -6,8 +6,8 @@ import kotlin.uuid.Uuid
 
 /**
  * Batch projection: one (training, tag-name) pair. Returned by
- * [TrainingTagDao.getTagNamesForTrainings] so the snapshot exporter resolves
- * denormalized tag names for many trainings in a single query, then groups by
+ * [TrainingTagDao.getAllTrainingTagNames] so the snapshot exporter resolves
+ * denormalized tag names for every training in a single full-table query, then groups by
  * [trainingUuid] in memory. Mirrors the `TrainingExercisePlanRow` batch pattern.
  */
 data class TrainingTagNameRow(

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagNameRow.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/tag/TrainingTagNameRow.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.tag
+
+import androidx.room.ColumnInfo
+import kotlin.uuid.Uuid
+
+/**
+ * Batch projection: one (training, tag-name) pair. Returned by
+ * [TrainingTagDao.getTagNamesForTrainings] so the snapshot exporter resolves
+ * denormalized tag names for many trainings in a single query, then groups by
+ * [trainingUuid] in memory. Mirrors the `TrainingExercisePlanRow` batch pattern.
+ */
+data class TrainingTagNameRow(
+    @ColumnInfo(name = "training_uuid") val trainingUuid: Uuid,
+    @ColumnInfo(name = "name") val name: String,
+)

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDao.kt
@@ -104,6 +104,16 @@ interface TrainingDao {
     @Query("SELECT * FROM training_table WHERE uuid = :uuid")
     fun observeById(uuid: Uuid): Flow<TrainingEntity?>
 
+    /**
+     * Every training row, unfiltered — includes `is_adhoc = 1` and `archived = 1`.
+     * Intentionally bypasses the `is_adhoc = 0` / `archived = 0` list invariant: the
+     * only caller is the AI-readable snapshot export, which dumps the full graph at
+     * full fidelity (adhoc trainings are also needed for referential integrity with
+     * their sessions). Never use this for a user-facing list.
+     */
+    @Query("SELECT * FROM training_table")
+    suspend fun getAll(): List<TrainingEntity>
+
     @Insert
     suspend fun insert(training: TrainingEntity)
 

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDao.kt
@@ -111,7 +111,7 @@ interface TrainingDao {
      * full fidelity (adhoc trainings are also needed for referential integrity with
      * their sessions). Never use this for a user-facing list.
      */
-    @Query("SELECT * FROM training_table")
+    @Query("SELECT * FROM training_table ORDER BY created_at ASC, uuid ASC")
     suspend fun getAll(): List<TrainingEntity>
 
     @Insert

--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingExerciseDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingExerciseDao.kt
@@ -67,6 +67,19 @@ interface TrainingExerciseDao {
         exerciseUuids: List<Uuid>,
     ): List<TrainingExercisePlanRow>
 
+    /**
+     * Every plan row across all trainings, ordered so the snapshot exporter can
+     * `groupBy { trainingUuid }` with each group already in plan order. Unfiltered
+     * by design (full-graph export); not for user-facing reads.
+     */
+    @Query(
+        """
+        SELECT * FROM training_exercise_table
+        ORDER BY training_uuid, position ASC
+        """,
+    )
+    suspend fun getAll(): List<TrainingExerciseEntity>
+
     @Query(
         """
         UPDATE training_exercise_table

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
@@ -37,18 +37,16 @@ internal class ExerciseDaoGetAllTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `getAll returns active plus adhoc and archived rows`() = runTest {
-        val active = exercise(name = "Squat")
-        val adhoc = exercise(name = "Adhoc Curl", isAdhoc = true)
-        val archived = exercise(name = "Old Press", archived = true)
-        listOf(active, adhoc, archived).forEach { exerciseDao.insert(it) }
+    fun `getAll returns all rows ordered by createdAt including adhoc and archived`() = runTest {
+        val active = exercise(name = "Squat", createdAt = 100L)
+        val adhoc = exercise(name = "Adhoc Curl", isAdhoc = true, createdAt = 200L)
+        val archived = exercise(name = "Old Press", archived = true, createdAt = 300L)
+        // Insert out of createdAt order to prove the ORDER BY, not insertion order.
+        listOf(archived, active, adhoc).forEach { exerciseDao.insert(it) }
 
         val all = exerciseDao.getAll()
 
-        assertEquals(
-            setOf(active.uuid, adhoc.uuid, archived.uuid),
-            all.map { it.uuid }.toSet(),
-        )
+        assertEquals(listOf(active.uuid, adhoc.uuid, archived.uuid), all.map { it.uuid })
     }
 
     @Test
@@ -78,13 +76,14 @@ internal class ExerciseDaoGetAllTest : BaseDatabaseTest() {
         name: String,
         isAdhoc: Boolean = false,
         archived: Boolean = false,
+        createdAt: Long = 0L,
     ) = ExerciseEntity(
         name = name,
         type = ExerciseTypeEntity.WEIGHTED,
         description = null,
         imagePath = null,
         archived = archived,
-        createdAt = 0L,
+        createdAt = createdAt,
         archivedAt = null,
         lastAdhocSets = null,
         isAdhoc = isAdhoc,

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
@@ -16,7 +16,7 @@ import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 /**
  * Covers the exercise-side unfiltered bulk readers used by the AI snapshot export:
  * [ExerciseDao.getAll] (must include adhoc + archived) and
- * [ExerciseTagDao.getTagNamesForExercises] (batch names).
+ * [ExerciseTagDao.getAllExerciseTagNames] (full-table batch names).
  */
 @ExtendWith(RobolectricExtension::class)
 @Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
@@ -50,7 +50,7 @@ internal class ExerciseDaoGetAllTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `getTagNamesForExercises groups denormalized names by exercise`() = runTest {
+    fun `getAllExerciseTagNames groups denormalized names by exercise`() = runTest {
         val squat = exercise(name = "Squat")
         val bench = exercise(name = "Bench")
         listOf(squat, bench).forEach { exerciseDao.insert(it) }
@@ -65,7 +65,7 @@ internal class ExerciseDaoGetAllTest : BaseDatabaseTest() {
         )
 
         val byExercise = exerciseTagDao
-            .getTagNamesForExercises(listOf(squat.uuid, bench.uuid))
+            .getAllExerciseTagNames()
             .groupBy({ it.exerciseUuid }, { it.name })
 
         assertEquals(listOf("legs"), byExercise.getValue(squat.uuid))

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/exercise/ExerciseDaoGetAllTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.exercise
+
+import io.github.stslex.workeeper.core.data.database.BaseDatabaseTest
+import io.github.stslex.workeeper.core.data.database.tag.ExerciseTagEntity
+import io.github.stslex.workeeper.core.data.database.tag.TagEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+/**
+ * Covers the exercise-side unfiltered bulk readers used by the AI snapshot export:
+ * [ExerciseDao.getAll] (must include adhoc + archived) and
+ * [ExerciseTagDao.getTagNamesForExercises] (batch names).
+ */
+@ExtendWith(RobolectricExtension::class)
+@Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
+internal class ExerciseDaoGetAllTest : BaseDatabaseTest() {
+
+    private val exerciseDao get() = database.exerciseDao
+    private val exerciseTagDao get() = database.exerciseTagDao
+    private val tagDao get() = database.tagDao
+
+    @BeforeEach
+    fun setup() {
+        initDb()
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearDb()
+    }
+
+    @Test
+    fun `getAll returns active plus adhoc and archived rows`() = runTest {
+        val active = exercise(name = "Squat")
+        val adhoc = exercise(name = "Adhoc Curl", isAdhoc = true)
+        val archived = exercise(name = "Old Press", archived = true)
+        listOf(active, adhoc, archived).forEach { exerciseDao.insert(it) }
+
+        val all = exerciseDao.getAll()
+
+        assertEquals(
+            setOf(active.uuid, adhoc.uuid, archived.uuid),
+            all.map { it.uuid }.toSet(),
+        )
+    }
+
+    @Test
+    fun `getTagNamesForExercises groups denormalized names by exercise`() = runTest {
+        val squat = exercise(name = "Squat")
+        val bench = exercise(name = "Bench")
+        listOf(squat, bench).forEach { exerciseDao.insert(it) }
+        val legs = TagEntity(name = "legs")
+        val push = TagEntity(name = "push")
+        listOf(legs, push).forEach { tagDao.insert(it) }
+        exerciseTagDao.insert(
+            listOf(
+                ExerciseTagEntity(squat.uuid, legs.uuid),
+                ExerciseTagEntity(bench.uuid, push.uuid),
+            ),
+        )
+
+        val byExercise = exerciseTagDao
+            .getTagNamesForExercises(listOf(squat.uuid, bench.uuid))
+            .groupBy({ it.exerciseUuid }, { it.name })
+
+        assertEquals(listOf("legs"), byExercise.getValue(squat.uuid))
+        assertEquals(listOf("push"), byExercise.getValue(bench.uuid))
+    }
+
+    private fun exercise(
+        name: String,
+        isAdhoc: Boolean = false,
+        archived: Boolean = false,
+    ) = ExerciseEntity(
+        name = name,
+        type = ExerciseTypeEntity.WEIGHTED,
+        description = null,
+        imagePath = null,
+        archived = archived,
+        createdAt = 0L,
+        archivedAt = null,
+        lastAdhocSets = null,
+        isAdhoc = isAdhoc,
+    )
+}

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImplTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImplTest.kt
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.export
+
+import io.github.stslex.workeeper.core.data.database.BaseDatabaseTest
+import io.github.stslex.workeeper.core.data.database.converters.PlanSetsConverter
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseTypeEntity
+import io.github.stslex.workeeper.core.data.database.export.model.ExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.ExerciseTypeExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PerformedExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PlanExerciseExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.PlanSetExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SessionExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SessionStateExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SetExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SetTypeExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.SourceExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.TrainingExportDto
+import io.github.stslex.workeeper.core.data.database.export.model.WorkoutExportDto
+import io.github.stslex.workeeper.core.data.database.migration.APP_DATABASE_VERSION
+import io.github.stslex.workeeper.core.data.database.session.PerformedExerciseEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionStateEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetTypeEntity
+import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
+import io.github.stslex.workeeper.core.data.database.sets.SetTypeDataModel
+import io.github.stslex.workeeper.core.data.database.tag.ExerciseTagEntity
+import io.github.stslex.workeeper.core.data.database.tag.TagEntity
+import io.github.stslex.workeeper.core.data.database.tag.TrainingTagEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingExerciseEntity
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.time.Instant
+
+@ExtendWith(RobolectricExtension::class)
+@Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
+internal class DatabaseJsonExporterImplTest : BaseDatabaseTest() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var exporter: DatabaseJsonExporterImpl
+
+    @BeforeEach
+    fun setup() {
+        initDb()
+        exporter = DatabaseJsonExporterImpl(database, UnconfinedTestDispatcher())
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearDb()
+    }
+
+    @Test
+    fun `export produces full nested graph including adhoc and archived rows`() = runTest {
+        seedFullGraph()
+
+        val raw = exporter.export(
+            appVersion = "9.9.9",
+            deviceModel = "Pixel Test",
+            exportedAtEpochMs = EXPORTED_AT_EPOCH_MS,
+        ).decodeToString()
+        val dto = json.decodeFromString<WorkoutExportDto>(raw)
+
+        assertEquals(1, dto.schemaVersion)
+        assertEquals(Instant.ofEpochMilli(EXPORTED_AT_EPOCH_MS).toString(), dto.exportedAt)
+        assertEquals("9.9.9", dto.source.appVersion)
+        assertEquals(APP_DATABASE_VERSION, dto.source.dbSchemaVersion)
+        assertEquals("Pixel Test", dto.source.deviceModel)
+
+        // Correctness trap: adhoc + archived exercises MUST be present (unfiltered read).
+        assertEquals(
+            setOf("Bench", "Plank", "Adhoc Curl", "Archived Row"),
+            dto.exercises.map { it.name }.toSet(),
+        )
+        assertTrue(dto.exercises.first { it.name == "Adhoc Curl" }.isAdhoc)
+        assertTrue(dto.exercises.first { it.name == "Archived Row" }.archived)
+        assertEquals(ExerciseTypeExportDto.WEIGHTLESS, dto.exercises.first { it.name == "Plank" }.type)
+
+        // imagePath is never exported (device-local path, spec §7).
+        assertFalse(raw.contains("imagePath"))
+        assertFalse(raw.contains("bench.png"))
+
+        // Archived training is included, with its (empty) plan/sessions.
+        assertEquals(setOf("Push", "Old Split"), dto.trainings.map { it.name }.toSet())
+        val old = dto.trainings.first { it.name == "Old Split" }
+        assertTrue(old.plan.isEmpty())
+        assertTrue(old.sessions.isEmpty())
+
+        val push = dto.trainings.first { it.name == "Push" }
+        assertEquals(listOf("push"), push.tags)
+
+        // Plan rows in position order; plan-set types normalized WARMUP -> WARM.
+        assertEquals(listOf("Bench", "Plank"), push.plan.map { it.exerciseName })
+        val benchPlan = push.plan.first { it.exerciseName == "Bench" }
+        assertEquals(listOf(SetTypeExportDto.WARM, SetTypeExportDto.WORK), benchPlan.planSets.map { it.type })
+        assertTrue(push.plan.first { it.exerciseName == "Plank" }.planSets.isEmpty())
+
+        // Sessions ordered by startedAt: FINISHED (10s) before IN_PROGRESS (20s).
+        assertEquals(
+            listOf(SessionStateExportDto.FINISHED, SessionStateExportDto.IN_PROGRESS),
+            push.sessions.map { it.state },
+        )
+        val finished = push.sessions.first { it.state == SessionStateExportDto.FINISHED }
+        assertEquals(listOf("Bench", "Plank"), finished.performedExercises.map { it.exerciseName })
+
+        // WEIGHTLESS performed set: weight omitted -> null after decode.
+        val plankSets = finished.performedExercises.first { it.exerciseName == "Plank" }.sets
+        assertEquals(1, plankSets.size)
+        assertNull(plankSets.first().weight)
+    }
+
+    @Test
+    fun `empty database exports a valid envelope with empty arrays`() = runTest {
+        val dto = json.decodeFromString<WorkoutExportDto>(
+            exporter.export(appVersion = "1.0", deviceModel = null, exportedAtEpochMs = EXPORTED_AT_EPOCH_MS)
+                .decodeToString(),
+        )
+
+        assertEquals(1, dto.schemaVersion)
+        assertTrue(dto.exercises.isEmpty())
+        assertTrue(dto.trainings.isEmpty())
+        assertNull(dto.source.deviceModel)
+    }
+
+    @Test
+    fun `enum round trip preserves all export enum values`() {
+        val original = WorkoutExportDto(
+            schemaVersion = 1,
+            exportedAt = "2026-06-26T10:00:00Z",
+            source = SourceExportDto(appVersion = "1.0", dbSchemaVersion = APP_DATABASE_VERSION, deviceModel = "Dev"),
+            exercises = listOf(
+                ExerciseExportDto(
+                    uuid = "e1",
+                    name = "Weighted",
+                    type = ExerciseTypeExportDto.WEIGHTED,
+                    isAdhoc = false,
+                    archived = false,
+                    createdAt = "2026-01-01T00:00:00Z",
+                    tags = emptyList(),
+                ),
+                ExerciseExportDto(
+                    uuid = "e2",
+                    name = "Bodyweight",
+                    type = ExerciseTypeExportDto.WEIGHTLESS,
+                    isAdhoc = true,
+                    archived = true,
+                    createdAt = "2026-01-01T00:00:00Z",
+                    tags = emptyList(),
+                ),
+            ),
+            trainings = listOf(
+                TrainingExportDto(
+                    uuid = "t1",
+                    name = "T",
+                    isAdhoc = false,
+                    archived = false,
+                    createdAt = "2026-01-01T00:00:00Z",
+                    tags = emptyList(),
+                    plan = listOf(
+                        PlanExerciseExportDto(
+                            exerciseUuid = "e1",
+                            exerciseName = "Weighted",
+                            position = 0,
+                            planSets = listOf(
+                                PlanSetExportDto(reps = 5, weight = 100.0, type = SetTypeExportDto.WARM),
+                                PlanSetExportDto(reps = 5, weight = 100.0, type = SetTypeExportDto.WORK),
+                                PlanSetExportDto(reps = 3, weight = 110.0, type = SetTypeExportDto.FAIL),
+                                PlanSetExportDto(reps = 8, weight = null, type = SetTypeExportDto.DROP),
+                            ),
+                        ),
+                    ),
+                    sessions = listOf(
+                        SessionExportDto(
+                            uuid = "s1",
+                            state = SessionStateExportDto.FINISHED,
+                            startedAt = "2026-01-01T00:00:00Z",
+                            finishedAt = "2026-01-01T01:00:00Z",
+                            performedExercises = listOf(
+                                PerformedExerciseExportDto(
+                                    exerciseUuid = "e1",
+                                    exerciseName = "Weighted",
+                                    position = 0,
+                                    skipped = false,
+                                    sets = listOf(
+                                        SetExportDto(
+                                            position = 0,
+                                            reps = 5,
+                                            weight = 100.0,
+                                            type = SetTypeExportDto.WORK,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        SessionExportDto(
+                            uuid = "s2",
+                            state = SessionStateExportDto.IN_PROGRESS,
+                            startedAt = "2026-01-02T00:00:00Z",
+                            finishedAt = null,
+                            performedExercises = emptyList(),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val decoded = json.decodeFromString<WorkoutExportDto>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+    }
+
+    private suspend fun seedFullGraph() {
+        val push = TrainingEntity(
+            name = "Push",
+            description = "Heavy",
+            isAdhoc = false,
+            archived = false,
+            createdAt = 1_000L,
+            archivedAt = null,
+        )
+        val oldSplit = TrainingEntity(
+            name = "Old Split",
+            description = null,
+            isAdhoc = false,
+            archived = true,
+            createdAt = 500L,
+            archivedAt = 2_000L,
+        )
+        listOf(push, oldSplit).forEach { database.trainingDao.insert(it) }
+
+        val bench = exercise(name = "Bench", imagePath = "/data/user/0/app/files/bench.png")
+        val plank = exercise(name = "Plank", type = ExerciseTypeEntity.WEIGHTLESS)
+        val adhocCurl = exercise(name = "Adhoc Curl", isAdhoc = true)
+        val archivedRow = exercise(name = "Archived Row", archived = true, archivedAt = 3_000L)
+        listOf(bench, plank, adhocCurl, archivedRow).forEach { database.exerciseDao.insert(it) }
+
+        val benchPlanJson = PlanSetsConverter.toJson(
+            listOf(
+                PlanSetDataModel(weight = 60.0, reps = 10, type = SetTypeDataModel.WARMUP),
+                PlanSetDataModel(weight = 100.0, reps = 5, type = SetTypeDataModel.WORK),
+            ),
+        )
+        database.trainingExerciseDao.insert(
+            listOf(
+                TrainingExerciseEntity(push.uuid, bench.uuid, position = 0, planSets = benchPlanJson),
+                TrainingExerciseEntity(push.uuid, plank.uuid, position = 1, planSets = null),
+            ),
+        )
+
+        val finished = SessionEntity(
+            trainingUuid = push.uuid,
+            state = SessionStateEntity.FINISHED,
+            startedAt = 10_000L,
+            finishedAt = 11_000L,
+        )
+        val active = SessionEntity(
+            trainingUuid = push.uuid,
+            state = SessionStateEntity.IN_PROGRESS,
+            startedAt = 20_000L,
+            finishedAt = null,
+        )
+        listOf(finished, active).forEach { database.sessionDao.insert(it) }
+
+        val benchPerformed = PerformedExerciseEntity(
+            sessionUuid = finished.uuid,
+            exerciseUuid = bench.uuid,
+            position = 0,
+            skipped = false,
+        )
+        val plankPerformed = PerformedExerciseEntity(
+            sessionUuid = finished.uuid,
+            exerciseUuid = plank.uuid,
+            position = 1,
+            skipped = false,
+        )
+        listOf(benchPerformed, plankPerformed).forEach { database.performedExerciseDao.insert(it) }
+
+        database.setDao.insert(
+            SetEntity(
+                performedExerciseUuid = benchPerformed.uuid,
+                position = 0,
+                reps = 5,
+                weight = 100.0,
+                type = SetTypeEntity.WORK,
+            ),
+        )
+        database.setDao.insert(
+            SetEntity(
+                performedExerciseUuid = plankPerformed.uuid,
+                position = 0,
+                reps = 30,
+                weight = null,
+                type = SetTypeEntity.WORK,
+            ),
+        )
+
+        val pushTag = TagEntity(name = "push")
+        val barbell = TagEntity(name = "barbell")
+        val core = TagEntity(name = "core")
+        listOf(pushTag, barbell, core).forEach { database.tagDao.insert(it) }
+        database.exerciseTagDao.insert(
+            listOf(
+                ExerciseTagEntity(bench.uuid, pushTag.uuid),
+                ExerciseTagEntity(bench.uuid, barbell.uuid),
+                ExerciseTagEntity(plank.uuid, core.uuid),
+            ),
+        )
+        database.trainingTagDao.insert(listOf(TrainingTagEntity(push.uuid, pushTag.uuid)))
+    }
+
+    private fun exercise(
+        name: String,
+        type: ExerciseTypeEntity = ExerciseTypeEntity.WEIGHTED,
+        imagePath: String? = null,
+        isAdhoc: Boolean = false,
+        archived: Boolean = false,
+        archivedAt: Long? = null,
+    ) = ExerciseEntity(
+        name = name,
+        type = type,
+        description = null,
+        imagePath = imagePath,
+        archived = archived,
+        createdAt = 1_000L,
+        archivedAt = archivedAt,
+        lastAdhocSets = null,
+        isAdhoc = isAdhoc,
+    )
+
+    private companion object {
+        const val EXPORTED_AT_EPOCH_MS = 1_700_000_000_000L
+    }
+}

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImplTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/export/DatabaseJsonExporterImplTest.kt
@@ -93,8 +93,9 @@ internal class DatabaseJsonExporterImplTest : BaseDatabaseTest() {
         assertFalse(raw.contains("imagePath"))
         assertFalse(raw.contains("bench.png"))
 
-        // Archived training is included, with its (empty) plan/sessions.
-        assertEquals(setOf("Push", "Old Split"), dto.trainings.map { it.name }.toSet())
+        // Archived training is included; top-level trainings are ordered by createdAt
+        // (Old Split = 500 before Push = 1000) so the snapshot is stable across runs.
+        assertEquals(listOf("Old Split", "Push"), dto.trainings.map { it.name })
         val old = dto.trainings.first { it.name == "Old Split" }
         assertTrue(old.plan.isEmpty())
         assertTrue(old.sessions.isEmpty())

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoGetAllTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.session
+
+import io.github.stslex.workeeper.core.data.database.BaseDatabaseTest
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseTypeEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetTypeEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import kotlin.uuid.Uuid
+
+/**
+ * Covers the session-side unfiltered bulk readers used by the AI snapshot export:
+ * [SessionDao.getAll] (must include IN_PROGRESS + FINISHED), [PerformedExerciseDao.getAll],
+ * and [SetDao.getAll] (rows returned in position order).
+ */
+@ExtendWith(RobolectricExtension::class)
+@Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
+internal class SessionDaoGetAllTest : BaseDatabaseTest() {
+
+    private val sessionDao get() = database.sessionDao
+    private val performedExerciseDao get() = database.performedExerciseDao
+    private val setDao get() = database.setDao
+    private val trainingDao get() = database.trainingDao
+    private val exerciseDao get() = database.exerciseDao
+
+    @BeforeEach
+    fun setup() {
+        initDb()
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearDb()
+    }
+
+    @Test
+    fun `getAll returns both in-progress and finished sessions`() = runTest {
+        val trainingUuid = Uuid.random()
+        val exerciseUuid = Uuid.random()
+        seedTrainingAndExercise(trainingUuid, exerciseUuid)
+        val active = session(trainingUuid, SessionStateEntity.IN_PROGRESS, finishedAt = null)
+        val finished = session(trainingUuid, SessionStateEntity.FINISHED, finishedAt = 100L)
+        listOf(active, finished).forEach { sessionDao.insert(it) }
+
+        val all = sessionDao.getAll()
+
+        assertEquals(setOf(active.uuid, finished.uuid), all.map { it.uuid }.toSet())
+    }
+
+    @Test
+    fun `performed-exercise and set getAll return the full graph in position order`() = runTest {
+        val trainingUuid = Uuid.random()
+        val exerciseUuid = Uuid.random()
+        seedTrainingAndExercise(trainingUuid, exerciseUuid)
+        val session = session(trainingUuid, SessionStateEntity.FINISHED, finishedAt = 100L)
+        sessionDao.insert(session)
+        val performed = PerformedExerciseEntity(
+            sessionUuid = session.uuid,
+            exerciseUuid = exerciseUuid,
+            position = 0,
+            skipped = false,
+        )
+        performedExerciseDao.insert(performed)
+        setDao.insert(
+            SetEntity(
+                performedExerciseUuid = performed.uuid,
+                position = 1,
+                reps = 8,
+                weight = 50.0,
+                type = SetTypeEntity.WORK,
+            ),
+        )
+        setDao.insert(
+            SetEntity(
+                performedExerciseUuid = performed.uuid,
+                position = 0,
+                reps = 5,
+                weight = null,
+                type = SetTypeEntity.WARM,
+            ),
+        )
+
+        assertEquals(listOf(performed.uuid), performedExerciseDao.getAll().map { it.uuid })
+        assertEquals(listOf(0, 1), setDao.getAll().map { it.position })
+    }
+
+    private suspend fun seedTrainingAndExercise(trainingUuid: Uuid, exerciseUuid: Uuid) {
+        trainingDao.insert(
+            TrainingEntity(
+                uuid = trainingUuid,
+                name = "Push Day",
+                description = null,
+                isAdhoc = false,
+                archived = false,
+                createdAt = 0L,
+                archivedAt = null,
+            ),
+        )
+        exerciseDao.insert(
+            ExerciseEntity(
+                uuid = exerciseUuid,
+                name = "Bench",
+                type = ExerciseTypeEntity.WEIGHTED,
+                description = null,
+                imagePath = null,
+                archived = false,
+                createdAt = 0L,
+                archivedAt = null,
+                lastAdhocSets = null,
+                isAdhoc = false,
+            ),
+        )
+    }
+
+    private fun session(
+        trainingUuid: Uuid,
+        state: SessionStateEntity,
+        finishedAt: Long?,
+    ) = SessionEntity(
+        trainingUuid = trainingUuid,
+        state = state,
+        startedAt = 0L,
+        finishedAt = finishedAt,
+    )
+}

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.training
+
+import io.github.stslex.workeeper.core.data.database.BaseDatabaseTest
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseTypeEntity
+import io.github.stslex.workeeper.core.data.database.tag.TagEntity
+import io.github.stslex.workeeper.core.data.database.tag.TrainingTagEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+/**
+ * Covers the training-side unfiltered bulk readers used by the AI snapshot export:
+ * [TrainingDao.getAll] (must include adhoc + archived), [TrainingExerciseDao.getAll]
+ * (plan rows in order), and [TrainingTagDao.getTagNamesForTrainings] (batch names).
+ */
+@ExtendWith(RobolectricExtension::class)
+@Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
+internal class TrainingDaoGetAllTest : BaseDatabaseTest() {
+
+    private val trainingDao get() = database.trainingDao
+    private val trainingExerciseDao get() = database.trainingExerciseDao
+    private val trainingTagDao get() = database.trainingTagDao
+    private val exerciseDao get() = database.exerciseDao
+    private val tagDao get() = database.tagDao
+
+    @BeforeEach
+    fun setup() {
+        initDb()
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearDb()
+    }
+
+    @Test
+    fun `getAll returns templates plus adhoc and archived rows`() = runTest {
+        val template = training(name = "Template")
+        val adhoc = training(name = "Adhoc", isAdhoc = true)
+        val archived = training(name = "Archived", archived = true, archivedAt = 10L)
+        listOf(template, adhoc, archived).forEach { trainingDao.insert(it) }
+
+        val all = trainingDao.getAll()
+
+        assertEquals(
+            setOf(template.uuid, adhoc.uuid, archived.uuid),
+            all.map { it.uuid }.toSet(),
+        )
+    }
+
+    @Test
+    fun `training-exercise getAll returns every plan row in plan order`() = runTest {
+        val training = training(name = "Push")
+        trainingDao.insert(training)
+        val bench = exercise(name = "Bench")
+        val ohp = exercise(name = "OHP")
+        listOf(bench, ohp).forEach { exerciseDao.insert(it) }
+        trainingExerciseDao.insert(
+            listOf(
+                TrainingExerciseEntity(training.uuid, ohp.uuid, position = 1),
+                TrainingExerciseEntity(training.uuid, bench.uuid, position = 0),
+            ),
+        )
+
+        val all = trainingExerciseDao.getAll()
+
+        assertEquals(listOf(bench.uuid, ohp.uuid), all.map { it.exerciseUuid })
+    }
+
+    @Test
+    fun `getTagNamesForTrainings groups denormalized names by training`() = runTest {
+        val legs = training(name = "Legs")
+        val push = training(name = "Push")
+        listOf(legs, push).forEach { trainingDao.insert(it) }
+        val heavy = TagEntity(name = "heavy")
+        val barbell = TagEntity(name = "barbell")
+        listOf(heavy, barbell).forEach { tagDao.insert(it) }
+        trainingTagDao.insert(
+            listOf(
+                TrainingTagEntity(legs.uuid, heavy.uuid),
+                TrainingTagEntity(legs.uuid, barbell.uuid),
+                TrainingTagEntity(push.uuid, barbell.uuid),
+            ),
+        )
+
+        val byTraining = trainingTagDao
+            .getTagNamesForTrainings(listOf(legs.uuid, push.uuid))
+            .groupBy({ it.trainingUuid }, { it.name })
+
+        assertEquals(listOf("barbell", "heavy"), byTraining.getValue(legs.uuid))
+        assertEquals(listOf("barbell"), byTraining.getValue(push.uuid))
+    }
+
+    private fun training(
+        name: String,
+        isAdhoc: Boolean = false,
+        archived: Boolean = false,
+        archivedAt: Long? = null,
+    ) = TrainingEntity(
+        name = name,
+        description = null,
+        isAdhoc = isAdhoc,
+        archived = archived,
+        createdAt = 0L,
+        archivedAt = archivedAt,
+    )
+
+    private fun exercise(name: String) = ExerciseEntity(
+        name = name,
+        type = ExerciseTypeEntity.WEIGHTED,
+        description = null,
+        imagePath = null,
+        archived = false,
+        createdAt = 0L,
+        archivedAt = null,
+        lastAdhocSets = null,
+        isAdhoc = false,
+    )
+}

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
@@ -18,7 +18,7 @@ import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 /**
  * Covers the training-side unfiltered bulk readers used by the AI snapshot export:
  * [TrainingDao.getAll] (must include adhoc + archived), [TrainingExerciseDao.getAll]
- * (plan rows in order), and [TrainingTagDao.getTagNamesForTrainings] (batch names).
+ * (plan rows in order), and [TrainingTagDao.getAllTrainingTagNames] (full-table batch names).
  */
 @ExtendWith(RobolectricExtension::class)
 @Config(application = BaseDatabaseTest.TestApplication::class, sdk = [33])
@@ -73,7 +73,7 @@ internal class TrainingDaoGetAllTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `getTagNamesForTrainings groups denormalized names by training`() = runTest {
+    fun `getAllTrainingTagNames groups denormalized names by training`() = runTest {
         val legs = training(name = "Legs")
         val push = training(name = "Push")
         listOf(legs, push).forEach { trainingDao.insert(it) }
@@ -89,7 +89,7 @@ internal class TrainingDaoGetAllTest : BaseDatabaseTest() {
         )
 
         val byTraining = trainingTagDao
-            .getTagNamesForTrainings(listOf(legs.uuid, push.uuid))
+            .getAllTrainingTagNames()
             .groupBy({ it.trainingUuid }, { it.name })
 
         assertEquals(listOf("barbell", "heavy"), byTraining.getValue(legs.uuid))

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/training/TrainingDaoGetAllTest.kt
@@ -41,18 +41,16 @@ internal class TrainingDaoGetAllTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `getAll returns templates plus adhoc and archived rows`() = runTest {
-        val template = training(name = "Template")
-        val adhoc = training(name = "Adhoc", isAdhoc = true)
-        val archived = training(name = "Archived", archived = true, archivedAt = 10L)
-        listOf(template, adhoc, archived).forEach { trainingDao.insert(it) }
+    fun `getAll returns all rows ordered by createdAt including adhoc and archived`() = runTest {
+        val template = training(name = "Template", createdAt = 100L)
+        val adhoc = training(name = "Adhoc", isAdhoc = true, createdAt = 200L)
+        val archived = training(name = "Archived", archived = true, archivedAt = 10L, createdAt = 300L)
+        // Insert out of createdAt order to prove the ORDER BY, not insertion order.
+        listOf(archived, template, adhoc).forEach { trainingDao.insert(it) }
 
         val all = trainingDao.getAll()
 
-        assertEquals(
-            setOf(template.uuid, adhoc.uuid, archived.uuid),
-            all.map { it.uuid }.toSet(),
-        )
+        assertEquals(listOf(template.uuid, adhoc.uuid, archived.uuid), all.map { it.uuid })
     }
 
     @Test
@@ -103,12 +101,13 @@ internal class TrainingDaoGetAllTest : BaseDatabaseTest() {
         isAdhoc: Boolean = false,
         archived: Boolean = false,
         archivedAt: Long? = null,
+        createdAt: Long = 0L,
     ) = TrainingEntity(
         name = name,
         description = null,
         isAdhoc = isAdhoc,
         archived = archived,
-        createdAt = 0L,
+        createdAt = createdAt,
         archivedAt = archivedAt,
     )
 

--- a/documentation/feature-specs/drive-ai-export-audit.md
+++ b/documentation/feature-specs/drive-ai-export-audit.md
@@ -1,0 +1,454 @@
+# Drive backup audit — basis for an "AI-readable Drive snapshot" enhancement
+
+**Status:** read-only audit. This document describes the *existing* Google Drive backup/restore
+implementation as of the current working tree. It designs nothing and changes no code.
+
+**Method:** every finding was read from source and is tagged `CONFIRMED` (read directly in source),
+`PARTIAL` (some evidence, gaps noted), or `NOT FOUND`. Symbol locations were found by searching the
+tree (files moved during the dialogs refactor), not by trusting doc/memory paths. Where a claim was
+gathered by a delegated source-reading pass, the cited file path is still the source of record.
+
+**TL;DR of the three blockers** (full evidence in §6):
+
+1. **An external LLM cannot read the current backup as-is.** It lives in the hidden Drive
+   `appDataFolder` (app-private) **and** the payload is a binary SQLite `.db` file. Both are
+   disqualifying independently.
+2. **Current scope is `drive.appdata`** (+ `userinfo.email`/`userinfo.profile`). Writing to a
+   user-visible "My Drive" folder requires a **new** scope — minimally `drive.file`. `drive.appdata`
+   cannot write to visible space.
+3. **No serializable export model of the workout data exists.** An AI-readable JSON snapshot layer
+   (Room → `@Serializable` export DTOs → JSON) would have to be built from scratch.
+
+---
+
+## 1. Backup mechanism (current)
+
+### 1.1 Triggers / entry points — `CONFIRMED`
+
+There are **two** runtime paths that produce a backup, both ending in the identical
+`captureSnapshot → BackupManifest → uploadBackup` sequence:
+
+| Path | Trigger | Executes | Citation |
+|---|---|---|---|
+| **Manual "Create backup"** (inline) | `Action.Backup.CreateBackup` button | Runs **inline** in the settings handler coroutine — NOT via WorkManager | `feature/settings/.../mvi/handler/BackupClickHandler.kt:274–300` → `feature/settings/.../domain/BackupInteractorImpl.kt:54–70` |
+| **Auto-backup** (periodic + bootstrap one-time) | First sign-in bootstrap and the periodic schedule | `BackupWorker` (`@HiltWorker CoroutineWorker`) | `core/data/backup/worker/.../BackupWorker.kt:44–87` |
+
+- **Bootstrap.** On the first transition to authenticated, `bootstrapOrRehydrate()` sets the default
+  schedule (Daily, Wi-Fi-only), calls `schedulePeriodic(DEFAULT)` and `enqueueOneTime()`, and shows a
+  snackbar. Re-entry only re-arms the periodic schedule.
+  `feature/settings/.../mvi/handler/BackupClickHandler.kt:162–177`, `:123–145`.
+- **Scheduling.** `BackupScheduler` (implements `AutoBackupController`) enqueues a
+  `PeriodicWorkRequest<BackupWorker>` under unique name `"auto_backup"` (Daily = 1 day, Weekly = 7
+  days; `ManualOnly` cancels it) with `ExistingPeriodicWorkPolicy.UPDATE`, and a
+  `OneTimeWorkRequest<BackupWorker>` under unique name `"one_time_backup"`
+  (`ExistingWorkPolicy.KEEP`). Constraints: network type (CONNECTED vs UNMETERED depending on
+  `allowOnMobileData`) and `setRequiresBatteryNotLow(true)` for the periodic one.
+  `core/data/backup/worker/.../scheduler/BackupScheduler.kt:36–101`.
+- **Worker is the single executor** for both periodic and one-time work; the two unique names route
+  to the same class. `core/data/backup/worker/.../BackupWorker.kt:24–28`.
+- Worker failure routing: `AuthRevoked` → cancel periodic + "auth paused" notification +
+  `Result.failure()`; `NetworkUnavailable` → `Result.retry()`; `StorageQuotaExceeded` /
+  `NotAuthenticated` → `Result.failure()`; everything else → `Result.retry()`.
+  `core/data/backup/worker/.../BackupWorker.kt:97–111`.
+
+### 1.2 Drive client library + how it's built — `CONFIRMED`
+
+- **Not** the Google Drive Java client (`com.google.api.services.drive`), and **no**
+  `GoogleAccountCredential` / `Drive.Builder`. The implementation calls the Drive **REST v3 API
+  directly over Ktor**.
+- `DriveApiImpl` uses a single shared `HttpClient(Android)`:
+  - List/download/delete → `https://www.googleapis.com/drive/v3/files`
+  - Upload → `https://www.googleapis.com/upload/drive/v3/files`
+  - `core/data/backup/google-drive/.../network/DriveApiImpl.kt:97–98`.
+- The client is built in `NetworkModule.provideHttpClient` with `ContentNegotiation` (kotlinx JSON,
+  `ignoreUnknownKeys`/`encodeDefaults`), `Logging(LogLevel.ALL)`, the custom `DriveAuthPlugin`, and a
+  `defaultRequest { url("https://www.googleapis.com/") }`. `expectSuccess = true`.
+  `core/data/backup/google-drive/.../di/NetworkModule.kt:21–48`.
+- Authorization is attached per-request by `DriveAuthPlugin` (a Ktor `createClientPlugin`) as
+  `Authorization: Bearer <token>`, and it converts a 401 response into a typed
+  `DriveException.AuthRevoked`. `core/data/backup/google-drive/.../network/DriveAuthPlugin.kt:17–35`.
+
+### 1.3 OAuth scope(s) — `CONFIRMED` **[BLOCKER]**
+
+`core/data/backup/google-drive/.../auth/DriveAuthScopes.kt:17–41`:
+
+- **Requested on every `AuthorizationRequest` / `RevokeAccessRequest`:**
+  - `https://www.googleapis.com/auth/drive.appdata`
+  - `https://www.googleapis.com/auth/userinfo.email`
+  - `https://www.googleapis.com/auth/userinfo.profile`
+- **Hard-required (gates all storage):** only `drive.appdata` (`REQUIRED`, line 40). The two
+  `userinfo` scopes are optional — declining them only degrades the displayed account name/email.
+- There is **no** `drive.file` and **no** broad `drive` scope anywhere in the tree.
+
+### 1.4 Destination: appDataFolder vs visible — `CONFIRMED` **[BLOCKER]**
+
+Backups are written to the **hidden, app-private `appDataFolder`** — never to user-visible "My
+Drive". Evidence:
+
+- Upload metadata sets `parents = listOf("appDataFolder")`.
+  `core/data/backup/google-drive/.../storage/DriveBackupStorage.kt:63`, const at `:151`.
+- List query uses `parameter("spaces", "appDataFolder")`.
+  `core/data/backup/google-drive/.../network/DriveApiImpl.kt:45`, const at `:99`.
+- DTO doc confirms: "`parents` for backup uploads is always `["appDataFolder"]`".
+  `core/data/backup/google-drive/.../network/DriveDtos.kt:27–31`.
+
+The `appDataFolder` is only reachable by this app's own OAuth client under the `drive.appdata`
+scope; it does not appear in the user's Drive UI and cannot be shared.
+
+### 1.5 Payload format & contents — `CONFIRMED` **[BLOCKER]**
+
+The uploaded payload is a **binary, raw SQLite database file** (the whole Room DB), **not** text/JSON.
+
+- The snapshot is produced by `DatabaseSnapshotProviderImpl.captureSnapshot`: it runs
+  `PRAGMA wal_checkpoint(TRUNCATE)` on the live DB then `File.copyTo`s the on-disk `app.db`.
+  `core/data/database/.../snapshot/DatabaseSnapshotProviderImpl.kt:29–41`.
+- The upload sets `mimeType = "application/x-sqlite3"`.
+  `core/data/backup/google-drive/.../storage/DriveBackupStorage.kt:64`, const at `:152`.
+- `uploadMultipart` builds a `multipart/related` body = JSON metadata part **+** `content.readBytes()`
+  (the raw DB bytes) **+** closing boundary; whole file buffered in memory.
+  `core/data/backup/google-drive/.../network/DriveApiImpl.kt:54–77`.
+- The only JSON in the request is the Drive **file metadata** part (`name`, `parents`, `mimeType`,
+  `appProperties`) — it carries no workout data. `DriveApiImpl.kt:59–65`,
+  `DriveDtos.kt:32–38` (`DriveFileMetadataDto`).
+
+### 1.6 File naming scheme — `CONFIRMED`
+
+- Filename: `app_<createdAtEpochMs>.db` — `"${FILE_PREFIX}${createdAtEpochMs}${DB_FILE_SUFFIX}"`.
+  `core/data/backup/google-drive/.../storage/DriveBackupStorage.kt:147–148`;
+  `FILE_PREFIX = "app_"`, `DB_FILE_SUFFIX = ".db"` at `core/data/backup/api/.../BackupConstants.kt:14,17`.
+- The manifest is **not** a sidecar file. It is stored as Drive **`appProperties`** (custom key/value
+  pairs on the same file), split one entry per field to stay under Drive's 124-byte-per-pair limit:
+  `app_version`, `db_schema_version`, `created_at_epoch_ms`, `db_file_size_bytes`, `device_model`
+  (truncated to 100 chars). `core/data/backup/google-drive/.../manifest/ManifestPropertiesMapper.kt:26–45`.
+- **Dead constant:** `BackupConstants.MANIFEST_FILE_SUFFIX = ".json"` exists with a comment about a
+  "sidecar manifest uploaded alongside the db file", but a tree-wide search shows it is **defined and
+  never referenced** — no separate `.json` file is uploaded today.
+  `core/data/backup/api/.../BackupConstants.kt:19–20` (only occurrence in non-test source).
+
+### 1.7 Auth / credential flow & token storage — `CONFIRMED`
+
+- **Mechanism:** GMS Identity `AuthorizationClient` (`Identity.getAuthorizationClient(context)`).
+  No `CredentialManager`, no legacy `GoogleSignIn` client, no Drive-Java `GoogleAccountCredential`.
+  `core/data/backup/google-drive/.../auth/DriveBackupAuth.kt:54–55`;
+  provider at `core/data/backup/google-drive/.../di/AuthProvidersModule.kt:18–22`.
+- **Sign-in:** `signIn()` builds `AuthorizationRequest.setRequestedScopes(ALL)` and calls
+  `authorize()`. If `hasResolution()` it returns `SignInResult.NeedsResolution(intentSender)` for the
+  UI to launch; otherwise it checks for missing required scopes, captures the access token, fetches
+  userinfo, and stores the account. `DriveBackupAuth.kt:74–88, 157–177`.
+- **Completion:** `completeSignIn(intent)` → `getAuthorizationResultFromIntent`, partial-grant guard
+  (`MissingRequiredScope`), token capture, userinfo, persist. `DriveBackupAuth.kt:90–121`.
+- **Sign-out:** `RevokeAccessRequest` via `revokeAccess` (chosen over the OAuth2 revoke endpoint
+  because it also clears the GMS-local token cache), then local clear. `DriveBackupAuth.kt:130–142`.
+- **Token storage:** access token + expiry persisted in a **Preferences DataStore** named
+  `"backup_account_prefs"`, keys `access_token` / `access_token_expires_at` (alongside `email` /
+  `display_name`). `core/data/backup/google-drive/.../auth/AccountDataStoreImpl.kt:49–61, 75–81`.
+- **Token TTL:** `TOKEN_TTL_MS = 50L * 60 * 1000` (50 min), defined in
+  `core/data/backup/google-drive/.../auth/TokenSnapshot.kt`.
+- **Token serving:** `DriveAuthTokenProvider.currentToken()` returns `null` if no account; else
+  prefers the cached token while unexpired; else does a silent `authorize()` refresh and re-caches.
+  `core/data/backup/google-drive/.../auth/DriveAuthTokenProvider.kt:35–67`.
+- **Identity:** email + display name come from a follow-up call to
+  `https://www.googleapis.com/oauth2/v3/userinfo` via `UserInfoFetcher` (best-effort; falls back to a
+  `drive_account` placeholder). `DriveBackupAuth.kt:48–51, 152–155, 195–201`;
+  `core/data/backup/google-drive/.../auth/UserInfoFetcherImpl.kt`.
+
+### 1.8 Existing retention / rotation — `CONFIRMED` (rotation exists)
+
+- `MAX_BACKUPS = 3` per account. `core/data/backup/api/.../BackupConstants.kt:10–11`.
+- After each successful upload, `DriveBackupStorage.rotate()` re-lists and deletes the oldest entries
+  beyond the cap; rotation is **best-effort** and never fails the upload.
+  `core/data/backup/google-drive/.../storage/DriveBackupStorage.kt:56–75, 99–115`.
+- Pure selection logic: `RotationPolicy.refsToDelete` sorts by `manifest.createdAtEpochMs` ascending
+  and drops `size - max`. `core/data/backup/google-drive/.../storage/RotationPolicy.kt:11–19`.
+
+### 1.9 Upload robustness — `CONFIRMED`
+
+- **Single-shot, fully buffered.** Upload concatenates metadata + entire DB bytes
+  (`content.readBytes()`) into one in-memory `ByteArray` and POSTs with `uploadType=multipart`. **Not
+  resumable.** The class doc explicitly accepts this trade-off (bounded to `MAX_BACKUPS=3` and
+  single-digit-MB DBs). `core/data/backup/google-drive/.../network/DriveApiImpl.kt:22–30, 54–77`.
+- **Download** also buffers fully via `bodyAsBytes()` then `writeBytes`; the caller verifies size
+  against `manifest.dbFileSizeBytes` with a 16-byte tolerance, else `CorruptedBackup`.
+  `DriveApiImpl.kt:79–88`; `DriveBackupStorage.kt:77–87, 131–145`.
+- **No temp-name-then-rename on the Drive side** — upload is a direct `files.create`. The 401 path
+  invalidates the token and retries the call exactly once (`withTokenRefreshOn401`).
+  `DriveBackupStorage.kt:117–129`.
+- **Partial-write protection on the local DB side** (restore, not upload): `captureSnapshot` does NOT
+  delete the target on failure (caller owns cleanup), but `restoreFromSnapshot` /
+  `rollbackToPreRestoreBackup` write to a same-directory `.tmp` and atomically `renameTo` the live
+  slot. `core/data/database/.../snapshot/DatabaseSnapshotProviderImpl.kt:164–200, 83–109`.
+
+---
+
+## 2. Restore mechanism (current) — the read contract — `CONFIRMED`
+
+The restore "read contract" is **whole-file SQLite replacement**. There is no field-level
+deserialization and no text/JSON read path anywhere.
+
+**Drive → live DB (`BackupInteractorImpl.restoreLatest`,
+`feature/settings/.../domain/BackupInteractorImpl.kt:78–142`):**
+
+1. `listBackups()` → newest `BackupRef` (else `CorruptedBackup("no backups available")`).
+2. Schema gate: if `backupSchemaVersion > current` → `BackupTooNew`; if `backupSchemaVersion <
+   current` and `!hasMigrationPath(...)` → `MissingMigrationPath`.
+3. `preserveCurrentDb()` → copies live DB to `cache/pre_restore_backup.db` (WAL-checkpointed) so undo
+   / rollback has a source. `DatabaseSnapshotProviderImpl.kt:67–81`.
+4. `markRestoreInProgress(RestoreInProgressContext(...))` (DataStore flag + payload).
+5. `downloadBackup(ref, tempFile)` → binary DB to a cache temp file.
+6. `restoreFromSnapshot(tempFile)`: validate the 16-byte `"SQLite format 3\0"` magic header, peek
+   `PRAGMA user_version`, reject if newer than running schema, `appDatabase.close()`, delete
+   `-wal`/`-shm`, copy to `.tmp`, atomic `renameTo` the live `app.db`.
+   `DatabaseSnapshotProviderImpl.kt:164–214`.
+7. On any pre-swap failure → `rollbackPreSwapFailure()` deletes the preserved file + clears the flag.
+
+**Post-restart recovery (`feature/recovery/.../domain/RestoreRecoveryCoordinator.kt`):**
+
+- **Scenario 1 (`handlePostRestoreLaunch`, :71–83, 123–158).** Called from `BaseApplication.onCreate`
+  when `restore_in_progress` is set. Peeks `currentSchemaVersion()`; on success clears the flag, marks
+  an undo slot, publishes `AppDialog.RestoreSuccess`. On failure rolls back to the preserved snapshot,
+  records a Crashlytics non-fatal, publishes `AppDialog.RestoreFailure`, and asks the caller to
+  restart.
+- **Scenario 3 undo (`performUndoRestore`, :104–121).** `rollbackToPreRestoreBackup()` →
+  `AppDialog.UndoRestoreSuccess` → restart.
+- UI side: `BackupClickHandler.confirmRestore()` drives the restore then `scheduleAppRestart()` after a
+  2 s delay. `feature/settings/.../mvi/handler/BackupClickHandler.kt:344–401`.
+- `restartApp()` relaunches the package with `NEW_TASK|CLEAR_TASK` and `Runtime.exit(0)`.
+  `RestoreRecoveryCoordinator.kt:179–186`.
+
+**Error taxonomy** (the typed contract both backup and restore speak):
+`NotAuthenticated`, `NetworkUnavailable`, `AuthRevoked`, `MissingRequiredScope`,
+`StorageQuotaExceeded`, `CorruptedBackup(reason)`, `BackupTooNew(…)`, `MissingMigrationPath(…)`,
+`Io(cause)`, `Unknown(cause)`. `core/data/backup/api/.../error/BackupError.kt:10–71`.
+
+---
+
+## 3. Data model
+
+### 3.1 Training-related entities (fields/relations) — `CONFIRMED`
+
+Schema version **6** (`core/data/database/.../migration/MigrationsRegistry.kt:15`,
+`APP_DATABASE_VERSION = 6`). DB file name `app.db`
+(`core/data/database/.../AppDatabase.kt:58`). `exportSchema = true`. Type converters:
+`UuidConverter`, `PlanSetsConverter`. The `@Database` entity list (read directly,
+`AppDatabase.kt:28–42`) has **9 entities**:
+
+| Entity | tableName | Key fields / type | Relations | File |
+|---|---|---|---|---|
+| `TrainingEntity` | `training_table` | PK `uuid: Uuid`; `name`, `description?`, `isAdhoc`, `archived`, `createdAt`, `archivedAt?` | — | `.../database/training/TrainingEntity.kt` |
+| `TrainingExerciseEntity` | `training_exercise_table` | composite PK `(training_uuid, exercise_uuid)`; `position: Int`, `planSets: String?` (JSON `List<PlanSetDataModel>`) | FK→`TrainingEntity` (CASCADE), FK→`ExerciseEntity` (RESTRICT) | `.../database/training/TrainingExerciseEntity.kt` |
+| `ExerciseEntity` | `exercise_table` | PK `uuid`; `name` (NOCASE), `type: ExerciseTypeEntity`, `description?`, `imagePath?`, `archived`, `createdAt`, `archivedAt?`, `lastAdhocSets: String?` (JSON), `isAdhoc` | — | `.../database/exercise/ExerciseEntity.kt` |
+| `SessionEntity` | `session_table` | PK `uuid`; `trainingUuid`, `state: SessionStateEntity`, `startedAt`, `finishedAt?` | FK→`TrainingEntity` (CASCADE) | `.../database/session/SessionEntity.kt` |
+| `PerformedExerciseEntity` | `performed_exercise_table` | PK `uuid`; `sessionUuid`, `exerciseUuid`, `position`, `skipped` | FK→`SessionEntity` (CASCADE), FK→`ExerciseEntity` (RESTRICT) | `.../database/session/PerformedExerciseEntity.kt` |
+| `SetEntity` | `set_table` | PK `uuid`; `performedExerciseUuid`, `position`, `reps: Int`, `weight: Double?`, `type: SetTypeEntity` | FK→`PerformedExerciseEntity` (CASCADE) | `.../database/session/model/SetEntity.kt` |
+| `TagEntity` | `tag_table` | PK `uuid`; `name` (NOCASE, unique) | — | `.../database/tag/TagEntity.kt` |
+| `ExerciseTagEntity` | `exercise_tag_table` | composite PK `(exercise_uuid, tag_uuid)` | FK→`ExerciseEntity` (CASCADE), FK→`TagEntity` (CASCADE) | `.../database/tag/ExerciseTagEntity.kt` |
+| `TrainingTagEntity` | `training_tag_table` | composite PK `(training_uuid, tag_uuid)` | FK→`TrainingEntity` (CASCADE), FK→`TagEntity` (CASCADE) | `.../database/tag/TrainingTagEntity.kt` |
+
+Enum column types (not entities): `ExerciseTypeEntity {WEIGHTED, WEIGHTLESS}`,
+`SessionStateEntity {IN_PROGRESS, FINISHED}`, `SetTypeEntity {WARM, WORK, FAIL, DROP}`.
+
+> Note: the per-field/index/FK specifics in the table above were gathered by a delegated read of each
+> entity file (paths cited). The `@Database` entity list, DAO surface, DB name, converters, and
+> schema version were verified directly in `AppDatabase.kt` and `MigrationsRegistry.kt`.
+
+### 3.2 DAOs + domain models + layering — `CONFIRMED`
+
+- **9 DAOs**, exposed off `AppDatabase` (`AppDatabase.kt:46–54`): `trainingDao`, `trainingExerciseDao`,
+  `exerciseDao`, `sessionDao`, `performedExerciseDao`, `setDao`, `tagDao`, `exerciseTagDao`,
+  `trainingTagDao`.
+- **Layering** (per CLAUDE.md and confirmed by module layout): Room `*Entity` → `*DataModel`
+  (in `core/data/...`) → `*Domain` (in `feature/<x>/domain/model/`). Data→domain mapping in
+  `feature/<x>/domain/mapper/`; domain→UI in `feature/<x>/mvi/mapper/`. Two Detekt rules
+  (`DomainLayerPurityRule`, `DomainLayerNoUiRule`) guard the boundary (§4.4).
+
+### 3.3 Existing Room→export DTO/mapper? — `NOT FOUND` **[BLOCKER]**
+
+There is **no** serializable export model of the workout data and **no** Room→export mapper. Tree-wide
+evidence (source only, tests/build excluded):
+
+- `@Serializable` appears only on: Drive wire DTOs (`DriveDtos.kt`, `UserInfoFetcherImpl.kt`); Room
+  **column-storage** models `PlanSetDataModel` + `SetTypeDataModel`
+  (`core/data/database/.../sets/`); and **navigation route args** (`core/ui/navigation/Screen.kt`,
+  `core/ui/plan-editor/model/*`). None of these is a training/workout data-export model.
+- **None of the 9 Room `@Entity` classes is `@Serializable`.**
+- No `Gson` / `Moshi` anywhere (`com.google.gson` / `com.squareup.moshi` → 0 hits).
+- No symbol resembling `ExportDto` / `ExportModel` / `JsonExport` / `*Export` for training/workout.
+
+Serialization plumbing that *does* exist: `kotlinx.serialization.json` is on the classpath in
+`core/data/database`, `core/data/backup/google-drive`, `feature/exercise`, `feature/plan-editor`, and
+the navigation/plan-editor UI modules — but only for Room column JSON, Drive wire DTOs, and nav args.
+
+### 3.4 schemaVersion, minSdk — `CONFIRMED`
+
+- Room `schemaVersion` = **6** (`MigrationsRegistry.kt:15`). Registered migrations: `MIGRATIONS =
+  arrayOf(Migration6)`; `MIN_SUPPORTED_SCHEMA_VERSION` derived from it (versions 1–4 are
+  non-migratable pre-Play-Store history). `MigrationsRegistry.kt:29–44`.
+- `minSdk = 28`, `targetSdk = 37`, `compileSdk = 36` (`gradle/libs.versions.toml:8–10`).
+
+---
+
+## 4. Architecture & placement
+
+### 4.1 Current real paths of backup/recovery symbols — `CONFIRMED`
+
+| Concern | Symbol(s) | Module / path |
+|---|---|---|
+| API contracts | `BackupStorage`, `BackupAuth`, `BackupManifest`, `BackupRef`, `BackupError`, `BackupConstants`, `RestoreStateRepository`, `AutoBackupController`, `BackupPreferencesRepository` | `core/data/backup/api/` |
+| Drive impl | `DriveBackupStorage`, `DriveApi(Impl)`, `DriveDtos`, `DriveFileMapper`, `RotationPolicy`, `DriveAuthPlugin`, `DriveBackupAuth`, `DriveAuthTokenProvider`, `AccountDataStore(Impl)`, `DriveAuthScopes`, `UserInfoFetcher(Impl)`, `ManifestPropertiesMapper`, `DriveErrorMapper` | `core/data/backup/google-drive/` |
+| Scheduling/state repos | `BackupPreferencesRepositoryImpl`, `RestoreStateRepositoryImpl` | `core/data/backup/scheduling/` |
+| Worker | `BackupWorker`, `BackupScheduler`, `BackupNotificationHelper` | `core/data/backup/worker/` |
+| Snapshot (DB file ops) | `DatabaseSnapshotProvider(Impl)` | `core/data/database/.../snapshot/` |
+| Recovery flows | `RestoreRecoveryCoordinator`, `StartupMigrationCoordinator`, `RecoveryActivity`, `RecoveryBootstrap`, diagnostics exporters | `feature/recovery/` |
+| Restore dialogs | `RestoreFailureDialog`, `RestoreSuccessDialog`, `UndoRestoreConfirmationDialog`, `UndoRestoreSuccessDialog` | `feature/app-dialogs/impl/.../ui/` |
+| Settings UI / MVI | `BackupClickHandler`, `BackupInteractor(Impl)`, `SettingsGraph`, backup `ui/components/*`, backup `mvi/model/*` | `feature/settings/` |
+
+### 4.2 Module shapes, deps, DB-free status — `CONFIRMED`
+
+- `core/data/backup/google-drive/build.gradle.kts:1–27`: plugins `convention.androidLibrary` +
+  `serialization`. Deps: `:core:core`, `:core:data:backup:api`, **`:core:data:database`**,
+  `:core:data:dataStore`, kotlinx-serialization-json, Ktor (core/android/logging/content-negotiation/
+  serialization-json), **`google.play.services.auth`**, `coroutines.play.services`, datastore.
+- `feature/recovery/build.gradle.kts:1–26`: plugin `convention.composeLibrary`. Deps: `:core:core`,
+  `:core:ui:kit`, `:core:ui:navigation`, **`:core:data:database`**, `:core:data:backup:api`,
+  `:feature:app-dialogs:api`.
+- **`feature/recovery` "DB-free" status:** it *depends on the database module* (for
+  `DatabaseSnapshotProvider` and `RestoreRecoveryCoordinator`) but is bound by an invariant to **never
+  open Room** — enforced by `RecoveryActivityDbFreeTest` with a `FailFastDatabaseModule` tripwire that
+  throws on `openHelper` access. `RecoveryActivity` is a plain `@AndroidEntryPoint ComponentActivity`
+  with **no MVI Store** (callback-based Compose). `feature/recovery/src/androidTest/.../RecoveryActivityDbFreeTest.kt`,
+  `feature/recovery/src/main/.../RecoveryActivity.kt`.
+- All backup modules apply Hilt via the convention plugin.
+
+### 4.3 Hilt provisioning of the Drive client — `CONFIRMED`
+
+All DI lives in `core/data/backup/google-drive/.../di/`, **`@InstallIn(SingletonComponent::class)`**,
+everything **`@Singleton`**:
+
+- `NetworkModule` (`@Module object`): `@Provides @Singleton provideHttpClient(authTokenProvider)`.
+  `di/NetworkModule.kt:21–48`.
+- `AuthProvidersModule` (`@Module object`): `@Provides @Singleton provideAuthorizationClient(context)
+  = Identity.getAuthorizationClient(context)`. `di/AuthProvidersModule.kt:14–23`.
+- `AuthBindingsModule` (`@Module interface`, all `@Binds @Singleton`): `BackupStorage←DriveBackupStorage`,
+  `DriveApi←DriveApiImpl`, `BackupAuth←DriveBackupAuth`, `AuthTokenProvider←DriveAuthTokenProvider`,
+  `AccountDataStore←AccountDataStoreImpl`, `TokenInvalidator←DriveTokenInvalidator`,
+  `UserInfoFetcher←UserInfoFetcherImpl`. `di/AuthBindingsModule.kt:24–55`.
+- `DatabaseSnapshotProvider` is bound `@Singleton` in `core/data/database/.../di/CoreDatabaseBindingsModule.kt`.
+
+> Scope note for new code: per the project's `HiltScopeRule` (§4.4), classes ending in `Storage` /
+> `Repository` / `DataStore` / `Database` must be `@Singleton`; `Handler` / `Interactor` / `Mapper`
+> must be `@ViewModelScoped`; a `Store` must be `@HiltViewModel`. The existing Drive graph is
+> uniformly `@Singleton`, which matches.
+
+### 4.4 Constraining custom Detekt rules — `CONFIRMED`
+
+Rules live in `lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/` (rule set registered
+in `MviArchitectureRules.kt`). The ones most likely to constrain new export/snapshot code:
+
+- **`MviHandlerConstructorRule`** — every `*Handler` needs a primary constructor with `@Inject` and ≥1
+  param and must implement `Handler`; `NavigationHandler` is the documented exception.
+- **`HiltScopeRule`** — scope-by-suffix enforcement (see §4.3 note); `Storage/Repository/DataStore/
+  Database/StoreDispatchers → @Singleton`, `Handler/Interactor/Mapper → @ViewModelScoped`,
+  `Store → @HiltViewModel`.
+- **`DomainLayerPurityRule`** — domain layer may not import `core.data.*` model types (suffixes
+  `DataModel`/`Entity`/`Dto`/`DataType`/…) except inside `/domain/mapper/` or `.api.*`.
+- **`DomainLayerNoUiRule`** — domain layer may not import Compose / `R` / `mvi` / `ui` types.
+- **`UiLayerNoDataRule`** — UI layer may not import `core.data.*` model types.
+- MVI structure rules: `MviStateImmutabilityRule`, `MviActionNamingRule`, `MviEventNamingRule`,
+  `MviHandlerNamingRule`, `MviStoreExtensionRule`, `MviStoreStateRule`, `ComposableStateRule`.
+
+Implication for an export feature: an `@Serializable` **export DTO** must NOT live in the domain layer
+(it would be a `*Dto`/data type) — it belongs in the data layer (e.g. the backup/database module),
+mapped to domain `*Domain` types only at the boundary.
+
+### 4.5 Canonical NavigationHandler / MVI reference — `CONFIRMED`
+
+`feature/home` is the canonical template (per `.claude/skills/add-feature.md`):
+`NavigationHandler` at `feature/home/.../mvi/handler/NavigationHandler.kt` (`@ViewModelScoped`,
+`@Inject constructor(navigator)`, `implements Handler<Action.Navigation>`); `Store`/`State`/`Action`/
+`Event` contract in `feature/home/.../mvi/store/HomeStore.kt`; `@HiltViewModel HomeStoreImpl` extends
+`BaseStore`. For a settings-resident enhancement, `feature/settings` is the closest in-tree analogue
+(its `BackupClickHandler` is the working example of an `@Inject`/`Handler`/`@ViewModelScoped` handler
+that consumes the backup API).
+
+---
+
+## 5. Consent / permissions / manifest — `CONFIRMED`
+
+- **Permissions (source manifests):**
+  - `android.permission.CAMERA` — `app/app/src/main/AndroidManifest.xml:5`.
+  - `android.permission.POST_NOTIFICATIONS` — `core/data/backup/worker/src/main/AndroidManifest.xml:4`
+    (for backup notifications).
+  - **`android.permission.INTERNET` is NOT declared in any source manifest.** It is contributed
+    transitively by a dependency AAR at manifest-merge time — verified present in the final
+    application merged manifests (`app/dev`, `app/store` under `build/intermediates/merged_manifest/`)
+    and absent from every `src/main` manifest. No Drive-specific permission is needed (GMS handles
+    consent).
+- **Consent UI flow:** GMS `authorize()` returns a resolution `PendingIntent` →
+  `SignInResult.NeedsResolution(intentSender)` → settings handler emits
+  `Event.AuthResolutionRequested(intentSender)` → `SettingsGraph` launches it via
+  `rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult())`, and feeds
+  the result back as `Action.Backup.HandleAuthResult`. `feature/settings/.../ui/SettingsGraph.kt:36–57`;
+  `feature/settings/.../mvi/handler/BackupClickHandler.kt:179–242`.
+- **Manifest notes:** `RecoveryActivity` is `exported=false` with no launcher intent-filter (only
+  reached programmatically). The default `androidx.work.WorkManagerInitializer` is removed via
+  `tools:node="remove"` — WorkManager is initialized on-demand through `BaseApplication`'s
+  `Configuration.Provider` + `HiltWorkerFactory`. `app/app/src/main/AndroidManifest.xml:33–81`.
+- `google-services.json` is present at repo root (686 bytes) — supplies the GMS/OAuth client config;
+  its contents were not inspected in this audit.
+
+---
+
+## 6. Decision-blocking answers (with evidence)
+
+### a. Can an external LLM read the current backup from Drive as-is? — **No.**
+
+Two independent disqualifiers:
+
+1. **Location.** Backups live in the hidden `appDataFolder` (`spaces=appDataFolder`,
+   `parents=["appDataFolder"]`). This space is private to this app's OAuth client under the
+   `drive.appdata` scope — it is not visible in the user's Drive, not shareable, and not reachable by a
+   general Drive access token. `DriveApiImpl.kt:45`, `DriveBackupStorage.kt:63`.
+2. **Format.** The payload is a **binary SQLite `.db`** (`mimeType application/x-sqlite3`), produced by
+   a WAL-checkpoint + raw file copy — not text/JSON an LLM can parse.
+   `DriveBackupStorage.kt:64`, `DatabaseSnapshotProviderImpl.kt:29–41`.
+
+To make a backup AI-readable, **both** would have to change (a visible/text destination *and* a text
+serialization).
+
+### b. Current scope, and does a visible folder need a new scope? — **`drive.appdata`; yes, needs `drive.file`.**
+
+- Current: `drive.appdata` (hard-required) + `userinfo.email` + `userinfo.profile`.
+  `DriveAuthScopes.kt:19–40`.
+- `drive.appdata` grants access **only** to the hidden app-data folder; it cannot create or write
+  files in user-visible "My Drive". Writing a visible (and shareable) file requires at minimum the
+  **`drive.file`** scope (per-file access to files the app creates). The broad `drive` scope is not
+  required and is a Google-"restricted" scope requiring app verification — avoid it. Adding a scope
+  means updating `DriveAuthScopes.ALL` (and keeping sign-in/refresh/revoke in lock-step, as the file's
+  own KDoc warns).
+
+### c. Does a serializable export model exist? — **No; must be built from scratch.**
+
+No `@Serializable` export DTO and no Room→export mapper exists for the workout data (§3.3). The
+existing `@Serializable` types are Drive wire DTOs, Room column-storage models
+(`PlanSetDataModel`/`SetTypeDataModel`), and navigation route args — none represents an exportable
+snapshot of trainings/sessions/sets. An AI-readable JSON snapshot would require a new layer: read the
+9 entities via their DAOs → map to new `@Serializable` export DTOs → encode JSON. kotlinx.serialization
+is already on the classpath, so no new dependency is needed; the rule constraints in §4.4 dictate that
+such DTOs live in the data layer, not the domain layer.
+
+---
+
+## 7. UNKNOWNs / not resolvable from source
+
+- **OAuth client ID / `google-services.json` contents.** The file exists at root but its contents
+  (web client id used by `AuthorizationClient`) were not inspected. The `AuthorizationClient` call site
+  does not pass an explicit server-client-id in source.
+- **R8/ProGuard keep rules** for kotlinx.serialization in release builds were not audited (relevant if
+  a new export DTO is added and obfuscated).
+- **Per-DAO method signatures** were not exhaustively enumerated — only the DAO set and the entities
+  they expose. A from-scratch export would need a read query per entity (or reuse of existing
+  list/observe queries; note the `is_adhoc = 0` filter invariant on exercise list queries).
+- **Drive `appProperties` query semantics for a future AI agent** are moot, since the file is in
+  `appDataFolder` and not externally reachable regardless.
+- **Whether any auto-backup currently runs in CI/headless** — not determinable from source; depends on
+  device/account state at runtime.

--- a/documentation/feature-specs/drive-ai-export.md
+++ b/documentation/feature-specs/drive-ai-export.md
@@ -33,7 +33,7 @@ folder (`Workeeper/`), so the user can point any LLM/agent at their Drive and ge
 
 | # | Decision |
 |---|---|
-| D1 | **Scope:** add `drive.file` to the requested set as **OPTIONAL** (static request set — `appdata` stays the only `REQUIRED` gate). Do **not** make the requested scope set dynamic. Gate export on the **actual grant** read from `AuthorizationResult.getGrantedScopes()`, plus the user toggle. |
+| D1 | **Scope:** `drive.file` is OPTIONAL (`appdata` stays the only `REQUIRED` gate). The requested set is **dynamic / granted-aware** (revised from the original "static" intent — see rationale): regular sign-in + silent refresh request only the *already-granted* set (base, plus `drive.file` only if previously granted); `drive.file` is requested solely via `BackupAuth.requestDriveFileAccess()` (the explicit toggle grant). **Rationale:** GMS `AuthorizationClient.authorize()` raises a resolution (no silent token) on *any* ungranted requested scope, so a static `ALL`-includes-`drive.file` set would break silent token refresh for every appdata-only user (all existing users + anyone who declines the optional scope). Export is gated on the actual grant — `driveFileGranted`, re-derived from `AuthorizationResult.getGrantedScopes()` on **every** authorize — AND the user toggle. |
 | D2 | **Coupling:** the exporter is fully independent and **best-effort**. It must never block, delay, or fail the binary backup. All exporter/upload errors are swallowed (logged + Crashlytics non-fatal). |
 | D3 | **Drive client:** make `DriveApi` **space-aware** (parameterize `spaces` on list, `parents` on upload). Add a sibling `DriveSnapshotStorage` next to `DriveBackupStorage`. The binary path keeps calling with `appDataFolder` — zero behavior change on the path that actually protects user data. |
 | D4 | **Placement:** JSON production lives in `core/data/database` (`DatabaseJsonExporter`, reads the 9 DAOs → encodes). Upload lives in `core/data/backup/google-drive`. Export DTOs (`@Serializable`) live in the **data layer**, never domain (Detekt `DomainLayerPurityRule`). The exporter must **not** be added to `feature/recovery` (it reads the DB → would trip `RecoveryActivityDbFreeTest`). |
@@ -161,11 +161,21 @@ Contract rules:
     name `workeeper_export_<epochMs>.json`.
   - **Rotation (D9):** reuse `RotationPolicy.refsToDelete` (cap 3), run after a successful upload,
     best-effort.
-- **Scope (D1):** `DriveAuthScopes.ALL` gains `drive.file` as **optional** (not `REQUIRED`). The
-  requested set stays static — no lock-step hazard across sign-in/refresh/revoke. Gate at runtime on
-  `AuthorizationResult.getGrantedScopes()` containing `drive.file`. `DriveBackupAuth.signIn/completeSignIn`
-  must surface granted scopes (or persist a `driveFileGranted` flag derived from the result) for the
-  toggle/runner to read.
+- **Scope (D1) — dynamic, granted-aware** (the requested set is NOT static; see D1 rationale):
+  `DriveAuthScopes.ALL` is the base set (`drive.appdata` + the two `userinfo` scopes, unchanged from
+  v1); `ALL_WITH_DRIVE_FILE` = base + `drive.file`.
+  - Regular `signIn()` requests `ALL` only (no `drive.file` prompt at first sign-in).
+  - Silent refresh (`DriveAuthTokenProvider`) requests only the **already-granted** set: `ALL`, plus
+    `drive.file` only when the persisted `driveFileGranted` flag is set. An appdata-only user therefore
+    requests exactly `ALL` — byte-identical to v1 — so `authorize()` never raises a resolution for them
+    (the no-regression invariant, by construction). An empty/unset flag defaults to `false` ⇒ base set.
+  - `drive.file` is requested **solely** by `BackupAuth.requestDriveFileAccess()` (`ALL_WITH_DRIVE_FILE`),
+    used by the explicit AI-export toggle grant.
+  - `driveFileGranted` is re-derived from `getGrantedScopes()` on **every** authorize (sign-in, explicit
+    grant, silent refresh) and persisted in `AccountDataStore`, so a later revocation flips it off; the
+    next silent refresh requests `drive.file` once, gets no token (resolution — never surfaced to the UI
+    on this background path), re-derives the flag to `false`, and silently retries with base scopes so
+    the binary token survives. `BackupAuth.observeDriveFileGranted()` exposes the flag to the toggle/runner.
 
 ### 4.3 `core/data/backup/api` — contracts & constants
 - New constants: folder name `"Workeeper"`, snapshot prefix `"workeeper_export_"`, suffix `".json"`,
@@ -278,6 +288,21 @@ independently green incl Detekt — bisect property).
   Event emitted); decline → toggle off + snackbar.
 - **Placement guard:** the exporter is not referenced from `feature/recovery` (keep
   `RecoveryActivityDbFreeTest` green).
+
+### Manual release gates (cannot be unit-tested; must pass before ship)
+
+1. **OAuth consent screen / verification (§7, §10.3).** `drive.file` is added to the app's OAuth
+   consent screen in Google Cloud Console; verification posture is acceptable for a "sensitive" scope.
+   Not determinable from source.
+2. **Appdata-only silent refresh stays resolution-free.** On a device signed in *without* `drive.file`
+   (the existing-user / v1-migration state), confirm the binary backup's silent token refresh succeeds
+   with no resolution prompt after the scope addition. The granted-aware design makes this safe by
+   construction (the request is byte-identical to v1), but verify empirically — the binary backup must
+   not regress for existing users.
+3. **Snapshot smoke.** Enable the toggle → grant `drive.file` → trigger a backup → find
+   `Workeeper/workeeper_export_<epochMs>.json` in visible Drive, open it, and verify the JSON structure.
+4. **R8 release build (§10.4).** Confirm the `@Serializable` export DTOs + enums survive minification
+   (no obfuscated-`serialName` decode failures) in a `store` release build.
 
 ## 9. Out of scope (v1) / deferred
 

--- a/documentation/feature-specs/drive-ai-export.md
+++ b/documentation/feature-specs/drive-ai-export.md
@@ -1,0 +1,331 @@
+# Feature spec — AI-readable Drive snapshot export
+
+**Status:** locked design. Decisions below are fixed; this spec is the authoritative target
+for the implementation prompt. Source-of-record for the current backup internals:
+`documentation/feature-specs/drive-ai-export-audit.md`.
+
+**One-line:** alongside the existing binary backup, write a human/LLM-readable JSON snapshot of the
+full training graph to a **user-visible** Google Drive folder, refreshed on the same triggers as the
+binary backup, so an external LLM (with the user's Drive access) can read and reason over the data.
+
+---
+
+## 1. Purpose & non-goals
+
+**Purpose.** Produce a plaintext, nested JSON projection of the workout database in a visible Drive
+folder (`Workeeper/`), so the user can point any LLM/agent at their Drive and get help with training
+(analysis, programming, progression). The snapshot is a **read-only projection**, not a backup.
+
+**Non-goals (v1):**
+- **Not a recovery artifact.** Source of truth for restore stays the binary `.db` in `appDataFolder`.
+  The app never reads the JSON back. Losing/rotating a JSON snapshot loses nothing recoverable.
+- **No incremental/diff export.** Full current-state snapshot every run. Diff is incompatible with
+  rotation and only safe as a never-rotated append-only log (same unbounded growth + reconstruction
+  cost, zero benefit). Rejected.
+- **No summary-tier in v1.** Full snapshot is small; an LLM computes aggregates itself. A summary
+  artifact earns its keep only when `full.json` stops fitting context — revisit then (§9, §11).
+- No CSV/multi-format, no per-exercise files, no snapshot encryption, no sharing UI, no reading the
+  snapshot into the app.
+
+---
+
+## 2. Locked decisions
+
+| # | Decision |
+|---|---|
+| D1 | **Scope:** add `drive.file` to the requested set as **OPTIONAL** (static request set — `appdata` stays the only `REQUIRED` gate). Do **not** make the requested scope set dynamic. Gate export on the **actual grant** read from `AuthorizationResult.getGrantedScopes()`, plus the user toggle. |
+| D2 | **Coupling:** the exporter is fully independent and **best-effort**. It must never block, delay, or fail the binary backup. All exporter/upload errors are swallowed (logged + Crashlytics non-fatal). |
+| D3 | **Drive client:** make `DriveApi` **space-aware** (parameterize `spaces` on list, `parents` on upload). Add a sibling `DriveSnapshotStorage` next to `DriveBackupStorage`. The binary path keeps calling with `appDataFolder` — zero behavior change on the path that actually protects user data. |
+| D4 | **Placement:** JSON production lives in `core/data/database` (`DatabaseJsonExporter`, reads the 9 DAOs → encodes). Upload lives in `core/data/backup/google-drive`. Export DTOs (`@Serializable`) live in the **data layer**, never domain (Detekt `DomainLayerPurityRule`). The exporter must **not** be added to `feature/recovery` (it reads the DB → would trip `RecoveryActivityDbFreeTest`). |
+| D5 | **JSON shape:** nested-denormalized — `trainings[] → exercises[] (plan) + sessions[] → performedExercises[] → sets[]`; a flat `exercises[]` library to avoid wholesale duplication, with denormalized `exerciseName` on references for LLM convenience. |
+| D6 | **Inclusion-set:** **everything, full fidelity** — archived **and** adhoc included, no filters. (Adhoc inclusion is also required for referential integrity: sessions reference adhoc exercises.) |
+| D7 | **Export schema version is independent of Room version.** Envelope carries its own `schemaVersion` (start at `1`); it is bumped when the JSON contract changes, not when `APP_DATABASE_VERSION` bumps. |
+| D8 | **Folder:** create-or-lookup a visible `Workeeper/` folder (by name, `trashed=false`), cache its id, dedup if multiple exist (pick oldest by `createdTime`), recreate if the cached id 404s. |
+| D9 | **Rotation:** reuse the existing `RotationPolicy.refsToDelete`, cap at `MAX_BACKUPS = 3` (mirror the binary path), scoped to the visible folder. Upload-then-rotate (never a zero-file window). No temp→rename needed on Drive — `files.create` is atomic for readers. |
+| D10 | **Triggers:** run on the **same two trigger points** as the binary backup — auto (`BackupWorker`: periodic + bootstrap one-time) and manual ("Create backup"). Always-fresh with the binary backup, no second schedule. Gated by toggle + `drive.file` grant, best-effort. |
+
+---
+
+## 3. Data contract — the snapshot JSON
+
+Envelope (timestamps are UTC ISO-8601, converted from the DB's epoch-millis; the LLM gets unambiguous
+UTC):
+
+```jsonc
+{
+  "schemaVersion": 1,                       // export-own version (D7), independent of Room v6
+  "exportedAt": "2026-06-26T10:42:23Z",
+  "source": {
+    "appVersion": "…",                      // reuse manifest fields (ManifestPropertiesMapper)
+    "dbSchemaVersion": 6,
+    "deviceModel": "…"                      // truncated to 100 chars, as in the binary manifest
+  },
+  "exercises": [                            // library — flat, canonical metadata lives once here
+    {
+      "uuid": "…",
+      "name": "…",
+      "type": "WEIGHTED",                   // WEIGHTED | WEIGHTLESS
+      "description": "…",                   // nullable → omit when null
+      "isAdhoc": false,
+      "archived": false,
+      "createdAt": "2026-01-04T08:00:00Z",
+      "archivedAt": null,                   // omit when null
+      "tags": ["push", "barbell"]           // denormalized tag names
+      // imagePath intentionally OMITTED (device-local path, no value to an LLM; §7)
+      // lastAdhocSets decoded under the exercise only if present (adhoc scaffolding)
+    }
+  ],
+  "trainings": [
+    {
+      "uuid": "…",
+      "name": "…",
+      "description": "…",                   // omit when null
+      "isAdhoc": false,
+      "archived": false,
+      "createdAt": "2026-01-04T08:00:00Z",
+      "archivedAt": null,                   // omit when null
+      "tags": ["legs"],
+      "plan": [                             // from training_exercise_table, ordered by position
+        {
+          "exerciseUuid": "…",
+          "exerciseName": "Back Squat",     // denormalized for convenience
+          "position": 0,
+          "planSets": [                     // decoded from the stored List<PlanSetDataModel> JSON
+            { "reps": 5, "weight": 100.0, "type": "WORK" }
+          ]
+        }
+      ],
+      "sessions": [                         // workout history for this training
+        {
+          "uuid": "…",
+          "state": "FINISHED",              // IN_PROGRESS | FINISHED
+          "startedAt": "2026-01-06T18:30:00Z",
+          "finishedAt": "2026-01-06T19:25:00Z",  // omit when null
+          "performedExercises": [
+            {
+              "exerciseUuid": "…",
+              "exerciseName": "Back Squat",
+              "position": 0,
+              "skipped": false,
+              "sets": [                     // ordered by position
+                { "position": 0, "reps": 5, "weight": 100.0, "type": "WORK" }
+                // type ∈ WARM | WORK | FAIL | DROP ; weight nullable (WEIGHTLESS) → omit when null
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Contract rules:
+- **UUIDs kept** on all rows (canonical join key) even though names are denormalized — unambiguous.
+- **Nullable fields omitted** when null (smaller, less noisy) — `encodeDefaults`/explicit-null policy
+  to be set on the `Json` instance; document the chosen convention in code.
+- **planSets / lastAdhocSets** are decoded from their stored column JSON into structured objects, not
+  passed through as raw strings (reuse `PlanSetDataModel` / `SetTypeDataModel` to decode, re-map to
+  export DTOs).
+- **Ordering** is explicit by `position` for plan/performed/sets; sessions by `startedAt`.
+
+---
+
+## 4. Architecture & components
+
+### 4.1 `core/data/database` — JSON production
+- **Export DTOs** (`@Serializable`), package `…/export/model/`: `WorkoutExportDto` (envelope),
+  `ExerciseExportDto`, `TrainingExportDto`, `PlanExerciseExportDto`, `PlanSetExportDto`,
+  `SessionExportDto`, `PerformedExerciseExportDto`, `SetExportDto`. Data-layer only (Detekt).
+- **`DatabaseJsonExporter` / `…Impl`** (`@Singleton`), package `…/export/`: reads all 9 DAOs, assembles
+  the nested DTO graph, encodes via `kotlinx.serialization.json`. Returns the JSON as `String`/bytes;
+  it does **not** know about Drive.
+- **Mapper** object(s), package `…/export/mapper/`: entity/DataModel → export DTO. No inline mapping
+  (repo convention). Timestamp epochMs→UTC ISO conversion lives here.
+- **Unfiltered reads — CORRECTNESS TRAP (hard requirement).** Existing exercise list queries filter
+  `is_adhoc = 0`. Reusing them would silently drop adhoc rows, violating D6. The exporter MUST use
+  unfiltered `SELECT *` reads per entity (add new DAO methods if absent). A unit test must assert
+  adhoc + archived rows are present in the output.
+
+### 4.2 `core/data/backup/google-drive` — visible-folder upload
+- **`DriveApi` made space-aware:** list takes a `spaces` arg; upload takes a `parents` arg. Binary
+  callers pass `appDataFolder` (unchanged); snapshot caller passes the `Workeeper/` folder id and
+  `spaces=drive`.
+- **`DriveSnapshotStorage`** (`@Singleton`, sibling of `DriveBackupStorage`):
+  - **Folder management (D8):** `files.list` with
+    `q = "mimeType='application/vnd.google-apps.folder' and name='Workeeper' and trashed=false"`,
+    `spaces=drive`. With `drive.file` the app sees only files it created, so it finds/creates its own
+    folder. Create if absent; cache id in a new DataStore key; on duplicate, pick oldest by
+    `createdTime`; on cached-id 404, recreate and retry once.
+  - **Upload:** JSON bytes, `mimeType = "application/json"`, `parents = [folderId]`,
+    name `workeeper_export_<epochMs>.json`.
+  - **Rotation (D9):** reuse `RotationPolicy.refsToDelete` (cap 3), run after a successful upload,
+    best-effort.
+- **Scope (D1):** `DriveAuthScopes.ALL` gains `drive.file` as **optional** (not `REQUIRED`). The
+  requested set stays static — no lock-step hazard across sign-in/refresh/revoke. Gate at runtime on
+  `AuthorizationResult.getGrantedScopes()` containing `drive.file`. `DriveBackupAuth.signIn/completeSignIn`
+  must surface granted scopes (or persist a `driveFileGranted` flag derived from the result) for the
+  toggle/runner to read.
+
+### 4.3 `core/data/backup/api` — contracts & constants
+- New constants: folder name `"Workeeper"`, snapshot prefix `"workeeper_export_"`, suffix `".json"`,
+  snapshot cap (reuse `MAX_BACKUPS = 3`). **Do not repurpose** the dead `MANIFEST_FILE_SUFFIX`
+  constant — different concern; leave/remove separately.
+- New api interface `SnapshotStorage` (mirrors `BackupStorage`) so orchestration depends on api, not
+  the Drive impl (api/impl split per project convention).
+
+### 4.4 Orchestration seam — `SnapshotExportRunner`
+- **`SnapshotExportRunner` / `…Impl`** (`@Singleton`, data layer), one suspend method
+  `runIfEligible()`:
+  1. toggle on? else no-op.
+  2. `drive.file` granted? else no-op (and, if toggle is on but grant missing, set a one-time
+     "grant needed" signal — see §5 decline handling).
+  3. `DatabaseJsonExporter` → JSON bytes.
+  4. `DriveSnapshotStorage` → upload → rotate.
+  - **Entire body wrapped so it never throws to the caller.** Failures → log + Crashlytics non-fatal,
+    return `Unit` (D2).
+- **Wiring (D10):** both `BackupInteractorImpl` (manual) and `BackupWorker` (auto) call
+  `snapshotExportRunner.runIfEligible()` **after** the binary backup step. Invocation is independent of
+  binary outcome but internally no-ops without auth/toggle. The binary `Result`/error path is
+  unaffected regardless of what the runner does.
+
+### 4.5 Hilt & Detekt compliance
+- All new data-layer singletons `@InstallIn(SingletonComponent::class)` `@Singleton`, matching the
+  existing Drive graph. `HiltScopeRule` forces `@Singleton` for `*Storage`; confirm it does not reject
+  the `Exporter`/`Runner` suffixes (unlisted suffixes are unconstrained) — if it does, rename to a
+  compliant suffix.
+- New `*Handler` (if any, §5) needs `@Inject` primary ctor with ≥1 param implementing `Handler`
+  (`MviHandlerConstructorRule`). No suppressions anywhere; empirical `detekt` run required per phase.
+
+---
+
+## 5. Settings / MVI surface
+
+**Canonical navigation pattern (invariant — stated per project rule):** navigation uses
+`Action.Navigation` consumed by a dedicated `NavigationHandler` with `Navigator` injected via Hilt;
+graph composables consume only UI events (Haptic, ShowExternalLink, BackHandler). Canonical reference:
+`feature/home` `NavigationHandler` + graph. **This feature needs no new navigation** — no screen
+change, no `NavCommand`. The consent step reuses the existing auth-resolution **Event** plumbing, not
+navigation.
+
+- **Toggle:** "Export AI-readable snapshot to Google Drive" in `feature/settings`, off by default.
+- **Persistence:** `BackupPreferencesRepository` gains `aiExportEnabled: Boolean` (DataStore).
+- **State:** a `Boolean` field on the settings State; `@Stable`/`@Immutable` UI model; toggle row is a
+  stateless kit composable; any display strings pre-formatted in mapper/handler.
+- **Actions / consent reuse:** add `Action.Backup.ToggleAiExport(enabled)`. On enable, if `drive.file`
+  not granted → trigger incremental `authorize()` requesting the static `ALL` set; if `NeedsResolution`
+  → emit the **existing** `Event.AuthResolutionRequested(intentSender)` → `SettingsGraph` launches via
+  the existing `StartIntentSenderForResult` launcher → result fed back as the existing
+  `Action.Backup.HandleAuthResult`. Minimal new surface.
+- **Handler:** fold the new action into the existing `BackupClickHandler` (it already owns backup +
+  auth-result actions; action surface here is small). Split only if it grows.
+- **Decline handling:** if the incremental grant is declined → revert the toggle to **off** and show a
+  snackbar ("Google Drive access is needed for AI export"). Never leave a toggle that reads "on" but
+  does nothing.
+
+---
+
+## 6. Failure modes & edge cases
+
+- **Grant declined** → toggle reverts off + snackbar (§5).
+- **`drive.file` later revoked** (in Google account) → snapshot upload 401 → `DriveAuthPlugin` maps to
+  `AuthRevoked` → swallowed for the snapshot (best-effort). The binary path's existing `AuthRevoked`
+  handling (cancel periodic + notification) governs user-facing behavior; **do not double-notify** from
+  the snapshot path.
+- **Folder trashed/deleted by user** → cached id 404 on upload → recreate folder, retry once.
+- **Two devices, same account** → device B's `drive.file` list sees A's app-created folder (same OAuth
+  client) → dedup by oldest `createdTime`; tolerate pre-existing duplicates (optionally clean extras
+  best-effort).
+- **Partial/corrupt upload** → Drive multipart `files.create` is atomic for readers (object appears
+  only on success); rotation runs only after success → no half-file ever visible. No temp→rename
+  needed.
+- **Concurrent manual + auto** → snapshot files are `epochMs`-named, so two near-simultaneous runs make
+  two files; rotation trims to 3. Acceptable.
+- **Empty DB** (new user, toggle on) → emit a valid envelope with empty arrays; never crash.
+- **Large-DB tail** → size grows unbounded with history; the deferred summary-tier is the lever.
+  Revisit when `full.json` exceeds ~1–2 MB or causes context pressure (§9).
+- **Schema drift** → bump the export `schemaVersion` (D7) only when the JSON contract changes.
+
+## 7. Security & privacy
+
+- **The snapshot is plaintext workout data in the user's *visible* Drive** — shareable, and readable by
+  any app/integration the user authorizes on their Drive. This is the intended behavior, but the toggle
+  copy MUST disclose it plainly (it is **not** the hidden `appDataFolder`; it is visible and shareable).
+- **`drive.file` is a "sensitive" (not "restricted") scope** — lighter Google verification than full
+  `drive`, but the OAuth consent screen must list it; unverified/testing apps show the unverified-app
+  warning. **Verify the OAuth consent-screen / `google-services.json` config supports adding
+  `drive.file` before shipping** (the audit did not inspect the client config — open item §10).
+- **`imagePath` omitted** from the export — a device-local path string, useless to an LLM and a minor
+  leak; drop it.
+- No new `INTERNET` permission needed (already transitively merged — audit-confirmed).
+
+## 8. Testing
+
+Per repo conventions (pure JVM JUnit5 where possible; in-memory Room for repository/DB tests;
+real read-then-assert, not mock-only; all custom Detekt rules green with no suppressions; each commit
+independently green incl Detekt — bisect property).
+
+- **Exporter (in-memory Room):** seed a full graph — archived + adhoc rows, multiple sessions/sets/tags,
+  planSets, WEIGHTLESS (null weight). Assert JSON structure **and** that archived + adhoc rows are
+  present (regression guard against the `is_adhoc = 0` trap, §4.1).
+- **Serialization round-trip:** encode export DTO → decode → equals, covering all four enums
+  (`ExerciseType`, `SessionState`, `SetType`, plan-set type) to catch serialName/R8 issues.
+- **`DriveSnapshotStorage` (mock `DriveApi`):** folder absent→creates; present→reuses id; cached-id
+  404→recreates; duplicates→picks oldest. Rotation keeps 3 and runs after upload.
+- **Decoupling invariant (critical):** `SnapshotExportRunner` swallows exporter/upload exceptions and
+  never propagates — assert the binary backup `Result` is unaffected when the runner throws (D2).
+- **Toggle/handler (JVM):** enable with grant missing → incremental-auth path (`NeedsResolution` →
+  Event emitted); decline → toggle off + snackbar.
+- **Placement guard:** the exporter is not referenced from `feature/recovery` (keep
+  `RecoveryActivityDbFreeTest` green).
+
+## 9. Out of scope (v1) / deferred
+
+Summary-tier (`summary.json` aggregates) · diff/incremental export · reading the snapshot back into the
+app · CSV/other formats · per-exercise files · snapshot encryption · sharing UI. Summary-tier is the
+first thing to revisit when `full.json` stops fitting an LLM context.
+
+## 10. Open items to confirm in discovery (CC, Phase 0)
+
+1. Unfiltered per-entity DAO read methods exist (or must be added) — required for D6 (§4.1).
+2. Exact shape of `PlanSetDataModel` / `SetTypeDataModel` for decoding `planSets` / `lastAdhocSets`.
+3. OAuth consent-screen / `google-services.json` supports adding `drive.file`; app verification posture
+   (§7).
+4. ProGuard/R8 keep rules: location + add a keep for `@Serializable` export DTOs and the four enums
+   (known repo failure mode — obfuscated serialNames). Hard requirement before release.
+5. `AuthorizationResult.getGrantedScopes()` available in the GMS version on the classpath (to gate on
+   the actual grant, D1).
+6. `HiltScopeRule` behavior for `Exporter` / `Runner` suffixes (rename to a compliant suffix if the
+   rule constrains them).
+
+## 11. Phasing (STOP gates between phases; bisectable; Detekt green per phase)
+
+- **Phase 0 — discovery + commit plan (no production code).** Resolve §10 items against source; map
+  every break/insertion point; produce the commit plan. STOP, report, wait for approval.
+- **Phase 1 — data layer only.** Export DTOs + `DatabaseJsonExporter` + mapper + unfiltered DAO reads +
+  unit/round-trip tests. No Drive, no toggle. Green.
+- **Phase 2 — Drive plumbing.** `DriveApi` space-aware + `DriveSnapshotStorage` (folder mgmt +
+  rotation) + tests (mock `DriveApi`). Binary path untouched + regression-tested. Green.
+- **Phase 3 — scope + seam.** `drive.file` optional + grant-gating + `SnapshotExportRunner` wired into
+  `BackupInteractorImpl` + `BackupWorker`, best-effort + decoupling test. Green.
+- **Phase 4 — settings + release-readiness.** Toggle (MVI surface, handler, consent copy) + ProGuard
+  keep rules + final Detekt + end-to-end check. Green.
+
+## 12. References
+
+- Audit (source-of-record): `documentation/feature-specs/drive-ai-export-audit.md`
+- Binary storage + rotation: `core/data/backup/google-drive/.../storage/DriveBackupStorage.kt`,
+  `…/storage/RotationPolicy.kt`
+- Drive REST client: `core/data/backup/google-drive/.../network/DriveApiImpl.kt`,
+  `…/network/DriveDtos.kt`
+- Scopes + auth: `core/data/backup/google-drive/.../auth/DriveAuthScopes.kt`,
+  `…/auth/DriveBackupAuth.kt`, `…/auth/DriveAuthTokenProvider.kt`
+- DB snapshot (binary) + entities: `core/data/database/.../snapshot/DatabaseSnapshotProviderImpl.kt`,
+  `core/data/database/.../AppDatabase.kt`, `…/migration/MigrationsRegistry.kt`
+- Manifest fields: `core/data/backup/google-drive/.../manifest/ManifestPropertiesMapper.kt`
+- Triggers: `feature/settings/.../mvi/handler/BackupClickHandler.kt`,
+  `feature/settings/.../domain/BackupInteractorImpl.kt`,
+  `core/data/backup/worker/.../BackupWorker.kt`
+- Canonical MVI/NavigationHandler reference: `feature/home/.../mvi/handler/NavigationHandler.kt`
+- Constants: `core/data/backup/api/.../BackupConstants.kt`
+- Detekt rules: `lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/`

--- a/documentation/feature-specs/drive-ai-export.md
+++ b/documentation/feature-specs/drive-ai-export.md
@@ -285,6 +285,10 @@ Summary-tier (`summary.json` aggregates) · diff/incremental export · reading t
 app · CSV/other formats · per-exercise files · snapshot encryption · sharing UI. Summary-tier is the
 first thing to revisit when `full.json` stops fitting an LLM context.
 
+**Size levers for the large-DB tail (§6), in order of cheapness.** (1) Drop `prettyPrint`: the
+exporter pretty-prints for human-readability, so compacting roughly halves the whitespace overhead at
+zero data loss — the cheapest first lever. (2) Then introduce the deferred summary-tier.
+
 ## 10. Open items to confirm in discovery (CC, Phase 0)
 
 1. Unfiltered per-entity DAO read methods exist (or must be added) — required for D6 (§4.1).

--- a/documentation/feature-specs/drive-ai-export.md
+++ b/documentation/feature-specs/drive-ai-export.md
@@ -43,6 +43,7 @@ folder (`Workeeper/`), so the user can point any LLM/agent at their Drive and ge
 | D8 | **Folder:** create-or-lookup a visible `Workeeper/` folder (by name, `trashed=false`), cache its id, dedup if multiple exist (pick oldest by `createdTime`), recreate if the cached id 404s. |
 | D9 | **Rotation:** reuse the existing `RotationPolicy.refsToDelete`, cap at `MAX_BACKUPS = 3` (mirror the binary path), scoped to the visible folder. Upload-then-rotate (never a zero-file window). No temp→rename needed on Drive — `files.create` is atomic for readers. |
 | D10 | **Triggers:** run on the **same two trigger points** as the binary backup — auto (`BackupWorker`: periodic + bootstrap one-time) and manual ("Create backup"). Always-fresh with the binary backup, no second schedule. Gated by toggle + `drive.file` grant, best-effort. |
+| D11 | **Consent withdrawal / sign-out cleanup:** disabling the AI-export toggle deletes the already-exported `workeeper_export_*` files from the visible folder (the consent that produced them is gone), and sign-out deletes them **before** `revokeAccess` — once `drive.file` is revoked the app can no longer see its own visible files, so a delete-after-revoke would strand them permanently. Both go through `SnapshotExportRunner.clearSnapshots()` (serialized with uploads via the same in-process `Mutex`) → `SnapshotStorage.deleteAllSnapshots()` (lists the folder, best-effort deletes each export, never CREATES a folder, no-op without the grant). The empty folder is left in place. Best-effort: failures are swallowed. |
 
 ---
 
@@ -232,6 +233,10 @@ navigation.
 - **Decline handling:** if the incremental grant is declined → revert the toggle to **off** and show a
   snackbar ("Google Drive access is needed for AI export"). Never leave a toggle that reads "on" but
   does nothing.
+- **Withdrawal cleanup (D11):** turning the toggle **off** persists `aiExportEnabled = false` *then*
+  deletes the already-exported snapshots from the visible folder (`interactor.deleteAiExportSnapshots()`);
+  sign-out deletes them **before** revoking `drive.file`. So "off" / signed-out leaves no plaintext
+  workout-history copy readable by a previously-authorized third party. Best-effort.
 
 ---
 
@@ -243,6 +248,10 @@ navigation.
   handling (cancel periodic + notification) governs user-facing behavior; **do not double-notify** from
   the snapshot path.
 - **Folder trashed/deleted by user** → cached id 404 on upload → recreate folder, retry once.
+- **Toggle off / sign-out with snapshots present** → `clearSnapshots()` lists the visible folder and
+  best-effort deletes each `workeeper_export_*` file (D11). Never creates a folder; no-op without the
+  `drive.file` grant; the empty folder is left in place. Sign-out deletes **before** `revokeAccess`
+  (after revoke the app can't see the files). Per-file delete failures are swallowed.
 - **Two devices, same account** → device B's `drive.file` list sees A's app-created folder (same OAuth
   client) → dedup by oldest `createdTime`; tolerate pre-existing duplicates (optionally clean extras
   best-effort).

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
@@ -33,6 +33,13 @@ internal interface BackupInteractor {
 
     suspend fun signOut(): BackupResult<Unit>
 
+    /**
+     * Best-effort removal of previously-exported AI snapshots from the visible Drive folder.
+     * Invoked when the user disables AI export (consent withdrawal) and during sign-out, BEFORE
+     * [signOut] revokes the grant — afterwards the files can no longer be reached. Never throws.
+     */
+    suspend fun deleteAiExportSnapshots()
+
     suspend fun createBackup(): BackupResult<Unit>
 
     suspend fun listLatestBackup(): BackupResult<BackupSummaryDomain?>

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
@@ -15,6 +15,17 @@ internal interface BackupInteractor {
 
     suspend fun signIn(): SignInOutcomeDomain
 
+    /**
+     * Requests the optional `drive.file` (visible-Drive) scope on the already-connected
+     * account — the incremental grant for AI export. Does NOT start a fresh sign-in. Same
+     * [SignInOutcomeDomain] contract as [signIn]; the resolution result (if any) is forwarded
+     * via [completeSignIn], exactly like sign-in.
+     */
+    suspend fun requestDriveFileAccess(): SignInOutcomeDomain
+
+    /** One-shot read of whether `drive.file` is currently granted (post-grant reconciliation). */
+    suspend fun isDriveFileGranted(): Boolean
+
     suspend fun completeSignIn(resultIntent: Intent?): BackupResult<AccountDomain>
 
     suspend fun signOut(): BackupResult<Unit>

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractor.kt
@@ -13,6 +13,9 @@ internal interface BackupInteractor {
 
     val authState: Flow<BackupAuthDomain>
 
+    /** Hot stream of the `drive.file` grant; drives the AI-export toggle's effective state. */
+    val driveFileGranted: Flow<Boolean>
+
     suspend fun signIn(): SignInOutcomeDomain
 
     /**

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
 import io.github.stslex.workeeper.core.data.backup.api.model.BackupManifest
 import io.github.stslex.workeeper.core.data.backup.api.restore.RestoreInProgressContext
@@ -36,6 +37,7 @@ internal class BackupInteractorImpl @Inject constructor(
     private val backupStorage: BackupStorage,
     private val snapshotProvider: DatabaseSnapshotProvider,
     private val restoreStateRepository: RestoreStateRepository,
+    private val snapshotExportRunner: SnapshotExportRunner,
     @ApplicationContext private val context: Context,
     @IODispatcher private val dispatcher: CoroutineDispatcher,
 ) : BackupInteractor {
@@ -52,10 +54,18 @@ internal class BackupInteractorImpl @Inject constructor(
     override suspend fun signOut(): BackupResult<Unit> = backupAuth.signOut()
 
     override suspend fun createBackup(): BackupResult<Unit> = withContext(dispatcher) {
+        val result = createBinaryBackup()
+        // Best-effort AI snapshot AFTER the binary backup. Wrapped so a runner fault can never
+        // affect the binary result (the runner also swallows internally); D2 decoupling.
+        runCatching { snapshotExportRunner.runIfEligible() }
+        result
+    }
+
+    private suspend fun createBinaryBackup(): BackupResult<Unit> {
         val tempFile = File.createTempFile(TEMP_BACKUP_PREFIX, TEMP_BACKUP_SUFFIX, context.cacheDir)
-        try {
+        return try {
             val capture = snapshotProvider.captureSnapshot(tempFile)
-            if (capture is BackupResult.Failure) return@withContext capture
+            if (capture is BackupResult.Failure) return capture
             val manifest = BackupManifest(
                 appVersion = readVersionName(),
                 dbSchemaVersion = snapshotProvider.currentSchemaVersion(),

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
@@ -26,6 +26,7 @@ import io.github.stslex.workeeper.feature.settings.domain.model.BackupSummaryDom
 import io.github.stslex.workeeper.feature.settings.domain.model.SignInOutcomeDomain
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -45,6 +46,12 @@ internal class BackupInteractorImpl @Inject constructor(
     override val authState: Flow<BackupAuthDomain> = backupAuth.state.map { it.toDomain() }
 
     override suspend fun signIn(): SignInOutcomeDomain = backupAuth.signIn().toDomain()
+
+    override suspend fun requestDriveFileAccess(): SignInOutcomeDomain =
+        backupAuth.requestDriveFileAccess().toDomain()
+
+    override suspend fun isDriveFileGranted(): Boolean =
+        backupAuth.observeDriveFileGranted().first()
 
     override suspend fun completeSignIn(resultIntent: Intent?): BackupResult<AccountDomain> =
         backupAuth.completeSignIn(resultIntent).mapSuccess {

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
@@ -45,6 +45,8 @@ internal class BackupInteractorImpl @Inject constructor(
 
     override val authState: Flow<BackupAuthDomain> = backupAuth.state.map { it.toDomain() }
 
+    override val driveFileGranted: Flow<Boolean> get() = backupAuth.observeDriveFileGranted()
+
     override suspend fun signIn(): SignInOutcomeDomain = backupAuth.signIn().toDomain()
 
     override suspend fun requestDriveFileAccess(): SignInOutcomeDomain =

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImpl.kt
@@ -62,6 +62,8 @@ internal class BackupInteractorImpl @Inject constructor(
 
     override suspend fun signOut(): BackupResult<Unit> = backupAuth.signOut()
 
+    override suspend fun deleteAiExportSnapshots() = snapshotExportRunner.clearSnapshots()
+
     override suspend fun createBackup(): BackupResult<Unit> = withContext(dispatcher) {
         val result = createBinaryBackup()
         // Best-effort AI snapshot AFTER the binary backup. Wrapped so a runner fault can never

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
@@ -288,7 +288,7 @@ internal class BackupClickHandler @Inject constructor(
             },
             onSuccess = { outcome ->
                 when (outcome) {
-                    SignInOutcomeDomain.Success -> {
+                    is SignInOutcomeDomain.Success -> {
                         preferencesRepository.setAiExportEnabled(true)
                         updateStateImmediate { current ->
                             current.copy(backupOperation = BackupOperationUi.Idle)
@@ -296,10 +296,11 @@ internal class BackupClickHandler @Inject constructor(
                     }
 
                     // Keep TogglingAiExport set; handleAuthResult resolves the grant and resets it.
-                    is SignInOutcomeDomain.NeedsResolution ->
-                        sendEvent(Event.AuthResolutionRequested(outcome.intentSender))
+                    is SignInOutcomeDomain.NeedsResolution -> sendEvent(
+                        Event.AuthResolutionRequested(outcome.intentSender),
+                    )
 
-                    SignInOutcomeDomain.PartialGrant,
+                    is SignInOutcomeDomain.PartialGrant,
                     is SignInOutcomeDomain.Failure,
                     -> {
                         updateStateImmediate { current ->

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
@@ -50,6 +50,15 @@ internal class BackupClickHandler @Inject constructor(
     store: SettingsHandlerStore,
 ) : Handler<Action.Backup>, SettingsHandlerStore by store {
 
+    /**
+     * In-flight marker for an AI-export-driven incremental `drive.file` grant: set when the
+     * toggle triggers `requestDriveFileAccess()` and the result needs resolution, consumed in
+     * [handleAuthResult] to decide whether to enable AI export (granted) or show the
+     * access-needed snackbar (declined). Transient (ViewModel-scoped) — lost on process death,
+     * which keeps the toggle pessimistically off.
+     */
+    private var pendingAiExportGrant: Boolean = false
+
     override fun invoke(action: Action.Backup) {
         when (action) {
             Action.Backup.ObserveAuth -> observeAuth()
@@ -77,6 +86,8 @@ internal class BackupClickHandler @Inject constructor(
                 action.schedule,
                 action.allowOnMobileData,
             )
+
+            is Action.Backup.ToggleAiExport -> toggleAiExport(action.enabled)
         }
     }
 
@@ -219,7 +230,10 @@ internal class BackupClickHandler @Inject constructor(
 
     private fun handleAuthResult(resultIntent: android.content.Intent?) {
         launchDefault(
-            onError = { emitUnknownErrorAndIdle(it) },
+            onError = { e ->
+                pendingAiExportGrant = false
+                emitUnknownErrorAndIdle(e)
+            },
             onSuccess = { result ->
                 when (result) {
                     is BackupResult.Success -> {
@@ -227,18 +241,75 @@ internal class BackupClickHandler @Inject constructor(
                         updateStateImmediate { current ->
                             current.copy(backupOperation = BackupOperationUi.Idle)
                         }
+                        reconcileAiExportGrant()
                         launchDefault { bootstrapOrRehydrate() }
                     }
 
                     is BackupResult.Failure -> {
-                        val errorUi = result.error.toUi()
-                        sendEvent(Event.ShowBackupError(errorUi))
+                        // A cancelled/failed resolution that was driving an AI-export grant
+                        // surfaces the access-needed snackbar, not a generic backup error.
+                        if (consumePendingAiExportGrant()) {
+                            sendEvent(Event.ShowAiExportAccessNeeded)
+                        } else {
+                            sendEvent(Event.ShowBackupError(result.error.toUi()))
+                        }
                     }
                 }
             },
         ) {
             interactor.completeSignIn(resultIntent)
         }
+    }
+
+    private fun toggleAiExport(enabled: Boolean) {
+        if (!enabled) {
+            launchDefault { preferencesRepository.setAiExportEnabled(false) }
+            return
+        }
+        // Pessimistic: never persist enabled=true before the drive.file grant is confirmed.
+        launchDefault(
+            onError = { e ->
+                logger.e(e, "Failed to request drive.file for AI export")
+                sendEvent(Event.ShowAiExportAccessNeeded)
+            },
+            onSuccess = { outcome ->
+                when (outcome) {
+                    SignInOutcomeDomain.Success ->
+                        preferencesRepository.setAiExportEnabled(true)
+
+                    is SignInOutcomeDomain.NeedsResolution -> {
+                        pendingAiExportGrant = true
+                        sendEvent(Event.AuthResolutionRequested(outcome.intentSender))
+                    }
+
+                    SignInOutcomeDomain.PartialGrant,
+                    is SignInOutcomeDomain.Failure,
+                    -> sendEvent(Event.ShowAiExportAccessNeeded)
+                }
+            },
+        ) {
+            interactor.requestDriveFileAccess()
+        }
+    }
+
+    /**
+     * Post-resolution reconciliation (called from [handleAuthResult] success). If a grant was
+     * pending, persist the toggle ON only when `drive.file` is now actually granted; otherwise
+     * the user declined the scope — surface the access-needed snackbar and leave the toggle off.
+     */
+    private suspend fun reconcileAiExportGrant() {
+        if (!consumePendingAiExportGrant()) return
+        if (interactor.isDriveFileGranted()) {
+            preferencesRepository.setAiExportEnabled(true)
+        } else {
+            sendEvent(Event.ShowAiExportAccessNeeded)
+        }
+    }
+
+    private fun consumePendingAiExportGrant(): Boolean {
+        val pending = pendingAiExportGrant
+        pendingAiExportGrant = false
+        return pending
     }
 
     private fun requestSignOut() {

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
@@ -259,7 +259,12 @@ internal class BackupClickHandler @Inject constructor(
 
     private fun toggleAiExport(enabled: Boolean) {
         if (!enabled) {
-            launchDefault { preferencesRepository.setAiExportEnabled(false) }
+            // Withdraw consent: stop future exports (flag off so a racing worker won't re-upload),
+            // then best-effort delete the already-exported plaintext snapshots from visible Drive.
+            launchDefault {
+                preferencesRepository.setAiExportEnabled(false)
+                interactor.deleteAiExportSnapshots()
+            }
             return
         }
         // Ignore a re-entrant enable while a grant is already in flight (the switch is also
@@ -349,6 +354,9 @@ internal class BackupClickHandler @Inject constructor(
             },
         ) {
             autoBackupController.cancelPeriodic()
+            // Delete the visible-Drive snapshots BEFORE signOut revokes drive.file — once revoked,
+            // drive.file can no longer see the app's own files, stranding them permanently.
+            interactor.deleteAiExportSnapshots()
             interactor.signOut()
         }
     }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
@@ -159,13 +159,16 @@ internal class BackupClickHandler @Inject constructor(
         combine(
             preferencesRepository.observe(),
             autoBackupController.observePeriodicStatus(),
-        ) { prefs, infos -> prefs to infos }
-            .launch { (prefs, infos) ->
-                val ui = BackupPreferencesUiMapper.toUi(
-                    prefs = prefs,
-                    periodicInfos = infos,
-                    now = System.currentTimeMillis(),
-                )
+            interactor.driveFileGranted,
+        ) { prefs, infos, driveFileGranted ->
+            BackupPreferencesUiMapper.toUi(
+                prefs = prefs,
+                periodicInfos = infos,
+                now = System.currentTimeMillis(),
+                driveFileGranted = driveFileGranted,
+            )
+        }
+            .launch { ui ->
                 updateState { current -> current.copy(backupPreferences = ui) }
             }
     }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandler.kt
@@ -50,15 +50,6 @@ internal class BackupClickHandler @Inject constructor(
     store: SettingsHandlerStore,
 ) : Handler<Action.Backup>, SettingsHandlerStore by store {
 
-    /**
-     * In-flight marker for an AI-export-driven incremental `drive.file` grant: set when the
-     * toggle triggers `requestDriveFileAccess()` and the result needs resolution, consumed in
-     * [handleAuthResult] to decide whether to enable AI export (granted) or show the
-     * access-needed snackbar (declined). Transient (ViewModel-scoped) — lost on process death,
-     * which keeps the toggle pessimistically off.
-     */
-    private var pendingAiExportGrant: Boolean = false
-
     override fun invoke(action: Action.Backup) {
         when (action) {
             Action.Backup.ObserveAuth -> observeAuth()
@@ -233,25 +224,27 @@ internal class BackupClickHandler @Inject constructor(
 
     private fun handleAuthResult(resultIntent: android.content.Intent?) {
         launchDefault(
-            onError = { e ->
-                pendingAiExportGrant = false
-                emitUnknownErrorAndIdle(e)
-            },
+            onError = { e -> emitUnknownErrorAndIdle(e) },
             onSuccess = { result ->
+                // The in-flight operation is the single source of truth for whether this
+                // resolution was driving an AI-export grant (vs a plain sign-in) — no
+                // cross-coroutine var. Read it before resetting to Idle.
+                val wasAiExportGrant =
+                    state.value.backupOperation == BackupOperationUi.TogglingAiExport
+                updateStateImmediate { current ->
+                    current.copy(backupOperation = BackupOperationUi.Idle)
+                }
                 when (result) {
                     is BackupResult.Success -> {
                         logger.i { "Sign-in successful for account: ${result.data}" }
-                        updateStateImmediate { current ->
-                            current.copy(backupOperation = BackupOperationUi.Idle)
-                        }
-                        reconcileAiExportGrant()
+                        if (wasAiExportGrant) reconcileAiExportGrant()
                         launchDefault { bootstrapOrRehydrate() }
                     }
 
                     is BackupResult.Failure -> {
                         // A cancelled/failed resolution that was driving an AI-export grant
                         // surfaces the access-needed snackbar, not a generic backup error.
-                        if (consumePendingAiExportGrant()) {
+                        if (wasAiExportGrant) {
                             sendEvent(Event.ShowAiExportAccessNeeded)
                         } else {
                             sendEvent(Event.ShowBackupError(result.error.toUi()))
@@ -269,25 +262,46 @@ internal class BackupClickHandler @Inject constructor(
             launchDefault { preferencesRepository.setAiExportEnabled(false) }
             return
         }
-        // Pessimistic: never persist enabled=true before the drive.file grant is confirmed.
+        // Ignore a re-entrant enable while a grant is already in flight (the switch is also
+        // disabled in the UI while TogglingAiExport) — prevents launching a second
+        // requestDriveFileAccess() and a second resolution intent.
+        if (state.value.backupOperation.isInProgress) return
+        // Mark in flight and keep it set THROUGH the resolution round-trip so handleAuthResult can
+        // tell this resolution apart from a plain sign-in. Pessimistic: never persist enabled=true
+        // before the drive.file grant is confirmed. (`updateState` — non-suspend entry point, as
+        // in `signIn`.)
+        updateState { current ->
+            current.copy(backupOperation = BackupOperationUi.TogglingAiExport)
+        }
         launchDefault(
             onError = { e ->
                 logger.e(e, "Failed to request drive.file for AI export")
+                updateStateImmediate { current ->
+                    current.copy(backupOperation = BackupOperationUi.Idle)
+                }
                 sendEvent(Event.ShowAiExportAccessNeeded)
             },
             onSuccess = { outcome ->
                 when (outcome) {
-                    SignInOutcomeDomain.Success ->
+                    SignInOutcomeDomain.Success -> {
                         preferencesRepository.setAiExportEnabled(true)
-
-                    is SignInOutcomeDomain.NeedsResolution -> {
-                        pendingAiExportGrant = true
-                        sendEvent(Event.AuthResolutionRequested(outcome.intentSender))
+                        updateStateImmediate { current ->
+                            current.copy(backupOperation = BackupOperationUi.Idle)
+                        }
                     }
+
+                    // Keep TogglingAiExport set; handleAuthResult resolves the grant and resets it.
+                    is SignInOutcomeDomain.NeedsResolution ->
+                        sendEvent(Event.AuthResolutionRequested(outcome.intentSender))
 
                     SignInOutcomeDomain.PartialGrant,
                     is SignInOutcomeDomain.Failure,
-                    -> sendEvent(Event.ShowAiExportAccessNeeded)
+                    -> {
+                        updateStateImmediate { current ->
+                            current.copy(backupOperation = BackupOperationUi.Idle)
+                        }
+                        sendEvent(Event.ShowAiExportAccessNeeded)
+                    }
                 }
             },
         ) {
@@ -296,23 +310,17 @@ internal class BackupClickHandler @Inject constructor(
     }
 
     /**
-     * Post-resolution reconciliation (called from [handleAuthResult] success). If a grant was
-     * pending, persist the toggle ON only when `drive.file` is now actually granted; otherwise
-     * the user declined the scope — surface the access-needed snackbar and leave the toggle off.
+     * Post-resolution reconciliation (called from [handleAuthResult] success only when the
+     * in-flight op was [BackupOperationUi.TogglingAiExport]). Persist the toggle ON only when
+     * `drive.file` is now actually granted; otherwise the user declined the scope — surface the
+     * access-needed snackbar and leave the toggle off.
      */
     private suspend fun reconcileAiExportGrant() {
-        if (!consumePendingAiExportGrant()) return
         if (interactor.isDriveFileGranted()) {
             preferencesRepository.setAiExportEnabled(true)
         } else {
             sendEvent(Event.ShowAiExportAccessNeeded)
         }
-    }
-
-    private fun consumePendingAiExportGrant(): Boolean {
-        val pending = pendingAiExportGrant
-        pendingAiExportGrant = false
-        return pending
     }
 
     private fun requestSignOut() {

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/mapper/BackupPreferencesUiMapper.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/mapper/BackupPreferencesUiMapper.kt
@@ -27,12 +27,17 @@ internal object BackupPreferencesUiMapper {
         prefs: BackupPreferences,
         periodicInfos: List<AutoBackupWorkInfo>,
         now: Long,
+        driveFileGranted: Boolean,
     ): BackupPreferencesUi = BackupPreferencesUi(
         schedule = prefs.schedule.toUi(),
         allowOnMobileData = prefs.allowOnMobileData,
         nextBackupText = nextBackupText(prefs.schedule, periodicInfos, now),
         isAuthPaused = prefs.lastError == BackupErrorCode.AuthRevoked,
-        aiExportEnabled = prefs.aiExportEnabled,
+        // Effective state: the persisted opt-in is meaningless without the live drive.file grant
+        // (re-derived on every silent refresh), so gate the displayed toggle on BOTH. Prevents a
+        // stale "on" switch after sign-out/sign-in or an external revocation, and makes
+        // re-tapping the row re-request the grant.
+        aiExportEnabled = prefs.aiExportEnabled && driveFileGranted,
     )
 
     private fun nextBackupText(

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/mapper/BackupPreferencesUiMapper.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/mapper/BackupPreferencesUiMapper.kt
@@ -32,6 +32,7 @@ internal object BackupPreferencesUiMapper {
         allowOnMobileData = prefs.allowOnMobileData,
         nextBackupText = nextBackupText(prefs.schedule, periodicInfos, now),
         isAuthPaused = prefs.lastError == BackupErrorCode.AuthRevoked,
+        aiExportEnabled = prefs.aiExportEnabled,
     )
 
     private fun nextBackupText(

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/model/BackupOperationUi.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/model/BackupOperationUi.kt
@@ -19,4 +19,7 @@ internal sealed interface BackupOperationUi {
     data object Restoring : BackupOperationUi
 
     data object SigningOut : BackupOperationUi
+
+    /** In-flight incremental `drive.file` grant driven by the AI-export toggle. */
+    data object TogglingAiExport : BackupOperationUi
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/model/BackupPreferencesUi.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/model/BackupPreferencesUi.kt
@@ -14,4 +14,5 @@ internal data class BackupPreferencesUi(
     val allowOnMobileData: Boolean,
     val nextBackupText: String?,
     val isAuthPaused: Boolean,
+    val aiExportEnabled: Boolean,
 )

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/mvi/store/SettingsStore.kt
@@ -111,6 +111,8 @@ internal interface SettingsStore : Store<State, Action, Event> {
                 val schedule: BackupScheduleUi,
                 val allowOnMobileData: Boolean,
             ) : Backup
+
+            data class ToggleAiExport(val enabled: Boolean) : Backup
         }
     }
 
@@ -128,5 +130,7 @@ internal interface SettingsStore : Store<State, Action, Event> {
         data object ShowBackupCreated : Event
 
         data object ShowAutoBackupEnabledSnackbarRequested : Event
+
+        data object ShowAiExportAccessNeeded : Event
     }
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/SettingsGraph.kt
@@ -27,6 +27,8 @@ fun NavGraphBuilder.settingsGraph(
         val context = LocalContext.current
         val haptic = LocalHapticFeedback.current
         val backupCreatedMessage = stringResource(R.string.feature_settings_backup_created)
+        val aiExportAccessNeededMessage =
+            stringResource(R.string.feature_settings_backup_ai_export_access_needed)
         val autoBackupEnabledMessage =
             stringResource(R.string.feature_settings_backup_auto_enabled_default)
         val autoBackupEnabledAction =
@@ -63,6 +65,9 @@ fun NavGraphBuilder.settingsGraph(
                 }
 
                 Event.ShowBackupCreated -> SnackbarManager.showSnackbar(backupCreatedMessage)
+
+                Event.ShowAiExportAccessNeeded ->
+                    SnackbarManager.showSnackbar(aiExportAccessNeededMessage)
 
                 Event.ShowAutoBackupEnabledSnackbarRequested -> SnackbarManager.showSnackbar(
                     message = autoBackupEnabledMessage,

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AiExportRow.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AiExportRow.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.settings.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListItem
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
+import io.github.stslex.workeeper.feature.settings.R
+
+/**
+ * Toggle row for the AI-readable JSON snapshot export. The supporting text is the consent
+ * disclosure required by the spec (§7): the snapshot is plaintext workout data in the user's
+ * *visible, shareable* Drive — not the hidden app-data backup. Shown only when authenticated.
+ */
+@Composable
+internal fun AiExportRow(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppListItem(
+        modifier = modifier
+            .padding(
+                horizontal = AppDimension.screenEdge,
+                vertical = AppDimension.Space.sm,
+            )
+            .testTag("AiExportRow"),
+        headline = stringResource(R.string.feature_settings_backup_ai_export_label),
+        supportingText = stringResource(R.string.feature_settings_backup_ai_export_caption),
+        onClick = { onToggle(!enabled) },
+        trailingContent = {
+            Switch(checked = enabled, onCheckedChange = onToggle)
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun AiExportRowOffPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        AiExportRow(enabled = false, onToggle = {})
+    }
+}
+
+@Preview
+@Composable
+private fun AiExportRowOnPreview() {
+    AppTheme(themeMode = ThemeMode.DARK) {
+        AiExportRow(enabled = true, onToggle = {})
+    }
+}

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AiExportRow.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/AiExportRow.kt
@@ -2,6 +2,8 @@
 package io.github.stslex.workeeper.feature.settings.ui.components
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import io.github.stslex.workeeper.core.ui.kit.components.list.AppListItem
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
 import io.github.stslex.workeeper.core.ui.kit.theme.ThemeMode
 import io.github.stslex.workeeper.feature.settings.R
 
@@ -18,10 +21,14 @@ import io.github.stslex.workeeper.feature.settings.R
  * Toggle row for the AI-readable JSON snapshot export. The supporting text is the consent
  * disclosure required by the spec (§7): the snapshot is plaintext workout data in the user's
  * *visible, shareable* Drive — not the hidden app-data backup. Shown only when authenticated.
+ *
+ * While [inProgress] (the incremental `drive.file` grant is mid-flight) the row is non-interactive
+ * and shows a spinner in place of the switch, so a re-tap can't launch a second grant request.
  */
 @Composable
 internal fun AiExportRow(
     enabled: Boolean,
+    inProgress: Boolean,
     onToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -34,9 +41,17 @@ internal fun AiExportRow(
             .testTag("AiExportRow"),
         headline = stringResource(R.string.feature_settings_backup_ai_export_label),
         supportingText = stringResource(R.string.feature_settings_backup_ai_export_caption),
-        onClick = { onToggle(!enabled) },
+        onClick = { if (!inProgress) onToggle(!enabled) },
         trailingContent = {
-            Switch(checked = enabled, onCheckedChange = onToggle)
+            if (inProgress) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(AppDimension.iconSm),
+                    strokeWidth = AppDimension.Space.xxs,
+                    color = AppUi.colors.accent,
+                )
+            } else {
+                Switch(checked = enabled, onCheckedChange = onToggle)
+            }
         },
     )
 }
@@ -45,7 +60,7 @@ internal fun AiExportRow(
 @Composable
 private fun AiExportRowOffPreview() {
     AppTheme(themeMode = ThemeMode.LIGHT) {
-        AiExportRow(enabled = false, onToggle = {})
+        AiExportRow(enabled = false, inProgress = false, onToggle = {})
     }
 }
 
@@ -53,6 +68,14 @@ private fun AiExportRowOffPreview() {
 @Composable
 private fun AiExportRowOnPreview() {
     AppTheme(themeMode = ThemeMode.DARK) {
-        AiExportRow(enabled = true, onToggle = {})
+        AiExportRow(enabled = true, inProgress = false, onToggle = {})
+    }
+}
+
+@Preview
+@Composable
+private fun AiExportRowInProgressPreview() {
+    AppTheme(themeMode = ThemeMode.LIGHT) {
+        AiExportRow(enabled = false, inProgress = true, onToggle = {})
     }
 }

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/BackupSection.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/BackupSection.kt
@@ -87,6 +87,10 @@ private fun AuthenticatedBlock(
             nextBackupText = preferences.nextBackupText,
             onClick = { onAction(Action.Backup.OpenFrequencyPicker) },
         )
+        AiExportRow(
+            enabled = preferences.aiExportEnabled,
+            onToggle = { onAction(Action.Backup.ToggleAiExport(it)) },
+        )
     }
     BackupButtonRow(
         title = stringResource(R.string.feature_settings_backup_create),
@@ -160,6 +164,7 @@ private fun BackupSectionAuthenticatedLightPreview() {
                     allowOnMobileData = false,
                     nextBackupText = "in 23 hours",
                     isAuthPaused = false,
+                    aiExportEnabled = true,
                 ),
                 canRevertLastRestore = true,
             ),
@@ -188,6 +193,7 @@ private fun BackupSectionAuthenticatedDarkPreview() {
                     allowOnMobileData = false,
                     nextBackupText = "in 23 hours",
                     isAuthPaused = false,
+                    aiExportEnabled = true,
                 ),
                 canRevertLastRestore = true,
             ),
@@ -216,6 +222,7 @@ private fun BackupSectionAuthPausedPreview() {
                     allowOnMobileData = false,
                     nextBackupText = null,
                     isAuthPaused = true,
+                    aiExportEnabled = false,
                 ),
                 canRevertLastRestore = false,
             ),

--- a/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/BackupSection.kt
+++ b/feature/settings/src/main/kotlin/io/github/stslex/workeeper/feature/settings/ui/components/BackupSection.kt
@@ -89,6 +89,7 @@ private fun AuthenticatedBlock(
         )
         AiExportRow(
             enabled = preferences.aiExportEnabled,
+            inProgress = operation == BackupOperationUi.TogglingAiExport,
             onToggle = { onAction(Action.Backup.ToggleAiExport(it)) },
         )
     }

--- a/feature/settings/src/main/res/values-ru/strings.xml
+++ b/feature/settings/src/main/res/values-ru/strings.xml
@@ -70,6 +70,9 @@
     <string name="feature_settings_backup_allow_mobile_data_label">Разрешить мобильные данные</string>
     <string name="feature_settings_backup_allow_mobile_data_caption">Резервные копии будут использовать мобильные данные при отсутствии Wi-Fi</string>
     <string name="feature_settings_backup_auto_row_label">Авто-копирование: %1$s</string>
+    <string name="feature_settings_backup_ai_export_label">Экспорт данных для ИИ в Google Drive</string>
+    <string name="feature_settings_backup_ai_export_caption">Сохраняет копию ваших тренировок в виде обычного текста (JSON) в видимую и доступную для общего доступа папку в Google Drive (не в скрытую резервную копию), чтобы ИИ-ассистент, которому вы дали доступ, мог её прочитать.</string>
+    <string name="feature_settings_backup_ai_export_access_needed">Для экспорта в ИИ нужен доступ к Google Drive</string>
     <string name="feature_settings_backup_auto_next_backup">Следующая копия: %1$s</string>
     <string name="feature_settings_backup_auto_paused_banner_title">Авто-копирование приостановлено</string>
     <string name="feature_settings_backup_auto_paused_banner_body">Войдите в Google Drive снова, чтобы возобновить.</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -68,6 +68,9 @@
     <string name="feature_settings_backup_allow_mobile_data_label">Allow on mobile data</string>
     <string name="feature_settings_backup_allow_mobile_data_caption">Backups will use mobile data when Wi-Fi unavailable</string>
     <string name="feature_settings_backup_auto_row_label">Auto-backup: %1$s</string>
+    <string name="feature_settings_backup_ai_export_label">Export AI-readable snapshot to Google Drive</string>
+    <string name="feature_settings_backup_ai_export_caption">Saves a plain-text JSON copy of your workouts to a visible, shareable folder in your Google Drive (not the hidden app backup) so an AI assistant you authorize can read it.</string>
+    <string name="feature_settings_backup_ai_export_access_needed">Google Drive access is needed for AI export</string>
     <string name="feature_settings_backup_auto_next_backup">Next backup: %1$s</string>
     <string name="feature_settings_backup_auto_paused_banner_title">Auto-backup paused</string>
     <string name="feature_settings_backup_auto_paused_banner_body">Sign in to Google Drive again to resume.</string>

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.IntentSender
 import io.github.stslex.workeeper.core.data.backup.api.BackupAuth
 import io.github.stslex.workeeper.core.data.backup.api.BackupStorage
+import io.github.stslex.workeeper.core.data.backup.api.SnapshotExportRunner
 import io.github.stslex.workeeper.core.data.backup.api.error.BackupError
 import io.github.stslex.workeeper.core.data.backup.api.model.Account
 import io.github.stslex.workeeper.core.data.backup.api.model.AuthState
@@ -50,6 +51,7 @@ internal class BackupInteractorImplTest {
     private val backupStorage = mockk<BackupStorage>(relaxed = true)
     private val snapshotProvider = mockk<DatabaseSnapshotProvider>(relaxed = true)
     private val restoreStateRepository = mockk<RestoreStateRepository>(relaxed = true)
+    private val snapshotExportRunner = mockk<SnapshotExportRunner>(relaxed = true)
     private val context = mockk<Context>(relaxed = true)
     private val packageManager = mockk<android.content.pm.PackageManager>(relaxed = true)
     private val packageInfo = android.content.pm.PackageInfo().apply {
@@ -83,6 +85,7 @@ internal class BackupInteractorImplTest {
             backupStorage = backupStorage,
             snapshotProvider = snapshotProvider,
             restoreStateRepository = restoreStateRepository,
+            snapshotExportRunner = snapshotExportRunner,
             context = context,
             dispatcher = testDispatcher,
         )
@@ -90,6 +93,23 @@ internal class BackupInteractorImplTest {
 
     @AfterEach
     fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `createBackup returns the binary result even when the snapshot runner throws`() =
+        runTest(testDispatcher) {
+            val captured = slot<File>()
+            coEvery { snapshotProvider.captureSnapshot(capture(captured)) } answers {
+                captured.captured.writeText("data")
+                BackupResult.Success(Unit)
+            }
+            coEvery { snapshotProvider.currentSchemaVersion() } returns 5
+            coEvery { backupStorage.uploadBackup(any(), any()) } returns BackupResult.Success(makeRef())
+            coEvery { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
+
+            val result = interactor.createBackup()
+
+            assertTrue(result is BackupResult.Success, "binary result must be unaffected, got $result")
+        }
 
     @Test
     fun `signIn Success returns SignInOutcomeDomain Success`() = runTest(testDispatcher) {

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
@@ -509,6 +509,13 @@ internal class BackupInteractorImplTest {
         coVerify(exactly = 1) { backupAuth.signOut() }
     }
 
+    @Test
+    fun `deleteAiExportSnapshots delegates to the snapshot runner`() = runTest(testDispatcher) {
+        interactor.deleteAiExportSnapshots()
+
+        coVerify(exactly = 1) { snapshotExportRunner.clearSnapshots() }
+    }
+
     private fun makeRef(
         remoteId: String = "remote-id",
         appVersion: String = "1.2.3",

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
@@ -105,7 +105,7 @@ internal class BackupInteractorImplTest {
             }
             coEvery { snapshotProvider.currentSchemaVersion() } returns 5
             coEvery { backupStorage.uploadBackup(any(), any()) } returns BackupResult.Success(makeRef())
-            coEvery { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
+            every { snapshotExportRunner.runIfEligible() } throws RuntimeException("runner blew up")
 
             val result = interactor.createBackup()
 

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/domain/BackupInteractorImplTest.kt
@@ -29,6 +29,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -110,6 +111,24 @@ internal class BackupInteractorImplTest {
 
             assertTrue(result is BackupResult.Success, "binary result must be unaffected, got $result")
         }
+
+    @Test
+    fun `requestDriveFileAccess maps NeedsResolution from backupAuth`() = runTest(testDispatcher) {
+        val sender = mockk<IntentSender>(relaxed = true)
+        coEvery { backupAuth.requestDriveFileAccess() } returns SignInResult.NeedsResolution(sender)
+
+        val outcome = interactor.requestDriveFileAccess()
+
+        assertTrue(outcome is SignInOutcomeDomain.NeedsResolution)
+        assertSame(sender, (outcome as SignInOutcomeDomain.NeedsResolution).intentSender)
+    }
+
+    @Test
+    fun `isDriveFileGranted reflects the backupAuth grant flow`() = runTest(testDispatcher) {
+        every { backupAuth.observeDriveFileGranted() } returns flowOf(true)
+
+        assertTrue(interactor.isDriveFileGranted())
+    }
 
     @Test
     fun `signIn Success returns SignInOutcomeDomain Success`() = runTest(testDispatcher) {

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
@@ -62,8 +62,10 @@ internal class BackupClickHandlerTest {
     private val authFlow = MutableStateFlow<BackupAuthDomain>(BackupAuthDomain.NotAuthenticated)
     private val preferencesFlow = MutableStateFlow(BackupPreferences.DEFAULT)
     private val periodicStatusFlow = MutableStateFlow<List<AutoBackupWorkInfo>>(emptyList())
+    private val driveFileGrantedFlow = MutableStateFlow(true)
     private val interactor = mockk<BackupInteractor>(relaxed = true).apply {
         every { authState } returns authFlow
+        every { driveFileGranted } returns driveFileGrantedFlow
     }
     private val preferencesRepository = mockk<BackupPreferencesRepository>(relaxed = true).apply {
         every { observe() } returns preferencesFlow
@@ -228,6 +230,25 @@ internal class BackupClickHandlerTest {
             val event = store.events.single()
             assertTrue(event is Event.AuthResolutionRequested)
             assertSame(sender, (event as Event.AuthResolutionRequested).intentSender)
+        }
+
+    @Test
+    fun `ObservePreferences gates aiExportEnabled on the drive_file grant`() =
+        runTest(testDispatcher) {
+            preferencesFlow.value = preferencesFlow.value.copy(aiExportEnabled = true)
+            driveFileGrantedFlow.value = false
+
+            handler.invoke(Action.Backup.ObservePreferences)
+
+            assertEquals(
+                false,
+                store.stateFlow.value.backupPreferences?.aiExportEnabled,
+                "toggle must read off when drive.file is not granted, even if the pref is on",
+            )
+
+            driveFileGrantedFlow.value = true
+
+            assertEquals(true, store.stateFlow.value.backupPreferences?.aiExportEnabled)
         }
 
     @Test

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
@@ -319,6 +319,37 @@ internal class BackupClickHandlerTest {
         }
 
     @Test
+    fun `ToggleAiExport on marks the operation in-flight until the resolution completes`() =
+        runTest(testDispatcher) {
+            coEvery { interactor.requestDriveFileAccess() } returns
+                SignInOutcomeDomain.NeedsResolution(mockk(relaxed = true))
+
+            handler.invoke(Action.Backup.ToggleAiExport(true))
+
+            assertEquals(
+                BackupOperationUi.TogglingAiExport,
+                store.stateFlow.value.backupOperation,
+            )
+        }
+
+    @Test
+    fun `ToggleAiExport ignores a re-entrant enable while a grant is already in flight`() =
+        runTest(testDispatcher) {
+            coEvery { interactor.requestDriveFileAccess() } returns
+                SignInOutcomeDomain.NeedsResolution(mockk(relaxed = true))
+
+            handler.invoke(Action.Backup.ToggleAiExport(true)) // in flight, awaiting resolution
+            handler.invoke(Action.Backup.ToggleAiExport(true)) // re-entrant: must be ignored
+
+            assertEquals(
+                BackupOperationUi.TogglingAiExport,
+                store.stateFlow.value.backupOperation,
+            )
+            coVerify(exactly = 1) { interactor.requestDriveFileAccess() }
+            assertEquals(1, store.events.count { it is Event.AuthResolutionRequested })
+        }
+
+    @Test
     fun `SignIn PartialGrant emits MISSING_REQUIRED_SCOPE and stays Idle`() =
         runTest(testDispatcher) {
             coEvery { interactor.signIn() } returns SignInOutcomeDomain.PartialGrant

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
@@ -231,6 +231,73 @@ internal class BackupClickHandlerTest {
         }
 
     @Test
+    fun `ToggleAiExport off persists disabled`() = runTest(testDispatcher) {
+        handler.invoke(Action.Backup.ToggleAiExport(false))
+
+        coVerify { preferencesRepository.setAiExportEnabled(false) }
+    }
+
+    @Test
+    fun `ToggleAiExport on with drive_file already granted persists enabled`() =
+        runTest(testDispatcher) {
+            coEvery { interactor.requestDriveFileAccess() } returns SignInOutcomeDomain.Success
+
+            handler.invoke(Action.Backup.ToggleAiExport(true))
+
+            coVerify { preferencesRepository.setAiExportEnabled(true) }
+        }
+
+    @Test
+    fun `ToggleAiExport on without grant emits AuthResolutionRequested and does not persist`() =
+        runTest(testDispatcher) {
+            val sender = mockk<IntentSender>(relaxed = true)
+            coEvery { interactor.requestDriveFileAccess() } returns
+                SignInOutcomeDomain.NeedsResolution(sender)
+
+            handler.invoke(Action.Backup.ToggleAiExport(true))
+
+            val event = store.events.single()
+            assertTrue(event is Event.AuthResolutionRequested)
+            assertSame(sender, (event as Event.AuthResolutionRequested).intentSender)
+            coVerify(exactly = 0) { preferencesRepository.setAiExportEnabled(true) }
+        }
+
+    @Test
+    fun `ToggleAiExport grant succeeds via resolution persists enabled`() =
+        runTest(testDispatcher) {
+            preferencesFlow.value = preferencesFlow.value.copy(autoBackupBootstrapped = true)
+            coEvery { interactor.requestDriveFileAccess() } returns
+                SignInOutcomeDomain.NeedsResolution(mockk(relaxed = true))
+            handler.invoke(Action.Backup.ToggleAiExport(true))
+
+            coEvery { interactor.completeSignIn(any()) } returns
+                BackupResult.Success(AccountDomain(email = "a@b.com", displayName = null))
+            coEvery { interactor.isDriveFileGranted() } returns true
+
+            handler.invoke(Action.Backup.HandleAuthResult(mockk(relaxed = true)))
+
+            coVerify { preferencesRepository.setAiExportEnabled(true) }
+        }
+
+    @Test
+    fun `ToggleAiExport grant declined shows access-needed snackbar and stays off`() =
+        runTest(testDispatcher) {
+            preferencesFlow.value = preferencesFlow.value.copy(autoBackupBootstrapped = true)
+            coEvery { interactor.requestDriveFileAccess() } returns
+                SignInOutcomeDomain.NeedsResolution(mockk(relaxed = true))
+            handler.invoke(Action.Backup.ToggleAiExport(true))
+
+            coEvery { interactor.completeSignIn(any()) } returns
+                BackupResult.Success(AccountDomain(email = "a@b.com", displayName = null))
+            coEvery { interactor.isDriveFileGranted() } returns false
+
+            handler.invoke(Action.Backup.HandleAuthResult(mockk(relaxed = true)))
+
+            assertTrue(store.events.any { it is Event.ShowAiExportAccessNeeded })
+            coVerify(exactly = 0) { preferencesRepository.setAiExportEnabled(true) }
+        }
+
+    @Test
     fun `SignIn PartialGrant emits MISSING_REQUIRED_SCOPE and stays Idle`() =
         runTest(testDispatcher) {
             coEvery { interactor.signIn() } returns SignInOutcomeDomain.PartialGrant

--- a/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
+++ b/feature/settings/src/test/kotlin/io/github/stslex/workeeper/feature/settings/mvi/handler/BackupClickHandlerTest.kt
@@ -34,6 +34,7 @@ import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Actio
 import io.github.stslex.workeeper.feature.settings.mvi.store.SettingsStore.Event
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -252,11 +253,16 @@ internal class BackupClickHandlerTest {
         }
 
     @Test
-    fun `ToggleAiExport off persists disabled`() = runTest(testDispatcher) {
-        handler.invoke(Action.Backup.ToggleAiExport(false))
+    fun `ToggleAiExport off persists disabled then deletes exported snapshots`() =
+        runTest(testDispatcher) {
+            handler.invoke(Action.Backup.ToggleAiExport(false))
 
-        coVerify { preferencesRepository.setAiExportEnabled(false) }
-    }
+            // Flag off FIRST (so a racing worker won't re-upload), then delete the plaintext copies.
+            coVerifyOrder {
+                preferencesRepository.setAiExportEnabled(false)
+                interactor.deleteAiExportSnapshots()
+            }
+        }
 
     @Test
     fun `ToggleAiExport on with drive_file already granted persists enabled`() =
@@ -899,6 +905,19 @@ internal class BackupClickHandlerTest {
 
         coVerify { autoBackupController.cancelPeriodic() }
         coVerify { interactor.signOut() }
+    }
+
+    @Test
+    fun `ConfirmSignOut deletes snapshots before revoking via signOut`() = runTest(testDispatcher) {
+        coEvery { interactor.signOut() } returns BackupResult.Success(Unit)
+
+        handler.invoke(Action.Backup.ConfirmSignOut)
+
+        // Deletion MUST precede signOut: drive.file can't see the app's files once revoked.
+        coVerifyOrder {
+            interactor.deleteAiExportSnapshots()
+            interactor.signOut()
+        }
     }
 
     @Test

--- a/proguard/proguard-rules.pro
+++ b/proguard/proguard-rules.pro
@@ -2,3 +2,10 @@
 -include firebase-crashlytics.pro
 -include gms.pro
 -include kotlinx-serialization.pro
+
+# AI-readable snapshot export DTOs + enums (drive-ai-export.md). Belt-and-suspenders over the
+# generic kotlinx-serialization keeps in kotlinx-serialization.pro: keep the classes + all
+# members so R8 cannot obfuscate the serialName or strip the generated serializers — the repo's
+# known minified-@Serializable-enum failure mode. The JSON contract is also externally consumed
+# (read by an LLM), so the field names must survive minification verbatim.
+-keep class io.github.stslex.workeeper.core.data.database.export.model.** { *; }


### PR DESCRIPTION
## Summary

Alongside the existing binary `.db` backup (hidden `appDataFolder`), write a human/LLM-readable
**JSON snapshot** of the full training graph to a **user-visible** Google Drive folder
(`Workeeper/`), refreshed on the same triggers as the binary backup, gated by an opt-in toggle +
the `drive.file` grant. It is a read-only projection — the app never reads it back.

Spec (locked): `documentation/feature-specs/drive-ai-export.md`. Source audit:
`documentation/feature-specs/drive-ai-export-audit.md`.

## What's included (phased; every commit independently green: compile + tests + full detekt)

- **Data layer** — `@Serializable` export DTOs + `DatabaseJsonExporter` (loads all 9 tables once,
  assembles the nested graph in memory with `groupBy`, zero N+1; UTF-8 JSON, UTC ISO-8601 from
  epoch-millis, nullable fields omitted, `imagePath` excluded). New unfiltered `getAll` / batch
  tag readers that include **adhoc + archived** rows (the include-everything correctness trap).
  Deterministic top-level ordering so the snapshot doesn't churn.
- **Drive plumbing** — `DriveApi` made space-aware; `DriveSnapshotStorage` (visible `Workeeper/`
  folder create-or-lookup with id cache, JSON upload, rotation reusing `RotationPolicy`, cached-id
  404 recreate-and-retry).
- **Scope + seam** — optional `drive.file` (dynamic granted-aware request set; see invariant);
  `SnapshotExportRunner` wired best-effort **after** the binary backup in both `BackupInteractor`
  (manual) and `BackupWorker` (auto), gated on the toggle + the actual grant.
- **Settings** — opt-in toggle with incremental `drive.file` consent (reuses the existing
  resolution / `StartIntentSenderForResult` path — no new navigation), pessimistic persistence
  (no `enabled=true` before the grant is confirmed), decline snackbar, consent disclosure copy
  (plaintext data in a visible, shareable folder — not the hidden appDataFolder). en + ru strings.

## Invariant: the binary backup must not regress
- The `DriveApi` change is proven non-regressing at the wire level (`DriveApiImplTest`: the
  appData list still sends `spaces=appDataFolder` + the `app_` query; upload unchanged) and at the
  caller level; binary rotation behavior is unchanged (existing rotation tests stay green).
- **The requested scope set is dynamic / granted-aware** (revised from the spec's original
  "static" intent): silent refresh requests only the already-granted scopes, so appdata-only users
  request exactly the v1 base set and `authorize()` never raises a resolution for them. `drive.file`
  is requested only via the explicit toggle grant; the grant flag is re-derived on every authorize
  (a revocation flips it off and the next refresh silently retries with base scopes). Rationale is
  documented in spec D1 / §4.2.
- The runner is fully decoupled: its body is swallowed (only *unexpected* errors → Crashlytics
  non-fatal; transient typed `BackupError`s are log-only), and both call sites also wrap it in
  `runCatching`.

## ⚠️ Manual release gates (must pass before shipping — spec §8)
1. **Cloud Console**: add `drive.file` to the OAuth consent screen + app verification.
2. **On-device**: confirm appdata-only silent refresh stays resolution-free (binary backup
   unaffected for existing users after the scope addition).
3. **On-device snapshot smoke**: enable the toggle → grant → trigger a backup → find and open
   `Workeeper/workeeper_export_<epochMs>.json` in visible Drive, verify structure.
4. **R8 release build**: `@Serializable` export DTOs + enums survive minification. A scoped keep
   rule is added; **the R8 release build could not be run in this sandbox (network offline + an
   uncached release-only dependency)** — verify in CI / locally.

## Tests
Unit + in-memory-Room across every touched module: exporter full-graph (archived + adhoc +
WEIGHTLESS null weight + planSets) + enum round-trip; space-aware binary regression; folder
create/reuse/dedup/404 + rotation; granted-aware refresh + revocation retry; runner gating +
decoupling (binary `Result` unaffected when the runner throws); toggle on/off/grant/decline.
Out of scope per spec §9: summary-tier, diff/incremental export, reading the snapshot back in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012NkHhyHhCMhoENWDCumxLa
