### PR TITLE
fix: reliable, actionable feedback for blocked exercise archive/delete

### DIFF
--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepository.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepository.kt
@@ -144,7 +144,8 @@ interface ExerciseRepository {
     /**
      * Bulk-archive a batch of exercises. Mirrors [ExerciseRepository.archive] except it
      * runs in one transaction; exercises currently used by an active (non-archived)
-     * training are excluded and surfaced in [BulkArchiveOutcome.blockedNames].
+     * training are excluded and surfaced in [BulkArchiveOutcome.blocked], each with the
+     * names of the active trainings that block it so the caller can tell the user why.
      */
     suspend fun bulkArchive(uuids: Set<String>): BulkArchiveOutcome
 
@@ -170,8 +171,19 @@ interface ExerciseRepository {
 
     data class BulkArchiveOutcome(
         val archivedCount: Int,
-        val blockedNames: List<String>,
-    )
+        val blocked: List<BlockedExercise>,
+    ) {
+
+        /**
+         * An exercise that could not be archived because it is still referenced by at
+         * least one active (non-archived, non-adhoc) training. [activeTrainings] holds
+         * those training names so the UI can name them and tell the user what to do.
+         */
+        data class BlockedExercise(
+            val name: String,
+            val activeTrainings: List<String>,
+        )
+    }
 
     /**
      * Result of [createInlineAdhocExercise]. [reusedExisting] is true when a case-insensitive

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImpl.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImpl.kt
@@ -415,12 +415,21 @@ internal class ExerciseRepositoryImpl @Inject constructor(
         val (allowed, blocked) = parsed.partition { uuid ->
             trainingExerciseDao.countActiveTemplatesUsing(uuid) == 0
         }
-        val blockedNames = blocked.mapNotNull { dao.getById(it)?.name }
+        // Reuse the same query the detail-screen archive uses (getActiveTemplateNamesUsing)
+        // so both surfaces name the blocking trainings identically. The blocked subset is
+        // small (only the user-selected exercises that are still referenced).
+        val blockedExercises = blocked.mapNotNull { uuid ->
+            val name = dao.getById(uuid)?.name ?: return@mapNotNull null
+            BulkArchiveOutcome.BlockedExercise(
+                name = name,
+                activeTrainings = trainingExerciseDao.getActiveTemplateNamesUsing(uuid),
+            )
+        }
         if (allowed.isNotEmpty()) {
             val now = System.currentTimeMillis()
             allowed.forEach { dao.archive(it, now) }
         }
-        BulkArchiveOutcome(archivedCount = allowed.size, blockedNames = blockedNames)
+        BulkArchiveOutcome(archivedCount = allowed.size, blocked = blockedExercises)
     }
 
     override suspend fun bulkPermanentDelete(uuids: Set<String>) {

--- a/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImplDbTest.kt
+++ b/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/exercise/ExerciseRepositoryImplDbTest.kt
@@ -17,6 +17,7 @@ import io.github.stslex.workeeper.core.data.database.sets.SetTypeDataModel
 import io.github.stslex.workeeper.core.data.database.testfixtures.RepositoryTestEnv
 import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
 import io.github.stslex.workeeper.core.data.database.training.TrainingExerciseEntity
+import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository.BulkArchiveOutcome.BlockedExercise
 import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository.SaveResult
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
@@ -1128,7 +1129,10 @@ internal class ExerciseRepositoryImplDbTest {
         val outcome = repository.bulkArchive(setOf(freeUuid.toString(), blockedUuid.toString()))
 
         assertEquals(1, outcome.archivedCount)
-        assertEquals(listOf("Blocked"), outcome.blockedNames)
+        assertEquals(
+            listOf(BlockedExercise(name = "Blocked", activeTrainings = listOf("Push"))),
+            outcome.blocked,
+        )
         assertTrue(env.exerciseDao.getById(freeUuid)?.archived == true)
         assertTrue(env.exerciseDao.getById(blockedUuid)?.archived == false)
     }

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppBlockedArchiveDialog.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/dialog/AppBlockedArchiveDialog.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.ui.kit.components.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
+import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * Acknowledge-style dialog shown when one or more exercises could not be archived because
+ * they are still used by active trainings. Shared by the all-exercises list (bulk archive)
+ * and the exercise detail screen (single archive) so the "blocked" feedback can't drift.
+ *
+ * All display strings are pre-formatted by the caller's UI mapper (including truncation of
+ * long training lists); this component only lays them out. There is nothing to confirm —
+ * the single button dismisses.
+ */
+@Composable
+fun AppBlockedArchiveDialog(
+    title: String,
+    items: ImmutableList<BlockedArchiveItem>,
+    nextStep: String,
+    confirmLabel: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    archivedSummary: String? = null,
+) {
+    val dialogBg = if (AppUi.colors.isDark) AppUi.colors.surfaceTier1 else AppUi.colors.surfaceTier2
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = modifier
+                .clip(AppUi.shapes.medium)
+                .background(dialogBg)
+                .padding(AppDimension.Space.lg),
+            verticalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+        ) {
+            Text(
+                text = title,
+                style = AppUi.typography.titleLarge,
+                color = AppUi.colors.textPrimary,
+            )
+            if (archivedSummary != null) {
+                Text(
+                    text = archivedSummary,
+                    style = AppUi.typography.bodyMedium,
+                    color = AppUi.colors.textSecondary,
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = MAX_LIST_HEIGHT)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.sm),
+            ) {
+                items.forEach { item ->
+                    BlockedRow(item)
+                }
+            }
+            Text(
+                text = nextStep,
+                style = AppUi.typography.bodyMedium,
+                color = AppUi.colors.textSecondary,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = AppDimension.Space.sm,
+                    alignment = Alignment.End,
+                ),
+            ) {
+                AppButton.Primary(
+                    text = confirmLabel,
+                    onClick = onDismiss,
+                    size = AppButtonSize.MEDIUM,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlockedRow(item: BlockedArchiveItem) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xxs),
+    ) {
+        Text(
+            text = item.exerciseName,
+            style = AppUi.typography.bodyMedium,
+            color = AppUi.colors.textPrimary,
+        )
+        Text(
+            text = item.trainingsLabel,
+            style = AppUi.typography.bodySmall,
+            color = AppUi.colors.textTertiary,
+        )
+    }
+}
+
+/**
+ * One blocked exercise. [trainingsLabel] is already formatted (and truncated) by the
+ * caller's UI mapper, e.g. "used in Push Day, Leg Day +3 more".
+ */
+data class BlockedArchiveItem(
+    val exerciseName: String,
+    val trainingsLabel: String,
+)
+
+private val MAX_LIST_HEIGHT = 220.dp
+
+@Preview(name = "Light", showBackground = true)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun AppBlockedArchiveDialogPreview() {
+    AppTheme {
+        AppBlockedArchiveDialog(
+            title = "Can't archive these",
+            archivedSummary = "1 exercise archived",
+            items = persistentListOf(
+                BlockedArchiveItem("Bench press", "used in Push Day, Upper A"),
+                BlockedArchiveItem("Squat", "used in Leg Day"),
+            ),
+            nextStep = "Remove them from those trainings first, then archive.",
+            confirmLabel = "Got it",
+            onDismiss = {},
+        )
+    }
+}

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/snackbar/SnackbarManager.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/snackbar/SnackbarManager.kt
@@ -1,12 +1,24 @@
 package io.github.stslex.workeeper.core.ui.kit.snackbar
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 object SnackbarManager {
 
-    private val _snackbar: MutableSharedFlow<AppSnackbarModel> = MutableSharedFlow()
+    /**
+     * Buffered so [showSnackbar] never silently drops feedback. The single collector
+     * (`App.kt`) suspends inside `SnackbarHostState.showSnackbar` for the whole time a
+     * snackbar is visible; a zero-buffer `MutableSharedFlow` would make [tryEmit] return
+     * `false` and discard any event emitted during that window. The buffer holds pending
+     * messages until the collector is free again; [BufferOverflow.DROP_OLDEST] keeps the
+     * newest feedback if a burst ever exceeds [BUFFER_CAPACITY].
+     */
+    private val _snackbar: MutableSharedFlow<AppSnackbarModel> = MutableSharedFlow(
+        extraBufferCapacity = BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
     val snackbar: SharedFlow<AppSnackbarModel> = _snackbar.asSharedFlow()
 
     fun showSnackbar(model: AppSnackbarModel) {
@@ -26,4 +38,6 @@ object SnackbarManager {
             action = action,
         ),
     )
+
+    private const val BUFFER_CAPACITY = 16
 }

--- a/core/ui/kit/src/test/kotlin/io/github/stslex/workeeper/core/ui/kit/snackbar/SnackbarManagerTest.kt
+++ b/core/ui/kit/src/test/kotlin/io/github/stslex/workeeper/core/ui/kit/snackbar/SnackbarManagerTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.ui.kit.snackbar
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class SnackbarManagerTest {
+
+    /**
+     * Regression for the silent-drop bug: the real collector (`App.kt`) suspends inside
+     * `SnackbarHostState.showSnackbar` for the whole time a snackbar is visible. A second
+     * event emitted during that window must be buffered and delivered, not dropped. With a
+     * zero-buffer `MutableSharedFlow` the second `tryEmit` returned `false` and the message
+     * vanished — exactly the "no snackbar appears" symptom on the all-exercises blocked
+     * bulk-archive path.
+     */
+    @Test
+    fun `emissions while the collector is busy are buffered, not dropped`() = runTest {
+        val received = mutableListOf<String>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            SnackbarManager.snackbar.collect { model ->
+                received += model.message
+                // Mirror the App.kt collector suspending while the snackbar is shown.
+                delay(SNACKBAR_VISIBLE_MILLIS)
+            }
+        }
+        runCurrent() // let the collector subscribe before the first emission
+
+        SnackbarManager.showSnackbar("first")
+        // Emitted while the collector is still suspended showing "first".
+        SnackbarManager.showSnackbar("second")
+
+        advanceUntilIdle()
+        job.cancel()
+
+        assertEquals(listOf("first", "second"), received)
+    }
+
+    private companion object {
+        const val SNACKBAR_VISIBLE_MILLIS = 1_000L
+    }
+}

--- a/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
+++ b/feature/all-exercises/src/androidTest/kotlin/io/github/stslex/workeeper/feature/all_exercises/AllExercisesScreenTest.kt
@@ -1,10 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.all_exercises
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.paging.PagingData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.BlockedArchiveItem
+import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.test.BaseComposeTest
+import io.github.stslex.workeeper.core.ui.test.annotations.Regression
 import io.github.stslex.workeeper.core.ui.test.annotations.Smoke
+import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseUiModel
+import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.Action
+import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.State
+import io.github.stslex.workeeper.feature.all_exercises.ui.AllExercisesScreen
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -17,8 +33,8 @@ class AllExercisesScreenTest : BaseComposeTest() {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    // TODO(feature-rewrite-tests): cover ExerciseRow click, FAB click, archive swipe, tag-filter
-    // toggle, and empty state once Smoke harness wiring for AllExercisesScreen is restored.
+    // TODO(feature-rewrite-tests): cover ExerciseRow click, FAB click, tag-filter toggle, and
+    // empty state once Smoke harness wiring for AllExercisesScreen is restored.
 
     @Test
     @Ignore("Awaiting feature rewrite — see GH issue #93 for coverage scope.")
@@ -26,4 +42,52 @@ class AllExercisesScreenTest : BaseComposeTest() {
         // Placeholder so AndroidJUnit4 has at least one @Test to discover.
         // Remove when real tests are added.
     }
+
+    /**
+     * The blocked-archive path must give reliable, actionable feedback: a persistent dialog
+     * that names each blocked exercise and the trainings blocking it (not a droppable
+     * snackbar). Renders the screen with a populated [State.blockedArchiveDialog] and asserts
+     * the blocked exercise + its trainings label show, and that acknowledging dismisses it.
+     */
+    @Test
+    @Regression
+    fun blockedArchiveDialogListsBlockingTrainings() {
+        val capture = createActionCapture<Action>()
+        val state = baseState().copy(
+            blockedArchiveDialog = State.BlockedArchiveDialog(
+                archivedSummary = null,
+                items = persistentListOf(
+                    BlockedArchiveItem(
+                        exerciseName = "Bench press",
+                        trainingsLabel = "used in Push Day, Leg Day",
+                    ),
+                ),
+            ),
+        )
+
+        composeTestRule.setContent {
+            AppTheme {
+                AllExercisesScreen(state = state, consume = capture)
+            }
+        }
+
+        composeTestRule.onNodeWithText("Bench press").assertIsDisplayed()
+        composeTestRule.onNodeWithText("used in Push Day, Leg Day").assertIsDisplayed()
+
+        val confirmLabel = InstrumentationRegistry.getInstrumentation().targetContext
+            .getString(R.string.feature_all_exercises_blocked_archive_confirm)
+        composeTestRule.onNodeWithText(confirmLabel).performClick()
+
+        capture.assertCapturedExactly(Action.Click.OnBlockedArchiveDismiss)
+    }
+
+    private fun baseState(): State = State(
+        pagingUiState = PagingUiState { flowOf(PagingData.empty<ExerciseUiModel>()) },
+        availableTags = persistentListOf(),
+        activeTagFilter = persistentSetOf(),
+        pendingPermanentDelete = null,
+        selectionMode = State.SelectionMode.Off,
+        pendingBulkDelete = null,
+        blockedArchiveDialog = null,
+    )
 }

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/domain/mapper/AllExercisesDomainMapper.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/domain/mapper/AllExercisesDomainMapper.kt
@@ -34,7 +34,13 @@ internal object AllExercisesDomainMapper {
 
     fun ExerciseRepository.BulkArchiveOutcome.toDomain(): BulkArchiveResult = BulkArchiveResult(
         archivedCount = archivedCount,
-        blockedNames = blockedNames,
+        blocked = blocked.map { it.toDomain() },
+    )
+
+    private fun ExerciseRepository.BulkArchiveOutcome.BlockedExercise.toDomain():
+        BulkArchiveResult.BlockedExerciseDomain = BulkArchiveResult.BlockedExerciseDomain(
+        name = name,
+        activeTrainings = activeTrainings,
     )
 
     fun ExerciseListItem.toDomain(): ExerciseListItemDomain = ExerciseListItemDomain(

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/domain/model/BulkArchiveResult.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/domain/model/BulkArchiveResult.kt
@@ -3,5 +3,16 @@ package io.github.stslex.workeeper.feature.all_exercises.domain.model
 
 internal data class BulkArchiveResult(
     val archivedCount: Int,
-    val blockedNames: List<String>,
-)
+    val blocked: List<BlockedExerciseDomain>,
+) {
+
+    /**
+     * An exercise that stayed active because it is still referenced by at least one
+     * active training. [activeTrainings] names those trainings so the UI can tell the
+     * user which trainings to detach it from before archiving.
+     */
+    internal data class BlockedExerciseDomain(
+        val name: String,
+        val activeTrainings: List<String>,
+    )
+}

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/handler/ClickHandler.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/handler/ClickHandler.kt
@@ -8,6 +8,7 @@ import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.feature.all_exercises.R
 import io.github.stslex.workeeper.feature.all_exercises.di.AllExercisesHandlerStore
 import io.github.stslex.workeeper.feature.all_exercises.domain.AllExercisesInteractor
+import io.github.stslex.workeeper.feature.all_exercises.mvi.mapper.AllExercisesUiMapper
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.Action
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.Event
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.State.PendingBulkDelete
@@ -37,6 +38,7 @@ internal class ClickHandler @Inject constructor(
             Action.Click.OnBulkDelete -> processBulkDelete()
             Action.Click.OnBulkDeleteConfirm -> processBulkDeleteConfirm()
             Action.Click.OnBulkDeleteDismiss -> processBulkDeleteDismiss()
+            Action.Click.OnBlockedArchiveDismiss -> processBlockedArchiveDismiss()
         }
     }
 
@@ -144,26 +146,36 @@ internal class ClickHandler @Inject constructor(
         val targets = mode.selectedUuids.toSet()
         launch(
             onSuccess = { result ->
-                updateStateImmediate { current ->
-                    current.copy(
-                        selectionMode = SelectionMode.Off,
-                        pendingBulkDelete = null,
-                    )
-                }
-                val message = if (result.blockedNames.isEmpty()) {
-                    resourceWrapper.getQuantityString(
-                        R.plurals.feature_all_exercises_bulk_archive_success,
-                        result.archivedCount,
-                        result.archivedCount,
+                if (result.blocked.isEmpty()) {
+                    updateStateImmediate { current ->
+                        current.copy(
+                            selectionMode = SelectionMode.Off,
+                            pendingBulkDelete = null,
+                        )
+                    }
+                    sendEvent(
+                        Event.ShowBulkDeleteSuccess(
+                            message = resourceWrapper.getQuantityString(
+                                R.plurals.feature_all_exercises_bulk_archive_success,
+                                result.archivedCount,
+                                result.archivedCount,
+                            ),
+                        ),
                     )
                 } else {
-                    resourceWrapper.getString(
-                        R.string.feature_all_exercises_bulk_archive_partial_format,
-                        result.archivedCount,
-                        result.blockedNames.joinToString(", "),
-                    )
+                    // Any blocked exercise → one consistent, persistent mechanism: a dialog
+                    // naming the blocking trainings, never a droppable snackbar.
+                    val dialog = with(AllExercisesUiMapper) {
+                        result.toBlockedArchiveDialog(resourceWrapper)
+                    }
+                    updateStateImmediate { current ->
+                        current.copy(
+                            selectionMode = SelectionMode.Off,
+                            pendingBulkDelete = null,
+                            blockedArchiveDialog = dialog,
+                        )
+                    }
                 }
-                sendEvent(Event.ShowBulkDeleteSuccess(message = message))
             },
         ) {
             interactor.bulkArchive(targets)
@@ -172,5 +184,9 @@ internal class ClickHandler @Inject constructor(
 
     private fun processBulkDeleteDismiss() {
         updateState { current -> current.copy(pendingBulkDelete = null) }
+    }
+
+    private fun processBlockedArchiveDismiss() {
+        updateState { current -> current.copy(blockedArchiveDialog = null) }
     }
 }

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapper.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapper.kt
@@ -2,13 +2,16 @@
 package io.github.stslex.workeeper.feature.all_exercises.mvi.mapper
 
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.BlockedArchiveItem
 import io.github.stslex.workeeper.feature.all_exercises.R
+import io.github.stslex.workeeper.feature.all_exercises.domain.model.BulkArchiveResult
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.ExerciseListItemDomain
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.TagDomain
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseTypeUiModel
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseUiModel
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.TagUiModel
+import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
@@ -17,6 +20,7 @@ internal object AllExercisesUiMapper {
     private const val MINUTE_MS = 60_000L
     private const val HOUR_MS = 60 * MINUTE_MS
     private const val DAY_MS = 24 * HOUR_MS
+    private const val MAX_TRAININGS_SHOWN = 2
 
     fun ExerciseListItemDomain.toUi(
         resourceWrapper: ResourceWrapper,
@@ -104,6 +108,53 @@ internal object AllExercisesUiMapper {
                 )
             }
         }
+    }
+
+    /**
+     * Builds the blocked-archive dialog model from a bulk-archive outcome that left at
+     * least one exercise active. [BulkArchiveResult.archivedCount] becomes the "N archived"
+     * summary (null when nothing was archived); each blocked exercise becomes a row with a
+     * truncated "used in …" trainings label.
+     */
+    fun BulkArchiveResult.toBlockedArchiveDialog(
+        resourceWrapper: ResourceWrapper,
+    ): AllExercisesStore.State.BlockedArchiveDialog =
+        AllExercisesStore.State.BlockedArchiveDialog(
+            archivedSummary = archivedCount.takeIf { it > 0 }?.let { count ->
+                resourceWrapper.getQuantityString(
+                    R.plurals.feature_all_exercises_bulk_archive_success,
+                    count,
+                    count,
+                )
+            },
+            items = blocked
+                .map { it.toBlockedArchiveItem(resourceWrapper) }
+                .toImmutableList(),
+        )
+
+    private fun BulkArchiveResult.BlockedExerciseDomain.toBlockedArchiveItem(
+        resourceWrapper: ResourceWrapper,
+    ): BlockedArchiveItem = BlockedArchiveItem(
+        exerciseName = name,
+        trainingsLabel = resourceWrapper.getString(
+            R.string.feature_all_exercises_blocked_archive_used_in_format,
+            formatTrainings(resourceWrapper, activeTrainings),
+        ),
+    )
+
+    private fun formatTrainings(
+        resourceWrapper: ResourceWrapper,
+        trainings: List<String>,
+    ): String {
+        if (trainings.size <= MAX_TRAININGS_SHOWN) return trainings.joinToString(", ")
+        val shown = trainings.take(MAX_TRAININGS_SHOWN).joinToString(", ")
+        val overflowCount = trainings.size - MAX_TRAININGS_SHOWN
+        val overflow = resourceWrapper.getQuantityString(
+            R.plurals.feature_all_exercises_blocked_archive_more,
+            overflowCount,
+            overflowCount,
+        )
+        return "$shown $overflow"
     }
 
     fun ExerciseTypeDomain.toUi(): ExerciseTypeUiModel = when (this) {

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/store/AllExercisesStore.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/store/AllExercisesStore.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.paging.PagingData
 import io.github.stslex.workeeper.core.ui.kit.components.PagingUiState
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.BlockedArchiveItem
 import io.github.stslex.workeeper.core.ui.mvi.Store
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseUiModel
 import io.github.stslex.workeeper.feature.all_exercises.mvi.model.TagUiModel
@@ -26,6 +27,7 @@ internal interface AllExercisesStore : Store<State, Action, Event> {
         val pendingPermanentDelete: PendingDelete?,
         val selectionMode: SelectionMode,
         val pendingBulkDelete: PendingBulkDelete?,
+        val blockedArchiveDialog: BlockedArchiveDialog?,
     ) : Store.State {
 
         val isSelecting: Boolean get() = selectionMode is SelectionMode.On
@@ -56,6 +58,19 @@ internal interface AllExercisesStore : Store<State, Action, Event> {
         @Stable
         data class PendingBulkDelete(val count: Int)
 
+        /**
+         * Blocked-archive acknowledgement dialog. Surfaced whenever a bulk archive left at
+         * least one exercise active because it is still used by a training. [archivedSummary]
+         * is the pre-formatted "N archived" line for the partial case (null when nothing was
+         * archived); [items] carry each blocked exercise with its pre-formatted, truncated
+         * blocking-trainings label. Strings are built by the UI mapper.
+         */
+        @Stable
+        data class BlockedArchiveDialog(
+            val archivedSummary: String?,
+            val items: ImmutableList<BlockedArchiveItem>,
+        )
+
         companion object {
 
             fun init(
@@ -67,6 +82,7 @@ internal interface AllExercisesStore : Store<State, Action, Event> {
                 pendingPermanentDelete = null,
                 selectionMode = SelectionMode.Off,
                 pendingBulkDelete = null,
+                blockedArchiveDialog = null,
             )
         }
     }
@@ -102,6 +118,8 @@ internal interface AllExercisesStore : Store<State, Action, Event> {
             data object OnBulkDeleteConfirm : Click
 
             data object OnBulkDeleteDismiss : Click
+
+            data object OnBlockedArchiveDismiss : Click
         }
 
         sealed interface Navigation : Action {

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/AllExercisesScreen.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/AllExercisesScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppBlockedArchiveDialog
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
 import io.github.stslex.workeeper.core.ui.kit.components.fab.AppFAB
 import io.github.stslex.workeeper.core.ui.kit.components.topbar.AppTopAppBar
@@ -155,6 +156,17 @@ internal fun AllExercisesScreen(
             confirmLabel = stringResource(R.string.feature_all_exercises_bulk_archive),
             onConfirm = { consume(Action.Click.OnBulkDeleteConfirm) },
             onDismiss = { consume(Action.Click.OnBulkDeleteDismiss) },
+        )
+    }
+
+    state.blockedArchiveDialog?.let { dialog ->
+        AppBlockedArchiveDialog(
+            title = stringResource(R.string.feature_all_exercises_blocked_archive_title),
+            items = dialog.items,
+            archivedSummary = dialog.archivedSummary,
+            nextStep = stringResource(R.string.feature_all_exercises_blocked_archive_next_step),
+            confirmLabel = stringResource(R.string.feature_all_exercises_blocked_archive_confirm),
+            onDismiss = { consume(Action.Click.OnBlockedArchiveDismiss) },
         )
     }
 }

--- a/feature/all-exercises/src/main/res/values-ru/strings.xml
+++ b/feature/all-exercises/src/main/res/values-ru/strings.xml
@@ -62,7 +62,6 @@
         <item quantity="many">%d упражнений в архиве</item>
         <item quantity="other">%d упражнения в архиве</item>
     </plurals>
-    <string name="feature_all_exercises_bulk_archive_partial_format">В архиве: %1$d, не получилось: %2$s</string>
     <string name="feature_all_exercises_bulk_archive_confirm_title">Архивировать выбранные?</string>
     <plurals name="feature_all_exercises_bulk_archive_confirm_body">
         <item quantity="one">%d упражнение будет перенесено в архив. Восстановить можно в Настройках → Архив.</item>
@@ -71,4 +70,14 @@
         <item quantity="other">%d упражнения будут перенесены в архив. Восстановить можно в Настройках → Архив.</item>
     </plurals>
     <string name="feature_all_exercises_bulk_archive_impact">Обратимо · история сохранится</string>
+    <string name="feature_all_exercises_blocked_archive_title">Не удалось архивировать</string>
+    <string name="feature_all_exercises_blocked_archive_used_in_format">в тренировках: %1$s</string>
+    <plurals name="feature_all_exercises_blocked_archive_more">
+        <item quantity="one">и ещё %1$d</item>
+        <item quantity="few">и ещё %1$d</item>
+        <item quantity="many">и ещё %1$d</item>
+        <item quantity="other">и ещё %1$d</item>
+    </plurals>
+    <string name="feature_all_exercises_blocked_archive_next_step">Они используются в активных тренировках. Сначала уберите их оттуда, затем архивируйте.</string>
+    <string name="feature_all_exercises_blocked_archive_confirm">Понятно</string>
 </resources>

--- a/feature/all-exercises/src/main/res/values/strings.xml
+++ b/feature/all-exercises/src/main/res/values/strings.xml
@@ -48,11 +48,18 @@
         <item quantity="one">%d exercise archived</item>
         <item quantity="other">%d exercises archived</item>
     </plurals>
-    <string name="feature_all_exercises_bulk_archive_partial_format">Archived %1$d, blocked: %2$s</string>
     <string name="feature_all_exercises_bulk_archive_confirm_title">Archive selected?</string>
     <plurals name="feature_all_exercises_bulk_archive_confirm_body">
         <item quantity="one">%d exercise will move to archive. Restore from Settings → Archive.</item>
         <item quantity="other">%d exercises will move to archive. Restore from Settings → Archive.</item>
     </plurals>
     <string name="feature_all_exercises_bulk_archive_impact">Reversible · history preserved</string>
+    <string name="feature_all_exercises_blocked_archive_title">Some couldn&#8217;t be archived</string>
+    <string name="feature_all_exercises_blocked_archive_used_in_format">used in %1$s</string>
+    <plurals name="feature_all_exercises_blocked_archive_more">
+        <item quantity="one">+%1$d more</item>
+        <item quantity="other">+%1$d more</item>
+    </plurals>
+    <string name="feature_all_exercises_blocked_archive_next_step">These are still in active trainings. Remove them from those trainings first, then archive.</string>
+    <string name="feature_all_exercises_blocked_archive_confirm">Got it</string>
 </resources>

--- a/feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/handler/ClickHandlerTest.kt
+++ b/feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/handler/ClickHandlerTest.kt
@@ -12,6 +12,7 @@ import io.github.stslex.workeeper.feature.all_exercises.mvi.model.ExerciseUiMode
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.Action
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.Event
 import io.github.stslex.workeeper.feature.all_exercises.mvi.store.AllExercisesStore.State
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -42,6 +43,7 @@ internal class ClickHandlerTest {
         pendingPermanentDelete = null,
         selectionMode = State.SelectionMode.Off,
         pendingBulkDelete = null,
+        blockedArchiveDialog = null,
     )
     private val stateFlow = MutableStateFlow(initialState)
 
@@ -148,7 +150,7 @@ internal class ClickHandlerTest {
         )
         coEvery {
             interactor.bulkArchive(any())
-        } returns BulkArchiveResult(archivedCount = 2, blockedNames = emptyList())
+        } returns BulkArchiveResult(archivedCount = 2, blocked = emptyList())
 
         val actionSlot = slot<suspend CoroutineScope.() -> BulkArchiveResult>()
         val onSuccessSlot = slot<suspend CoroutineScope.(BulkArchiveResult) -> Unit>()
@@ -169,6 +171,101 @@ internal class ClickHandlerTest {
         onSuccessSlot.captured(this, result)
         assertTrue(stateFlow.value.selectionMode is State.SelectionMode.Off)
         assertNull(stateFlow.value.pendingBulkDelete)
+        // Pure success surfaces a snackbar, never the blocked dialog.
+        assertNull(stateFlow.value.blockedArchiveDialog)
+        verify(exactly = 1) { store.sendEvent(ofType<Event.ShowBulkDeleteSuccess>()) }
+    }
+
+    @Test
+    fun `OnBulkDeleteConfirm opens blocked dialog and no snackbar when all blocked`() = runTest {
+        val targets = persistentSetOf("uuid-1")
+        stateFlow.value = stateFlow.value.copy(
+            selectionMode = State.SelectionMode.On(selectedUuids = targets),
+            pendingBulkDelete = State.PendingBulkDelete(count = 1),
+        )
+        coEvery { interactor.bulkArchive(any()) } returns BulkArchiveResult(
+            archivedCount = 0,
+            blocked = listOf(
+                BulkArchiveResult.BlockedExerciseDomain(
+                    name = "Bench",
+                    activeTrainings = listOf("Push", "Legs"),
+                ),
+            ),
+        )
+        val (actionSlot, onSuccessSlot) = captureLaunch()
+
+        handler.invoke(Action.Click.OnBulkDeleteConfirm)
+        onSuccessSlot.captured(this, actionSlot.captured(this))
+
+        val dialog = stateFlow.value.blockedArchiveDialog
+        assertNotNull(dialog)
+        assertEquals(1, dialog?.items?.size)
+        // Nothing archived → no "N archived" summary line.
+        assertNull(dialog?.archivedSummary)
+        assertTrue(stateFlow.value.selectionMode is State.SelectionMode.Off)
+        assertNull(stateFlow.value.pendingBulkDelete)
+        verify(exactly = 0) { store.sendEvent(ofType<Event.ShowBulkDeleteSuccess>()) }
+    }
+
+    @Test
+    fun `OnBulkDeleteConfirm opens blocked dialog with archived summary on partial block`() = runTest {
+        val targets = persistentSetOf("uuid-1", "uuid-2")
+        stateFlow.value = stateFlow.value.copy(
+            selectionMode = State.SelectionMode.On(selectedUuids = targets),
+            pendingBulkDelete = State.PendingBulkDelete(count = 2),
+        )
+        coEvery { interactor.bulkArchive(any()) } returns BulkArchiveResult(
+            archivedCount = 1,
+            blocked = listOf(
+                BulkArchiveResult.BlockedExerciseDomain(
+                    name = "Bench",
+                    activeTrainings = listOf("Push"),
+                ),
+            ),
+        )
+        val (actionSlot, onSuccessSlot) = captureLaunch()
+
+        handler.invoke(Action.Click.OnBulkDeleteConfirm)
+        onSuccessSlot.captured(this, actionSlot.captured(this))
+
+        val dialog = stateFlow.value.blockedArchiveDialog
+        assertNotNull(dialog)
+        assertEquals(1, dialog?.items?.size)
+        // One exercise archived → summary line present (formatted via ResourceWrapper mock).
+        assertNotNull(dialog?.archivedSummary)
+        verify(exactly = 0) { store.sendEvent(ofType<Event.ShowBulkDeleteSuccess>()) }
+    }
+
+    private fun captureLaunch(): LaunchSlots {
+        val actionSlot = slot<suspend CoroutineScope.() -> BulkArchiveResult>()
+        val onSuccessSlot = slot<suspend CoroutineScope.(BulkArchiveResult) -> Unit>()
+        every {
+            store.launch(
+                onError = any(),
+                onSuccess = capture(onSuccessSlot),
+                workDispatcher = any(),
+                eachDispatcher = any(),
+                action = capture(actionSlot),
+            )
+        } returns mockk(relaxed = true)
+        return LaunchSlots(actionSlot, onSuccessSlot)
+    }
+
+    private data class LaunchSlots(
+        val action: CapturingSlot<suspend CoroutineScope.() -> BulkArchiveResult>,
+        val onSuccess: CapturingSlot<suspend CoroutineScope.(BulkArchiveResult) -> Unit>,
+    )
+
+    @Test
+    fun `OnBlockedArchiveDismiss clears the blocked dialog`() {
+        stateFlow.value = stateFlow.value.copy(
+            blockedArchiveDialog = State.BlockedArchiveDialog(
+                archivedSummary = null,
+                items = persistentListOf(),
+            ),
+        )
+        handler.invoke(Action.Click.OnBlockedArchiveDismiss)
+        assertNull(stateFlow.value.blockedArchiveDialog)
     }
 
     @Test

--- a/feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapperTest.kt
+++ b/feature/all-exercises/src/test/kotlin/io/github/stslex/workeeper/feature/all_exercises/mvi/mapper/AllExercisesUiMapperTest.kt
@@ -3,14 +3,17 @@ package io.github.stslex.workeeper.feature.all_exercises.mvi.mapper
 
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.feature.all_exercises.R
+import io.github.stslex.workeeper.feature.all_exercises.domain.model.BulkArchiveResult
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.ExerciseDomain
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.ExerciseListItemDomain
 import io.github.stslex.workeeper.feature.all_exercises.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.all_exercises.mvi.mapper.AllExercisesUiMapper.composeFooterLabel
+import io.github.stslex.workeeper.feature.all_exercises.mvi.mapper.AllExercisesUiMapper.toBlockedArchiveDialog
 import io.github.stslex.workeeper.feature.all_exercises.mvi.mapper.AllExercisesUiMapper.toUi
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -215,5 +218,69 @@ internal class AllExercisesUiMapperTest {
         val ui = item.toUi(resourceWrapper = resourceWrapper)
         assertEquals("", ui.footerLabel)
         assertTrue(ui.tags.isEmpty())
+    }
+
+    @Test
+    fun `toBlockedArchiveDialog truncates trainings and sets archived summary on partial block`() {
+        stubBlockedArchiveStrings()
+        val result = BulkArchiveResult(
+            archivedCount = 1,
+            blocked = listOf(
+                BulkArchiveResult.BlockedExerciseDomain(
+                    name = "Bench",
+                    activeTrainings = listOf("Push", "Pull", "Legs", "Upper"),
+                ),
+            ),
+        )
+
+        val dialog = result.toBlockedArchiveDialog(resourceWrapper)
+
+        assertEquals("1 archived", dialog.archivedSummary)
+        assertEquals(1, dialog.items.size)
+        assertEquals("Bench", dialog.items.first().exerciseName)
+        // 4 trainings, first two shown, remaining two folded into "+2 more".
+        assertEquals("used in Push, Pull +2 more", dialog.items.first().trainingsLabel)
+    }
+
+    @Test
+    fun `toBlockedArchiveDialog omits archived summary and truncation when nothing archived`() {
+        stubBlockedArchiveStrings()
+        val result = BulkArchiveResult(
+            archivedCount = 0,
+            blocked = listOf(
+                BulkArchiveResult.BlockedExerciseDomain(
+                    name = "Bench",
+                    activeTrainings = listOf("Push", "Legs"),
+                ),
+            ),
+        )
+
+        val dialog = result.toBlockedArchiveDialog(resourceWrapper)
+
+        assertNull(dialog.archivedSummary)
+        assertEquals("used in Push, Legs", dialog.items.first().trainingsLabel)
+    }
+
+    private fun stubBlockedArchiveStrings() {
+        every {
+            resourceWrapper.getString(
+                R.string.feature_all_exercises_blocked_archive_used_in_format,
+                any(),
+            )
+        } answers { "used in ${secondArg<Array<Any>>().first()}" }
+        every {
+            resourceWrapper.getQuantityString(
+                R.plurals.feature_all_exercises_blocked_archive_more,
+                any<Int>(),
+                any(),
+            )
+        } answers { "+${secondArg<Int>()} more" }
+        every {
+            resourceWrapper.getQuantityString(
+                R.plurals.feature_all_exercises_bulk_archive_success,
+                any<Int>(),
+                any(),
+            )
+        } answers { "${secondArg<Int>()} archived" }
     }
 }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailScreen.kt
@@ -57,8 +57,6 @@ import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.State
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.plus
 import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -157,28 +155,7 @@ private fun DetailLargeTopBar(
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
 ) {
     val actions = remember(state.canPermanentlyDelete) {
-        persistentListOf(
-            TopbarAction(
-                titleRes = R.string.feature_exercise_detail_edit,
-                testTag = "ExerciseDetailEditMenuItem",
-                onClick = { consume(Action.Click.OnEditClick) },
-            ),
-            TopbarAction(
-                titleRes = R.string.feature_exercise_detail_archive,
-                testTag = "ExerciseDetailArchiveMenuItem",
-                onClick = { consume(Action.Click.OnArchiveMenuClick) },
-            ),
-        ).apply {
-            if (state.canPermanentlyDelete) {
-                plus(
-                    TopbarAction(
-                        titleRes = R.string.feature_exercise_detail_permanent_delete,
-                        testTag = "ExerciseDetailPermanentDeleteMenuItem",
-                        onClick = { consume(Action.Click.OnPermanentDeleteMenuClick) },
-                    ),
-                )
-            }
-        }
+        exerciseDetailActions(state.canPermanentlyDelete, consume)
     }
     DetailTopbar(
         title = state.name,
@@ -187,6 +164,43 @@ private fun DetailLargeTopBar(
         scrollBehavior = scrollBehavior,
     )
 }
+
+/**
+ * Overflow-menu actions for the exercise detail screen. The permanent-delete entry is
+ * appended only when [canPermanentlyDelete] is true (no history, no active templates).
+ *
+ * Built with [buildList] rather than `persistentListOf(...).apply { plus(...) }`: `apply`
+ * returns its receiver and the `plus` result was discarded, so the permanent-delete item
+ * never reached the menu — a silent regression this function makes testable.
+ */
+internal fun exerciseDetailActions(
+    canPermanentlyDelete: Boolean,
+    consume: (Action) -> Unit,
+): ImmutableList<TopbarAction> = buildList {
+    add(
+        TopbarAction(
+            titleRes = R.string.feature_exercise_detail_edit,
+            testTag = "ExerciseDetailEditMenuItem",
+            onClick = { consume(Action.Click.OnEditClick) },
+        ),
+    )
+    add(
+        TopbarAction(
+            titleRes = R.string.feature_exercise_detail_archive,
+            testTag = "ExerciseDetailArchiveMenuItem",
+            onClick = { consume(Action.Click.OnArchiveMenuClick) },
+        ),
+    )
+    if (canPermanentlyDelete) {
+        add(
+            TopbarAction(
+                titleRes = R.string.feature_exercise_detail_permanent_delete,
+                testTag = "ExerciseDetailPermanentDeleteMenuItem",
+                onClick = { consume(Action.Click.OnPermanentDeleteMenuClick) },
+            ),
+        )
+    }
+}.toImmutableList()
 
 @Composable
 private fun DefaultPlanCard(

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseGraph.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import androidx.navigation.NavGraphBuilder
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.ActiveSessionConflictDialog
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppBlockedArchiveDialog
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppConfirmDialog
 import io.github.stslex.workeeper.core.ui.kit.components.dialog.AppDialog
 import io.github.stslex.workeeper.core.ui.kit.snackbar.AppSnackbarModel
@@ -39,6 +40,7 @@ import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.DialogState
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Action
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.Event
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.ExerciseStore.State.Mode
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -212,11 +214,12 @@ fun NavGraphBuilder.exerciseGraph(
                 onDismiss = { processor.consume(Action.Click.OnDismissDiscard) },
             )
 
-            is DialogState.ArchiveBlocked -> AppDialog(
+            is DialogState.ArchiveBlocked -> AppBlockedArchiveDialog(
                 title = stringResource(R.string.feature_exercise_detail_archive_blocked_title),
-                body = dialog.body,
+                items = persistentListOf(dialog.item),
+                nextStep = stringResource(R.string.feature_exercise_detail_archive_blocked_next_step),
                 confirmLabel = stringResource(R.string.feature_exercise_detail_archive_blocked_ok),
-                onConfirm = { processor.consume(Action.Click.OnDismissArchiveBlocked) },
+                onDismiss = { processor.consume(Action.Click.OnDismissArchiveBlocked) },
             )
 
             is DialogState.PermanentDeleteConfirm -> AppConfirmDialog(

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/ClickHandler.kt
@@ -12,6 +12,7 @@ import io.github.stslex.workeeper.core.core.di.MainImmediateDispatcher
 import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
 import io.github.stslex.workeeper.core.core.resources.ResourceWrapper
 import io.github.stslex.workeeper.core.core.utils.CommonExt.parseOrRandom
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.BlockedArchiveItem
 import io.github.stslex.workeeper.core.ui.mvi.handler.Handler
 import io.github.stslex.workeeper.core.ui.plan_editor.domain.PlanDraftReducer
 import io.github.stslex.workeeper.core.ui.plan_editor.model.ExerciseTypeUiModel
@@ -159,13 +160,15 @@ internal class ClickHandler @Inject constructor(
                 }
 
                 is ArchiveResult.Blocked -> {
-                    val body = resourceWrapper.getString(
-                        R.string.feature_exercise_detail_archive_blocked_body_format,
-                        name,
-                        result.activeTrainings.joinToString(", "),
+                    val item = BlockedArchiveItem(
+                        exerciseName = name,
+                        trainingsLabel = resourceWrapper.getString(
+                            R.string.feature_exercise_detail_archive_blocked_used_in_format,
+                            result.activeTrainings.joinToString(", "),
+                        ),
                     )
                     updateStateImmediate {
-                        it.copy(dialogState = DialogState.ArchiveBlocked(body = body))
+                        it.copy(dialogState = DialogState.ArchiveBlocked(item = item))
                     }
                 }
             }

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/DialogState.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/store/DialogState.kt
@@ -2,6 +2,7 @@
 package io.github.stslex.workeeper.feature.exercise.ui.mvi.store
 
 import androidx.compose.runtime.Stable
+import io.github.stslex.workeeper.core.ui.kit.components.dialog.BlockedArchiveItem
 
 /**
  * Single source of truth for every dialog rendered on the Exercise screen. Folds the
@@ -25,11 +26,12 @@ internal sealed interface DialogState {
 
     /**
      * Surfaced when archiving an exercise that is still referenced by an active training.
-     * The body string is pre-formatted by the handler — it embeds the exercise name and
-     * the comma-joined list of active trainings.
+     * Rendered by the shared `AppBlockedArchiveDialog` (same component the all-exercises
+     * bulk-archive path uses) so the two surfaces can't drift. [item] carries the exercise
+     * name and the pre-formatted "used in …" trainings label built by the handler.
      */
     @Stable
-    data class ArchiveBlocked(val body: String) : DialogState
+    data class ArchiveBlocked(val item: BlockedArchiveItem) : DialogState
 
     @Stable
     data class PermanentDeleteConfirm(

--- a/feature/exercise/src/main/res/values-ru/strings.xml
+++ b/feature/exercise/src/main/res/values-ru/strings.xml
@@ -13,7 +13,8 @@
 
     <string name="feature_exercise_detail_archive_success_format">«%1$s» в архиве</string>
     <string name="feature_exercise_detail_archive_blocked_title">Нельзя архивировать</string>
-    <string name="feature_exercise_detail_archive_blocked_body_format">«%1$s» используется в активных тренировках: %2$s. Удалите из них сначала.</string>
+    <string name="feature_exercise_detail_archive_blocked_used_in_format">в тренировках: %1$s</string>
+    <string name="feature_exercise_detail_archive_blocked_next_step">Сначала уберите его из этих тренировок, затем архивируйте.</string>
     <string name="feature_exercise_detail_archive_blocked_ok">ОК</string>
     <string name="feature_exercise_detail_archive_undo">Восстановить</string>
     <string name="feature_exercise_detail_history_meta_format">%1$s · %2$s</string>

--- a/feature/exercise/src/main/res/values/strings.xml
+++ b/feature/exercise/src/main/res/values/strings.xml
@@ -12,7 +12,8 @@
     <string name="feature_exercise_detail_archive">Archive</string>
     <string name="feature_exercise_detail_archive_success_format">&#8216;%1$s&#8217; archived</string>
     <string name="feature_exercise_detail_archive_blocked_title">Cannot archive</string>
-    <string name="feature_exercise_detail_archive_blocked_body_format">&#8216;%1$s&#8217; is used in active trainings: %2$s. Remove from those first.</string>
+    <string name="feature_exercise_detail_archive_blocked_used_in_format">used in %1$s</string>
+    <string name="feature_exercise_detail_archive_blocked_next_step">Remove it from those trainings first, then archive.</string>
     <string name="feature_exercise_detail_archive_blocked_ok">OK</string>
     <string name="feature_exercise_detail_archive_undo">Undo</string>
     <string name="feature_exercise_detail_history_meta_format">%1$s · %2$s</string>

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailActionsTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/ExerciseDetailActionsTest.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class ExerciseDetailActionsTest {
+
+    /**
+     * Regression for the discarded `apply { plus(...) }` result: the permanent-delete
+     * overflow item never rendered even when [canPermanentlyDelete] was true. It must be
+     * present exactly when permanent delete is allowed, and absent otherwise.
+     */
+    @Test
+    fun `permanent-delete action is appended only when canPermanentlyDelete is true`() {
+        val whenDeletable = exerciseDetailActions(canPermanentlyDelete = true) {}
+            .map { it.testTag }
+        val whenNotDeletable = exerciseDetailActions(canPermanentlyDelete = false) {}
+            .map { it.testTag }
+
+        assertEquals(
+            listOf(
+                "ExerciseDetailEditMenuItem",
+                "ExerciseDetailArchiveMenuItem",
+                "ExerciseDetailPermanentDeleteMenuItem",
+            ),
+            whenDeletable,
+        )
+        assertEquals(
+            listOf("ExerciseDetailEditMenuItem", "ExerciseDetailArchiveMenuItem"),
+            whenNotDeletable,
+        )
+    }
+}

--- a/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/ui/TrainingDetailScreen.kt
+++ b/feature/single-training/src/main/kotlin/io/github/stslex/workeeper/feature/single_training/ui/TrainingDetailScreen.kt
@@ -36,7 +36,8 @@ import io.github.stslex.workeeper.feature.single_training.mvi.store.SingleTraini
 import io.github.stslex.workeeper.feature.single_training.ui.components.TrainingExerciseRow
 import io.github.stslex.workeeper.feature.single_training.ui.components.TrainingHero
 import io.github.stslex.workeeper.feature.single_training.ui.components.TrainingHistoryRow
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -91,28 +92,7 @@ private fun DetailLargeTopBar(
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val actions = remember(state.canPermanentlyDelete) {
-        persistentListOf(
-            TopbarAction(
-                titleRes = R.string.feature_training_detail_edit,
-                testTag = "TrainingDetailMenuButton",
-                onClick = { consume(Action.Click.OnEditClick) },
-            ),
-            TopbarAction(
-                titleRes = R.string.feature_training_detail_archive,
-                testTag = "TrainingDetailArchiveMenuItem",
-                onClick = { consume(Action.Click.OnArchiveClick) },
-            ),
-        ).apply {
-            if (state.canPermanentlyDelete) {
-                plus(
-                    TopbarAction(
-                        titleRes = R.string.feature_training_detail_permanent_delete,
-                        testTag = "TrainingDetailPermanentDeleteMenuItem",
-                        onClick = { consume(Action.Click.OnPermanentDeleteClick) },
-                    ),
-                )
-            }
-        }
+        trainingDetailActions(state.canPermanentlyDelete, consume)
     }
     DetailTopbar(
         title = state.name,
@@ -121,6 +101,43 @@ private fun DetailLargeTopBar(
         scrollBehavior = scrollBehavior,
     )
 }
+
+/**
+ * Overflow-menu actions for the training detail screen. The permanent-delete entry is
+ * appended only when [canPermanentlyDelete] is true.
+ *
+ * Built with [buildList] rather than `persistentListOf(...).apply { plus(...) }`: `apply`
+ * returns its receiver and the discarded `plus` result meant the permanent-delete item
+ * never reached the menu — a silent regression this function makes testable.
+ */
+internal fun trainingDetailActions(
+    canPermanentlyDelete: Boolean,
+    consume: (Action) -> Unit,
+): ImmutableList<TopbarAction> = buildList {
+    add(
+        TopbarAction(
+            titleRes = R.string.feature_training_detail_edit,
+            testTag = "TrainingDetailMenuButton",
+            onClick = { consume(Action.Click.OnEditClick) },
+        ),
+    )
+    add(
+        TopbarAction(
+            titleRes = R.string.feature_training_detail_archive,
+            testTag = "TrainingDetailArchiveMenuItem",
+            onClick = { consume(Action.Click.OnArchiveClick) },
+        ),
+    )
+    if (canPermanentlyDelete) {
+        add(
+            TopbarAction(
+                titleRes = R.string.feature_training_detail_permanent_delete,
+                testTag = "TrainingDetailPermanentDeleteMenuItem",
+                onClick = { consume(Action.Click.OnPermanentDeleteClick) },
+            ),
+        )
+    }
+}.toImmutableList()
 
 @Composable
 private fun ExercisesSection(

--- a/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/ui/TrainingDetailActionsTest.kt
+++ b/feature/single-training/src/test/kotlin/io/github/stslex/workeeper/feature/single_training/ui/TrainingDetailActionsTest.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.single_training.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class TrainingDetailActionsTest {
+
+    /**
+     * Regression for the discarded `apply { plus(...) }` result (twin of the exercise
+     * detail bug): the permanent-delete overflow item must appear exactly when
+     * [canPermanentlyDelete] is true.
+     */
+    @Test
+    fun `permanent-delete action is appended only when canPermanentlyDelete is true`() {
+        val whenDeletable = trainingDetailActions(canPermanentlyDelete = true) {}
+            .map { it.testTag }
+        val whenNotDeletable = trainingDetailActions(canPermanentlyDelete = false) {}
+            .map { it.testTag }
+
+        assertEquals(
+            listOf(
+                "TrainingDetailMenuButton",
+                "TrainingDetailArchiveMenuItem",
+                "TrainingDetailPermanentDeleteMenuItem",
+            ),
+            whenDeletable,
+        )
+        assertEquals(
+            listOf("TrainingDetailMenuButton", "TrainingDetailArchiveMenuItem"),
+            whenNotDeletable,
+        )
+    }
+}

--- a/lint-rules/detekt.yml
+++ b/lint-rules/detekt.yml
@@ -657,3 +657,5 @@ mvi-architecture:
     active: true
   UiLayerNoDataRule:
     active: true
+  DiscardedScopeResultRule:
+    active: true

--- a/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/DiscardedScopeResultRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/DiscardedScopeResultRule.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.lint_rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+/**
+ * Flags a pure, value-returning transform (`plus` / `minus` / `map` / `filter` / `copy` …)
+ * whose result is discarded as a statement inside an `apply { }` or `also { }` block.
+ *
+ * `apply` and `also` return their *receiver*, not the lambda result, so a bare `plus(x)` or
+ * `list.map { }` statement inside them silently throws away the new value it produced. This
+ * is exactly the dead permanent-delete menu bug this rule was written for:
+ *
+ * ```
+ * persistentListOf(edit, archive).apply {
+ *     if (canDelete) { plus(deleteAction) } // result discarded → delete item never added
+ * }
+ * ```
+ *
+ * Fix by returning/assigning the result instead — e.g. `buildList { … }` or reassignment.
+ */
+class DiscardedScopeResultRule(
+    config: Config = Config.empty,
+) : Rule(config) {
+
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Defect,
+        description = "Result of a pure transform is discarded inside an apply/also block",
+        debt = Debt.TEN_MINS,
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        val scopeName = expression.calleeExpression?.text ?: return
+        if (scopeName != SCOPE_APPLY && scopeName != SCOPE_ALSO) return
+        val body = expression.lambdaArguments
+            .firstOrNull()
+            ?.getLambdaExpression()
+            ?.bodyExpression
+            ?: return
+        flattenStatements(body.statements)
+            .filter { it.isDiscardedPureTransform() }
+            .forEach { offender ->
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(offender),
+                        "'${offender.text.take(MAX_SNIPPET)}' produces a new value that is " +
+                            "discarded: `$scopeName` returns its receiver, not this result. " +
+                            "Assign or return it (e.g. use buildList or reassignment).",
+                    ),
+                )
+            }
+    }
+
+    /** Descends only into control-flow branches (if/when), never into nested lambdas or call args. */
+    private fun flattenStatements(statements: List<KtExpression>): List<KtExpression> =
+        statements.flatMap { stmt ->
+            when (stmt) {
+                is KtIfExpression -> flattenStatements(
+                    listOfNotNull(stmt.then, stmt.`else`).flatMap(::branchStatements),
+                )
+
+                is KtWhenExpression -> flattenStatements(
+                    stmt.entries.mapNotNull { it.expression }.flatMap(::branchStatements),
+                )
+
+                else -> listOf(stmt)
+            }
+        }
+
+    private fun branchStatements(expr: KtExpression?): List<KtExpression> = when (expr) {
+        is KtBlockExpression -> expr.statements
+        null -> emptyList()
+        else -> listOf(expr)
+    }
+
+    private fun KtExpression.isDiscardedPureTransform(): Boolean = when (this) {
+        is KtCallExpression -> calleeExpression?.text in PURE_TRANSFORMS
+        is KtDotQualifiedExpression ->
+            (selectorExpression as? KtCallExpression)?.calleeExpression?.text in PURE_TRANSFORMS
+
+        is KtBinaryExpression ->
+            operationToken == KtTokens.PLUS || operationToken == KtTokens.MINUS
+
+        else -> false
+    }
+
+    private companion object {
+        const val SCOPE_APPLY = "apply"
+        const val SCOPE_ALSO = "also"
+        const val MAX_SNIPPET = 40
+        val PURE_TRANSFORMS = setOf(
+            "plus", "minus", "plusElement", "minusElement",
+            "map", "mapNotNull", "mapIndexed",
+            "filter", "filterNot", "filterNotNull",
+            "drop", "dropLast", "take", "takeLast",
+            "sorted", "sortedBy", "sortedByDescending", "sortedWith",
+            "reversed", "distinct", "distinctBy", "copy",
+        )
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/MviArchitectureRules.kt
+++ b/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/MviArchitectureRules.kt
@@ -25,6 +25,7 @@ class MviArchitectureRuleSet : RuleSetProvider {
             DomainLayerNoUiRule(config),
             DomainLayerPurityRule(config),
             UiLayerNoDataRule(config),
+            DiscardedScopeResultRule(config),
         ),
     )
 }

--- a/lint-rules/src/test/kotlin/io/github/stslex/workeeper/lint_rules/DiscardedScopeResultRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/stslex/workeeper/lint_rules/DiscardedScopeResultRuleTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.lint_rules
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class DiscardedScopeResultRuleTest {
+
+    private val rule = DiscardedScopeResultRule()
+
+    @Test
+    fun `flags discarded plus inside apply guarded by an if - the detail-menu bug shape`() {
+        val findings = rule.lint(
+            """
+            fun build(cond: Boolean): List<Int> = listOf(1, 2).apply {
+                if (cond) {
+                    plus(3)
+                }
+            }
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "Expected one finding, got: $findings")
+    }
+
+    @Test
+    fun `flags discarded map statement inside apply`() {
+        val findings = rule.lint(
+            """
+            fun build(): List<Int> = listOf(1, 2).apply {
+                map { it + 1 }
+            }
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "Expected one finding, got: $findings")
+    }
+
+    @Test
+    fun `does not flag mutating calls inside apply`() {
+        val findings = rule.lint(
+            """
+            fun build(): MutableList<Int> = mutableListOf(1).apply {
+                add(2)
+                removeAt(0)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty(), "Unexpected findings: $findings")
+    }
+
+    @Test
+    fun `does not flag transform whose result is used by run`() {
+        val findings = rule.lint(
+            """
+            fun build(): List<Int> = listOf(1, 2).run {
+                plus(3)
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty(), "Unexpected findings: $findings")
+    }
+
+    @Test
+    fun `does not flag assignment of a transform result inside apply`() {
+        val findings = rule.lint(
+            """
+            class Holder(var items: List<Int>) {
+                fun refresh() = apply {
+                    items = items.map { it + 1 }
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty(), "Unexpected findings: $findings")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes *"a single exercise cannot be archived/deleted from the All-Exercises list."* The reported repro (selection mode → select one exercise → trash FAB → confirm → nothing happens, no snackbar) turned out to be **two stacked defects**, fixed in three independently-green commits.

### 1. `fix: buffer SnackbarManager so feedback is not silently dropped`
`SnackbarManager` was a **zero-buffer `MutableSharedFlow`** emitted via `tryEmit` with the result ignored. The single collector (`App.kt`) suspends inside `SnackbarHostState.showSnackbar` for the whole time a snackbar is visible, so any event emitted during that window found no ready subscriber and was **silently dropped** — the "no snackbar appears" symptom. Now buffered (`extraBufferCapacity = 16`, `DROP_OLDEST`), mirroring the reliability the MVI `BaseStore` event bus already had (`extraBufferCapacity` + `emit()` fallback). Global fix.

### 2. `fix: surface blocked exercises in an actionable dialog on bulk archive`
Archiving an exercise still used by an active training is **intentionally blocked** to protect template referential integrity. The list reported this only through a terse, ephemeral snackbar (`"Archived 0, blocked: X"`) that named the exercise but not the reason. Replaced with a **persistent acknowledgement dialog** shown whenever *any* selected exercise is blocked (fully or partially): it lists each blocked exercise with the trainings that block it, plus how many were archived on a partial batch. Pure success still shows a snackbar. The bulk-only removal flow and the block rule are unchanged.

Extracted a shared `AppBlockedArchiveDialog` reused by **both** the list and the exercise detail screen (both name the blocking trainings via the same `getActiveTemplateNamesUsing` query) so the two surfaces can't drift.

- `ExerciseRepository.BulkArchiveOutcome` now carries the blocked exercises with their active-training names (was a flat list of names).

### 3. `fix: render the permanent-delete overflow item on detail screens`
`persistentListOf(edit, archive).apply { if (canPermanentlyDelete) { plus(delete) } }` discarded the `plus` result (`apply` returns its receiver), so the permanent-delete overflow item **never rendered** on `ExerciseDetailScreen` or `TrainingDetailScreen` even when `canPermanentlyDelete` was true — a gated action documented by `@Regression` scenario L-05, dead in the shipped UI. Rebuilt with `buildList`, extracted into testable `exerciseDetailActions` / `trainingDetailActions` functions. Added a `DiscardedScopeResultRule` Detekt rule (mvi-architecture ruleset) that flags a pure transform whose result is discarded inside `apply`/`also`, so this silent-bug class can't recur (2 occurrences existed).

## Testing
- **Full-project Detekt** clean, including the new rule (0 false positives repo-wide).
- **JVM unit tests**: `ExerciseRepositoryImplDbTest` (surfaces blocking trainings), `ClickHandlerTest` (fully-/partially-blocked + dismiss), `AllExercisesUiMapperTest` (truncation), `SnackbarManagerTest`, `ExerciseDetailActionsTest`, `TrainingDetailActionsTest`, `DiscardedScopeResultRuleTest`.
- **Lint** clean on all changed modules.
- **Not run locally (no emulator attached)**: `@Regression AllExercisesScreenTest` and end-to-end detail-screen instrumentation — these compile but were not executed here.

## Not included (follow-ups)
- `feature/all-trainings` has the identical blocked-bulk-archive terse-snackbar pattern (own `TrainingRepository.BulkArchiveOutcome`).
- Dead `pendingPermanentDelete` machinery in `feature/all-exercises` (unreachable single-item permanent-delete plumbing) — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVVMAJexL8P2H7t1wQrHQW
