### PR TITLE
KMP Phase C.0: toolchain foundation (KSP 2.3.9, unapplied Metro/Room3 catalog, KMP convention plugin, NO_ACTUAL_FOR_EXPECT guard)

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -43,6 +43,10 @@ gradlePlugin {
             id = libs.plugins.convention.androidLibrary.get().pluginId
             implementationClass = "AndroidLibraryConventionPlugin"
         }
+        register("kmpLibrary") {
+            id = libs.plugins.convention.kmpLibrary.get().pluginId
+            implementationClass = "KmpLibraryConventionPlugin"
+        }
         register("composeLibrary") {
             id = libs.plugins.convention.composeLibrary.get().pluginId
             implementationClass = "AndroidLibraryComposeConventionPlugin"

--- a/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
@@ -1,0 +1,31 @@
+import AppExt.findPluginId
+import AppExt.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Kotlin Multiplatform library convention (Phase C KMP foundation).
+ *
+ * Applies AGP's KMP-native `com.android.kotlin.multiplatform.library` plugin — required
+ * since AGP 9.0, which rejects the legacy `com.android.library` + `kotlin-multiplatform`
+ * combination. Deliberately bypasses [KotlinAndroid.configureKotlinAndroid], which
+ * force-applies Hilt to every Android module; a KMP module wires DI through Metro instead.
+ * Detekt + the custom `:lint-rules` still apply via the shared `convention.lint` plugin.
+ *
+ * Status in C.0: this convention is REGISTERED but APPLIED TO NO MODULE. It is the seam the
+ * first Hilt->Metro / Room-2->3 slice (C.1) applies when it converts a leaf module. Target
+ * declarations (android + iosX/Arm64), source-set layout, namespace/compileSdk/minSdk, and
+ * the Metro/Room3 wiring are intentionally deferred to that slice rather than guessed here.
+ */
+class KmpLibraryConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply {
+                apply(libs.findPluginId("kotlinMultiplatform"))
+                apply(libs.findPluginId("androidKmpLibrary"))
+                apply(libs.findPluginId("convention.lint"))
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 androidDesugarJdkLibs = "2.1.5"
 kotlin = "2.3.20"
-ksp = "2.3.6"
+# KSP 2.3.9 (not 2.3.6): 2.3.6 silently skips KMP/native codegen — a proven false-green
+# (Probe-2). Repo-wide single source of truth; must survive existing Hilt-Android codegen.
+ksp = "2.3.9"
 androidGradlePlugin = "9.1.0"
 androidTools = "32.1.0"
 
@@ -45,6 +47,11 @@ gms = "4.4.4"
 fbCrashlytics = "3.0.7"
 
 room = "2.8.4"
+# KMP toolchain (Phase C) — declared but UNAPPLIED in C.0; the Room 2->3 migration and
+# the K/N SQLite driver land when C.1 converts the first module. No module references
+# these yet, so they are inert until then.
+room3 = "3.0.0"
+sqliteBundled = "2.7.0"
 vkompose = "0.7.2"
 serialization = "1.9.0"
 datetime = "0.7.1"
@@ -66,6 +73,11 @@ junitKtx = "1.3.0"
 
 # Other tools
 haze = "1.7.1"
+
+# KMP DI (Phase C) — Metro pinned to 1.1.1: the last line compatible with Kotlin 2.3.20
+# (1.2.0+ requires Kotlin 2.4.0, which CMP does not yet support). Declared but UNAPPLIED
+# in C.0; applied when the first Hilt->Metro DI slice lands in C.1.
+metro = "1.1.1"
 [libraries]
 android-desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
@@ -145,6 +157,13 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
+# Room 3.0 (androidx.room3) + BundledSQLiteDriver on K/N — UNAPPLIED in C.0. These replace
+# the androidx.room 2.8.4 coordinates above during the Room 2->3 migration (a later phase);
+# both sets coexist in the catalog only until that swap is committed.
+androidx-sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqliteBundled" }
+androidx-room3-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "room3" }
+androidx-room3-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "room3" }
+
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-datastore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "datastore" }
 
@@ -188,6 +207,12 @@ detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref 
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+# KMP toolchain (Phase C) — UNAPPLIED in C.0. androidKmpLibrary is AGP's KMP-native library
+# plugin (AGP 9.0+ rejects com.android.library + kotlin-multiplatform together). Consumed by
+# the promoted KmpLibraryConventionPlugin, which is itself applied to zero modules until C.1.
+kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "androidGradlePlugin" }
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -207,6 +232,7 @@ convention-application-store = { id = "workeeper.android.application.store", ver
 convention-application-dev = { id = "workeeper.android.application.dev", version = "1.0" }
 
 convention-androidLibrary = { id = "workeeper.android.androidLibrary", version = "1.0" }
+convention-kmpLibrary = { id = "workeeper.kmp.library", version = "1.0" }
 convention-composeLibrary = { id = "workeeper.android.composeLibrary", version = "1.0" }
 convention-roomLibrary = { id = "workeeper.room.library", version = "1.0" }
 convention-lint = { id = "workeeper.lint.convention", version = "1.0" }

--- a/lint-rules/detekt.yml
+++ b/lint-rules/detekt.yml
@@ -659,3 +659,5 @@ mvi-architecture:
     active: true
   DiscardedScopeResultRule:
     active: true
+  NoActualForExpectSuppressionRule:
+    active: true

--- a/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/MviArchitectureRules.kt
+++ b/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/MviArchitectureRules.kt
@@ -26,6 +26,7 @@ class MviArchitectureRuleSet : RuleSetProvider {
             DomainLayerPurityRule(config),
             UiLayerNoDataRule(config),
             DiscardedScopeResultRule(config),
+            NoActualForExpectSuppressionRule(config),
         ),
     )
 }

--- a/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/NoActualForExpectSuppressionRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/stslex/workeeper/lint_rules/NoActualForExpectSuppressionRule.kt
@@ -1,0 +1,85 @@
+package io.github.stslex.workeeper.lint_rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+/**
+ * Bans `@Suppress("NO_ACTUAL_FOR_EXPECT")` anywhere in the repo.
+ *
+ * `NO_ACTUAL_FOR_EXPECT` is a Kotlin *compiler* diagnostic: it fires when an `expect`
+ * declaration has no matching `actual` for some target. Suppressing it does not fix the
+ * missing `actual` — it makes the module compile while the binding is silently absent.
+ *
+ * This is not hypothetical. Probe-2 caught exactly this FALSE GREEN: KSP 2.3.6 silently
+ * skipped Room's native (`actual`) codegen, and a `@Suppress("NO_ACTUAL_FOR_EXPECT")`
+ * masked the missing `actual` so the build went green while broken. The fix is to make the
+ * `actual` real — ensure KSP >= 2.3.9 (which generates it) or provide the `actual` by hand —
+ * never to suppress the diagnostic.
+ *
+ * Scope: repo-wide, all source sets. Validated safe as a blanket ban — at the time this rule
+ * was introduced (Phase C.0) the repo had ZERO `expect`/`actual` declarations and ZERO
+ * `NO_ACTUAL_FOR_EXPECT` suppressions outside disposable probe modules, so there is no
+ * legitimate location for this suppression. If a future KMP `expect` legitimately relies on
+ * plugin-generated `actual`s, correct toolchain configuration makes the diagnostic disappear
+ * on its own; the suppression stays banned.
+ *
+ * Detection is AST-based: it flags a `@Suppress` / `@file:Suppress` annotation entry (in any
+ * argument form — positional strings or the `names = [...]` array) whose arguments contain the
+ * literal `"NO_ACTUAL_FOR_EXPECT"`. A file that merely contains the string as text (e.g. a
+ * rule fixture inside a triple-quoted literal) is not an annotation entry and is not flagged.
+ */
+class NoActualForExpectSuppressionRule(
+    config: Config = Config.empty,
+) : Rule(config) {
+
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Defect,
+        description = "@Suppress(\"NO_ACTUAL_FOR_EXPECT\") masks a missing `actual` for an " +
+            "`expect` declaration (a proven false-green). Fix the real cause — ensure KSP " +
+            ">= 2.3.9 generates the actual, or provide the actual — instead of suppressing " +
+            "the compiler diagnostic.",
+        debt = Debt.TWENTY_MINS,
+    )
+
+    override fun visitAnnotationEntry(annotationEntry: KtAnnotationEntry) {
+        super.visitAnnotationEntry(annotationEntry)
+
+        if (annotationEntry.shortName?.asString() != SUPPRESS) return
+
+        val suppressed = annotationEntry
+            .collectDescendantsOfType<KtStringTemplateExpression>()
+            .mapNotNull { it.plainContentOrNull() }
+        if (FORBIDDEN_DIAGNOSTIC !in suppressed) return
+
+        report(
+            CodeSmell(
+                issue,
+                Entity.from(annotationEntry),
+                "`@Suppress(\"$FORBIDDEN_DIAGNOSTIC\")` is forbidden: it hides a missing " +
+                    "`actual` and produces a false-green build. Ensure the `actual` is really " +
+                    "generated (KSP >= 2.3.9) or write it explicitly — do not suppress the " +
+                    "compiler diagnostic.",
+            ),
+        )
+    }
+
+    /** Content of a plain, non-interpolated string literal, or null for templated strings. */
+    private fun KtStringTemplateExpression.plainContentOrNull(): String? {
+        if (hasInterpolation()) return null
+        return entries.joinToString(separator = "") { it.text }
+    }
+
+    private companion object {
+        const val SUPPRESS = "Suppress"
+        const val FORBIDDEN_DIAGNOSTIC = "NO_ACTUAL_FOR_EXPECT"
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/stslex/workeeper/lint_rules/NoActualForExpectSuppressionRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/stslex/workeeper/lint_rules/NoActualForExpectSuppressionRuleTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.lint_rules
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for [NoActualForExpectSuppressionRule].
+ *
+ * The positive-control tests are load-bearing: they PROVE the detector actually fires on a
+ * known-bad input, so a green detekt run over the real repo means "clean", not "the rule
+ * never ran". (Probe-2 lesson: a green result is worthless until the detector is shown to
+ * fire on a negative control.)
+ *
+ * The `does not flag ... as plain string content` test pins the AST-based nature of the
+ * rule — it is why THIS very test file (which embeds `@Suppress("NO_ACTUAL_FOR_EXPECT")`
+ * inside triple-quoted fixtures) is not itself flagged when detekt scans the repo.
+ */
+internal class NoActualForExpectSuppressionRuleTest {
+
+    private val rule = NoActualForExpectSuppressionRule()
+
+    // ---------------------------- positive controls (must fire) ----------------------------
+
+    @Test
+    fun `flags @Suppress NO_ACTUAL_FOR_EXPECT on a declaration`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            @Suppress("NO_ACTUAL_FOR_EXPECT")
+            expect class ExampleConstructor
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "Expected the banned suppression to be flagged, got: $findings")
+        assertTrue(findings.single().message.contains("NO_ACTUAL_FOR_EXPECT"))
+    }
+
+    @Test
+    fun `flags file-level @file colon Suppress NO_ACTUAL_FOR_EXPECT`() {
+        val findings = rule.lint(
+            """
+            @file:Suppress("NO_ACTUAL_FOR_EXPECT")
+
+            package io.github.stslex.workeeper.feature.example
+
+            expect class ExampleConstructor
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "File-level suppression must be flagged, got: $findings")
+    }
+
+    @Test
+    fun `flags NO_ACTUAL_FOR_EXPECT when mixed with other suppressions`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            @Suppress("UNUSED", "NO_ACTUAL_FOR_EXPECT", "RedundantVisibilityModifier")
+            expect class ExampleConstructor
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "Mixed-argument suppression must be flagged, got: $findings")
+    }
+
+    @Test
+    fun `flags NO_ACTUAL_FOR_EXPECT in the names array argument form`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            @Suppress(names = ["NO_ACTUAL_FOR_EXPECT"])
+            expect class ExampleConstructor
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size, "Array-form suppression must be flagged, got: $findings")
+    }
+
+    // ---------------------------- negative controls (must NOT fire) ----------------------------
+
+    @Test
+    fun `does not flag an unrelated suppression`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            @Suppress("UNUSED", "unused")
+            class Example
+            """.trimIndent(),
+        )
+        assertEquals(0, findings.size, "Unrelated suppressions must not be flagged, got: $findings")
+    }
+
+    @Test
+    fun `does not flag a declaration with no suppression`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            expect class ExampleConstructor
+            """.trimIndent(),
+        )
+        assertEquals(0, findings.size, "No suppression means no finding, got: $findings")
+    }
+
+    @Test
+    fun `does not flag the diagnostic name as plain string content`() {
+        // The string appears as a value, NOT inside a @Suppress annotation — must not fire.
+        // This is exactly why this test file's own fixtures are safe when detekt scans the repo.
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            val doc = "banning @Suppress(\"NO_ACTUAL_FOR_EXPECT\") prevents false greens"
+            """.trimIndent(),
+        )
+        assertEquals(0, findings.size, "Plain string content must not be flagged, got: $findings")
+    }
+
+    @Test
+    fun `does not flag the diagnostic name inside a non-Suppress annotation`() {
+        val findings = rule.lint(
+            """
+            package io.github.stslex.workeeper.feature.example
+
+            @Deprecated("NO_ACTUAL_FOR_EXPECT")
+            class Example
+            """.trimIndent(),
+        )
+        assertEquals(0, findings.size, "Only @Suppress is targeted, got: $findings")
+    }
+}


### PR DESCRIPTION
## Phase C.0 — green toolchain foundation, ZERO migration

No-regret foundation for the Android→KMP migration. **No module is converted, no Room rename is executed, no DI slice is started.** Every KMP-facing addition is *declared but applied to nothing* — this PR only makes the toolchain ready and adds one guardrail.

### What changed (7 files, +284/-1)
- **Version catalog** — KSP `2.3.6` → `2.3.9`; add **unapplied** `metro 1.1.1`, `room3 3.0.0`, `sqlite-bundled 2.7.0`, and the `convention-kmpLibrary` alias + KMP/Metro plugin aliases.
- **`KmpLibraryConventionPlugin`** — promoted into `build-logic` and registered, but **applied to zero modules**. Target/source-set/Metro/Room3 wiring is deliberately deferred to the first C.1 slice rather than guessed here.
- **`NoActualForExpectSuppressionRule`** (Detekt) — repo-wide ban on `@Suppress("NO_ACTUAL_FOR_EXPECT")`, which masks a missing `actual` and produces a false-green build (the exact issue Probe-2 caught when KSP 2.3.6 silently skipped native codegen). Validated safe as a blanket ban: the repo has **zero** `expect`/`actual` and **zero** such suppressions today.

### Why KSP 2.3.9 / Metro 1.1.1
- KSP **2.3.6 silently skips KMP/native codegen** — a proven false-green; 2.3.9 is the fix.
- Locked at **Kotlin 2.3.20** (CMP caps the KMP world at 2.3.x). Metro **1.1.1** is the last release compatible with 2.3.20 (1.2.0+ needs Kotlin 2.4.0).

### Gate — proven, not just green
- `assembleDebug` + `detekt` green under KSP 2.3.9.
- **32/32 `kspDebugKotlin` AND 32/32 `kspDebugUnitTestKotlin` executed with 0 cached** (the version bump invalidated every KSP cache) → existing **Hilt-Android codegen survives KSP 2.3.9 on every module**, including the three apps' `@HiltAndroidApp` aggregation. This was the migration's #1 unverified assumption.
- **1094 unit tests pass.** `detekt` clean across all 32 modules with `config.validation: true` (rule is correctly registered).
- **Guard proven end-to-end:** a planted `@Suppress("NO_ACTUAL_FOR_EXPECT")` fails `detekt` citing `NoActualForExpectSuppressionRule`; green on removal. 8/8 unit tests cover 4 positive + 4 negative controls.

### Not in this PR (C.1, on macOS for iOS/K-N compile)
- Room 2→3 migration — scoped as **CHUNKY** (driver now mandatory, `@TypeConverter`→`@ColumnTypeConverter`, `Migration.migrate(SQLiteConnection)`, driver-aware `MigrationTestHelper`, explicit PagingSource converter). C.1 must also add `room3-paging`, `room3-testing`, and the **room3 Gradle plugin coordinate (unconfirmed on Google Maven — blocker)**.
- First Hilt→Metro DI slice — recommended target **`feature/archive`** (off the Room track; exercises the representative cross-module `@Singleton` bridge; the shared `core:ui:mvi` `hiltViewModel()` resolution rework is the real first-slice prerequisite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdATiNmTB5zFWUWH2ZqJeK
