### PR TITLE
PR ordering: one rule, five sites, one fixture

### DIFF
--- a/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDao.kt
+++ b/core/data/database/src/main/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDao.kt
@@ -9,6 +9,83 @@ import androidx.room3.Update
 import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
+/**
+ * The one PR row shape. `exercise_table` is joined in so the *exercise* type is read from
+ * the DB rather than passed in by a caller that read it separately — a caller-supplied type
+ * can go stale between the read and the query and silently reorder the result.
+ *
+ * `s.type` is the **set** type (WARM/WORK/FAIL/DROP); `e.type` is the **exercise** type
+ * (WEIGHTED/WEIGHTLESS). Only `s.type` is projected.
+ */
+private const val PR_ROW_SELECT = """
+        SELECT pe.exercise_uuid AS exercise_uuid,
+               s.uuid AS set_uuid,
+               s.weight AS weight,
+               s.reps AS reps,
+               s.type AS type,
+               s.performed_exercise_uuid AS performed_exercise_uuid,
+               sn.uuid AS session_uuid,
+               sn.finished_at AS finished_at
+        FROM set_table s
+        JOIN performed_exercise_table pe ON pe.uuid = s.performed_exercise_uuid
+        JOIN session_table sn ON sn.uuid = pe.session_uuid
+        JOIN exercise_table e ON e.uuid = pe.exercise_uuid
+        """
+
+/**
+ * Which sets may hold the record. A set is eligible iff its session is FINISHED with a
+ * non-null `finished_at`, it logged at least one rep, and — for WEIGHTED exercises only —
+ * it carries a weight. WEIGHTLESS exercises ignore `set_table.weight` entirely: residual
+ * non-null weights on weightless rows exist in the wild and must not gate eligibility.
+ *
+ * Appended after the caller's own `WHERE pe.exercise_uuid …` predicate, hence the leading
+ * `AND`.
+ */
+private const val PR_ELIGIBILITY = """
+          AND sn.state = 'FINISHED'
+          AND sn.finished_at IS NOT NULL
+          AND s.reps > 0
+          AND (e.type = 'WEIGHTLESS' OR s.weight IS NOT NULL)
+        """
+
+/**
+ * Who wins among eligible sets: weight DESC (WEIGHTED only), then reps DESC, then earliest
+ * `finished_at`, then lowest `position`. The `CASE` collapses to a constant NULL for
+ * WEIGHTLESS exercises, so weight drops out of the comparison instead of being coerced.
+ * Weight is never NULL for a WEIGHTED exercise here — [PR_ELIGIBILITY] already excluded
+ * those rows — so SQLite's NULL-ordering rules never come into play.
+ */
+private const val PR_ORDER = """
+            CASE WHEN e.type = 'WEIGHTED' THEN s.weight END DESC,
+            s.reps DESC,
+            sn.finished_at ASC,
+            s.position ASC
+        """
+
+/** Single-exercise PR: the one holder row, or nothing. */
+private const val PR_SINGLE_SQL = """
+        $PR_ROW_SELECT
+        WHERE pe.exercise_uuid = :exerciseUuid
+        $PR_ELIGIBILITY
+        ORDER BY
+        $PR_ORDER
+        LIMIT 1
+        """
+
+/**
+ * Batch PR: *every* eligible candidate for every requested exercise, grouped by exercise and
+ * ordered so the consumer takes `.first()` per group. No `LIMIT`/window function — `minSdk 28`
+ * ships SQLite 3.22 and `ROW_NUMBER()` needs 3.25 (the bundled-SQLite dependency is declared
+ * but inert; `AndroidSQLiteDriver` uses framework SQLite).
+ */
+private const val PR_BATCH_SQL = """
+        $PR_ROW_SELECT
+        WHERE pe.exercise_uuid IN (:exerciseUuids)
+        $PR_ELIGIBILITY
+        ORDER BY pe.exercise_uuid,
+        $PR_ORDER
+        """
+
 @Suppress("TooManyFunctions")
 @Dao
 interface SessionDao {
@@ -211,105 +288,35 @@ interface SessionDao {
     }
 
     /**
-     * Heaviest set the user has ever logged for [exerciseUuid] across finished sessions.
-     * The `:isWeightless` flag controls whether weight participates in the ordering — for
-     * weightless exercises only reps and timestamp drive PR ownership. Tiebreak by earliest
-     * `finished_at` so the PR badge belongs to the first occurrence.
+     * The set that holds the record for [exerciseUuid], or null when no finished session has
+     * logged an eligible set yet. Eligibility is [PR_ELIGIBILITY], ordering is [PR_ORDER] —
+     * both shared verbatim with [observePersonalRecord] and [observePersonalRecordsBatch], so
+     * the three cannot drift. The exercise type is read from `exercise_table`, not passed in.
+     */
+    @Query(PR_SINGLE_SQL)
+    suspend fun getPersonalRecord(exerciseUuid: Uuid): PersonalRecordRow?
+
+    /**
+     * Reactive form of [getPersonalRecord] — literally the same SQL body ([PR_SINGLE_SQL]).
+     * Room re-emits whenever any participating table changes, so subscribers see the new
+     * holder after a finished session bumps it, an edit-save changes a top set, or the
+     * holder set is deleted.
+     */
+    @Query(PR_SINGLE_SQL)
+    fun observePersonalRecord(exerciseUuid: Uuid): Flow<PersonalRecordRow?>
+
+    /**
+     * Reactive PR rows across many exercises in a single subscription. Returns *all* eligible
+     * candidates, contiguous per exercise and best-first within each group, so the consumer
+     * picks holders with `groupBy { exerciseUuid }.mapValues { it.first() }`. One subscription
+     * instead of the combine-of-N amplification long-lived subscribers (Past session, Live
+     * workout pre-snapshot) would otherwise hit.
      *
-     * Ordering semantics here mirror [observePersonalRecordsBatch]; if the tiebreak rule
-     * changes, update both in lockstep.
+     * Eligibility and ordering are the same constants [getPersonalRecord] uses. Because the
+     * eligibility predicate now lives here, consumers must not re-filter candidates — half a
+     * rule in a second module is how the two paths diverged before.
      */
-    @Query(
-        """
-        SELECT pe.exercise_uuid AS exercise_uuid,
-               s.uuid AS set_uuid,
-               s.weight AS weight,
-               s.reps AS reps,
-               s.type AS type,
-               s.performed_exercise_uuid AS performed_exercise_uuid,
-               sn.uuid AS session_uuid,
-               sn.finished_at AS finished_at
-        FROM set_table s
-        JOIN performed_exercise_table pe ON pe.uuid = s.performed_exercise_uuid
-        JOIN session_table sn ON sn.uuid = pe.session_uuid
-        WHERE pe.exercise_uuid = :exerciseUuid
-          AND sn.state = 'FINISHED'
-          AND sn.finished_at IS NOT NULL
-          AND (:isWeightless = 1 OR s.weight IS NOT NULL)
-        ORDER BY
-            CASE WHEN :isWeightless = 0 THEN s.weight END DESC,
-            s.reps DESC,
-            sn.finished_at ASC,
-            s.position ASC
-        LIMIT 1
-        """,
-    )
-    suspend fun getPersonalRecord(exerciseUuid: Uuid, isWeightless: Boolean): PersonalRecordRow?
-
-    /**
-     * Reactive PR for [exerciseUuid]. Same SQL body as [getPersonalRecord]; Room re-emits
-     * whenever any of the participating tables change. Subscribers see the new PR after a
-     * finished session bumps it, an edit-save changes a top set, or the holder set is deleted.
-     */
-    @Query(
-        """
-        SELECT pe.exercise_uuid AS exercise_uuid,
-               s.uuid AS set_uuid,
-               s.weight AS weight,
-               s.reps AS reps,
-               s.type AS type,
-               s.performed_exercise_uuid AS performed_exercise_uuid,
-               sn.uuid AS session_uuid,
-               sn.finished_at AS finished_at
-        FROM set_table s
-        JOIN performed_exercise_table pe ON pe.uuid = s.performed_exercise_uuid
-        JOIN session_table sn ON sn.uuid = pe.session_uuid
-        WHERE pe.exercise_uuid = :exerciseUuid
-          AND sn.state = 'FINISHED'
-          AND sn.finished_at IS NOT NULL
-          AND (:isWeightless = 1 OR s.weight IS NOT NULL)
-        ORDER BY
-            CASE WHEN :isWeightless = 0 THEN s.weight END DESC,
-            s.reps DESC,
-            sn.finished_at ASC,
-            s.position ASC
-        LIMIT 1
-        """,
-    )
-    fun observePersonalRecord(exerciseUuid: Uuid, isWeightless: Boolean): Flow<PersonalRecordRow?>
-
-    /**
-     * Reactive PR rows across many exercises in a single subscription. Returns *all* candidate
-     * sets ordered so the consumer can `groupBy { exerciseUuid }.mapValues { it.first() }` to
-     * pick the heaviest per exercise. Single batch query avoids the combine-of-N amplification
-     * pattern that long-lived subscribers (Past session) would otherwise hit. Ordering matches
-     * [getPersonalRecord]: non-null weights first, then weight DESC, reps DESC, earliest
-     * finished_at wins.
-     */
-    @Query(
-        """
-        SELECT pe.exercise_uuid AS exercise_uuid,
-               s.uuid AS set_uuid,
-               s.weight AS weight,
-               s.reps AS reps,
-               s.type AS type,
-               s.performed_exercise_uuid AS performed_exercise_uuid,
-               sn.uuid AS session_uuid,
-               sn.finished_at AS finished_at
-        FROM set_table s
-        JOIN performed_exercise_table pe ON pe.uuid = s.performed_exercise_uuid
-        JOIN session_table sn ON sn.uuid = pe.session_uuid
-        WHERE pe.exercise_uuid IN (:exerciseUuids)
-          AND sn.state = 'FINISHED'
-          AND sn.finished_at IS NOT NULL
-        ORDER BY pe.exercise_uuid,
-            CASE WHEN s.weight IS NULL THEN 1 ELSE 0 END,
-            s.weight DESC,
-            s.reps DESC,
-            sn.finished_at ASC,
-            s.position ASC
-        """,
-    )
+    @Query(PR_BATCH_SQL)
     fun observePersonalRecordsBatch(exerciseUuids: List<Uuid>): Flow<List<PersonalRecordRow>>
 
     /**

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoObservePersonalRecordTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoObservePersonalRecordTest.kt
@@ -45,7 +45,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
         val exerciseUuid = Uuid.random()
         seedTrainingAndExercise(trainingUuid, exerciseUuid)
 
-        val result = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = false).first()
+        val result = sessionDao.observePersonalRecord(exerciseUuid).first()
 
         assertNull(result)
     }
@@ -70,7 +70,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
             reps = 5,
         )
 
-        val result = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = false).first()
+        val result = sessionDao.observePersonalRecord(exerciseUuid).first()
 
         assertEquals(100.0, result?.weight)
         assertEquals(5, result?.reps)
@@ -90,7 +90,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
             reps = 5,
         )
 
-        val initial = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = false).first()
+        val initial = sessionDao.observePersonalRecord(exerciseUuid).first()
         assertEquals(80.0, initial?.weight)
 
         insertFinishedSet(
@@ -101,7 +101,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
             reps = 5,
         )
 
-        val updated = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = false).first()
+        val updated = sessionDao.observePersonalRecord(exerciseUuid).first()
         assertEquals(110.0, updated?.weight)
     }
 
@@ -125,7 +125,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
             reps = 18,
         )
 
-        val result = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = true).first()
+        val result = sessionDao.observePersonalRecord(exerciseUuid).first()
 
         assertEquals(18, result?.reps)
     }
@@ -175,7 +175,7 @@ internal class SessionDaoObservePersonalRecordTest : BaseDatabaseTest() {
             ),
         )
 
-        val result = sessionDao.observePersonalRecord(exerciseUuid, isWeightless = false).first()
+        val result = sessionDao.observePersonalRecord(exerciseUuid).first()
 
         assertEquals(60.0, result?.weight)
         assertEquals(8, result?.reps)

--- a/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoPersonalRecordTest.kt
+++ b/core/data/database/src/test/kotlin/io/github/stslex/workeeper/core/data/database/session/SessionDaoPersonalRecordTest.kt
@@ -44,7 +44,7 @@ internal class SessionDaoPersonalRecordTest : BaseDatabaseTest() {
         val exerciseUuid = Uuid.random()
         seedTrainingAndExercise(trainingUuid, exerciseUuid)
 
-        val result = sessionDao.getPersonalRecord(exerciseUuid, isWeightless = false)
+        val result = sessionDao.getPersonalRecord(exerciseUuid)
 
         assertNull(result)
     }
@@ -87,7 +87,7 @@ internal class SessionDaoPersonalRecordTest : BaseDatabaseTest() {
             reps = 4,
         )
 
-        val result = sessionDao.getPersonalRecord(exerciseUuid, isWeightless = false)
+        val result = sessionDao.getPersonalRecord(exerciseUuid)
 
         assertEquals(100.0, result?.weight)
         assertEquals(5, result?.reps)
@@ -141,7 +141,7 @@ internal class SessionDaoPersonalRecordTest : BaseDatabaseTest() {
             ),
         )
 
-        val result = sessionDao.getPersonalRecord(exerciseUuid, isWeightless = false)
+        val result = sessionDao.getPersonalRecord(exerciseUuid)
 
         assertEquals(60.0, result?.weight)
         assertEquals(8, result?.reps)
@@ -167,7 +167,7 @@ internal class SessionDaoPersonalRecordTest : BaseDatabaseTest() {
             reps = 15,
         )
 
-        val result = sessionDao.getPersonalRecord(exerciseUuid, isWeightless = true)
+        val result = sessionDao.getPersonalRecord(exerciseUuid)
 
         assertEquals(15, result?.reps)
         assertEquals(recordSession, result?.sessionUuid)
@@ -193,7 +193,7 @@ internal class SessionDaoPersonalRecordTest : BaseDatabaseTest() {
             reps = 12,
         )
 
-        val result = sessionDao.getPersonalRecord(exerciseUuid, isWeightless = true)
+        val result = sessionDao.getPersonalRecord(exerciseUuid)
 
         assertEquals(earliest, result?.sessionUuid)
         assertEquals(1_000L, result?.finishedAt)

--- a/core/data/database/src/testFixtures/kotlin/io/github/stslex/workeeper/core/data/database/testfixtures/PrRuleDbSeeder.kt
+++ b/core/data/database/src/testFixtures/kotlin/io/github/stslex/workeeper/core/data/database/testfixtures/PrRuleDbSeeder.kt
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.testfixtures
+
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseEntity
+import io.github.stslex.workeeper.core.data.database.exercise.ExerciseTypeEntity
+import io.github.stslex.workeeper.core.data.database.session.PerformedExerciseEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionEntity
+import io.github.stslex.workeeper.core.data.database.session.SessionStateEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
+import io.github.stslex.workeeper.core.data.database.session.model.SetTypeEntity
+import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
+import io.github.stslex.workeeper.core.data.database.testfixtures.PrRuleFixture.PrScenario
+import org.jetbrains.annotations.TestOnly
+import kotlin.uuid.Uuid
+
+/**
+ * Writes a [PrScenario] into a [RepositoryTestEnv] as real rows, and hands back the set UUID
+ * each candidate label was given so assertions can name a winner rather than compare
+ * weight/reps tuples (two candidates in the tie scenarios are identical on those).
+ *
+ * Sessions are seeded [SessionStateEntity.IN_PROGRESS] by default so a test can assert the
+ * two-phase contract: while the session is unfinished the SQL sites see nothing and only
+ * `PrComparator` can answer; [finishAllSessions] then flips them and the SQL sites must
+ * arrive at the same answer.
+ */
+@TestOnly
+class PrRuleDbSeeder(private val env: RepositoryTestEnv) {
+
+    data class Seeded(
+        val scenario: PrScenario,
+        val exerciseUuid: Uuid,
+        val setUuidByLabel: Map<String, Uuid>,
+        val sessionUuidByFinishedAt: Map<Long, Uuid>,
+    ) {
+        /** The set UUID the rule must name, or null when the scenario expects no holder. */
+        val expectedHolderSetUuid: Uuid? get() = scenario.expectedHolder?.let(setUuidByLabel::getValue)
+
+        fun labelOf(setUuid: Uuid?): String? =
+            setUuidByLabel.entries.firstOrNull { it.value == setUuid }?.key
+    }
+
+    suspend fun seed(
+        scenario: PrScenario,
+        state: SessionStateEntity = SessionStateEntity.IN_PROGRESS,
+    ): Seeded {
+        val trainingUuid = Uuid.random()
+        val exerciseUuid = Uuid.random()
+        env.trainingDao.insert(
+            TrainingEntity(
+                uuid = trainingUuid,
+                name = "Training-$trainingUuid",
+                description = null,
+                isAdhoc = false,
+                archived = false,
+                createdAt = 0L,
+                archivedAt = null,
+            ),
+        )
+        env.exerciseDao.insert(
+            ExerciseEntity(
+                uuid = exerciseUuid,
+                name = "Exercise-$exerciseUuid",
+                type = if (scenario.isWeightless) {
+                    ExerciseTypeEntity.WEIGHTLESS
+                } else {
+                    ExerciseTypeEntity.WEIGHTED
+                },
+                description = null,
+                imagePath = null,
+                archived = false,
+                createdAt = 0L,
+                archivedAt = null,
+                lastAdhocSets = null,
+            ),
+        )
+
+        val setUuidByLabel = mutableMapOf<String, Uuid>()
+        val sessionUuidByFinishedAt = mutableMapOf<Long, Uuid>()
+
+        // Candidates sharing a finishedAt share a session — that is what makes `position`
+        // reachable as a tiebreak instead of being masked by finished_at.
+        scenario.candidates.groupBy { it.finishedAt }.forEach { (finishedAt, candidates) ->
+            val sessionUuid = Uuid.random()
+            sessionUuidByFinishedAt[finishedAt] = sessionUuid
+            env.sessionDao.insert(
+                SessionEntity(
+                    uuid = sessionUuid,
+                    trainingUuid = trainingUuid,
+                    state = state,
+                    startedAt = 0L,
+                    finishedAt = if (state == SessionStateEntity.FINISHED) finishedAt else null,
+                ),
+            )
+            val performedUuid = Uuid.random()
+            env.performedExerciseDao.insert(
+                listOf(
+                    PerformedExerciseEntity(
+                        uuid = performedUuid,
+                        sessionUuid = sessionUuid,
+                        exerciseUuid = exerciseUuid,
+                        position = 0,
+                        skipped = false,
+                    ),
+                ),
+            )
+            candidates.forEach { candidate ->
+                val setUuid = Uuid.random()
+                setUuidByLabel[candidate.label] = setUuid
+                env.setDao.insert(
+                    SetEntity(
+                        uuid = setUuid,
+                        performedExerciseUuid = performedUuid,
+                        position = candidate.position,
+                        reps = candidate.reps,
+                        weight = candidate.weight,
+                        type = SetTypeEntity.WORK,
+                    ),
+                )
+            }
+        }
+
+        return Seeded(
+            scenario = scenario,
+            exerciseUuid = exerciseUuid,
+            setUuidByLabel = setUuidByLabel,
+            sessionUuidByFinishedAt = sessionUuidByFinishedAt,
+        )
+    }
+
+    /** Flips every session seeded for [seeded] to FINISHED at its candidate's `finishedAt`. */
+    suspend fun finishAllSessions(seeded: Seeded) {
+        seeded.sessionUuidByFinishedAt.forEach { (finishedAt, sessionUuid) ->
+            env.sessionDao.finishSession(uuid = sessionUuid, finishedAt = finishedAt)
+        }
+    }
+}

--- a/core/data/database/src/testFixtures/kotlin/io/github/stslex/workeeper/core/data/database/testfixtures/PrRuleFixture.kt
+++ b/core/data/database/src/testFixtures/kotlin/io/github/stslex/workeeper/core/data/database/testfixtures/PrRuleFixture.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.database.testfixtures
+
+import org.jetbrains.annotations.TestOnly
+
+/**
+ * The one description of "which set holds the record", as data.
+ *
+ * Five places decide this — `SessionDao.getPersonalRecord`, `SessionDao.observePersonalRecord`,
+ * `SessionDao.observePersonalRecordsBatch` (via `PersonalRecordRepositoryImpl`),
+ * `PrComparator`, and `ChartFolder`'s day-winner. They are in three different modules and
+ * cannot share an implementation. They can share a fixture, and that is what this is: every
+ * site is fed [SCENARIOS] and must name [PrScenario.expectedHolder].
+ *
+ * Deliberately plain data — no Room, no Android — so a module that has no database on its
+ * test classpath can still be held to the same answers.
+ *
+ * The fixture that matters most is [WEIGHTLESS_WITH_RESIDUAL_WEIGHTS]. Every pre-existing
+ * weightless test seeds `set_table.weight = null`, which is precisely the input on which the
+ * batch query and the single-exercise query happened to agree — so the disagreement survived
+ * for as long as it did. Residual weights on weightless rows exist in the wild (`set_table`
+ * carries no type-conditional constraint) and there is no migration scrubbing them.
+ */
+@TestOnly
+object PrRuleFixture {
+
+    /**
+     * One candidate set. [finishedAt] doubles as the session key: candidates sharing a value
+     * belong to the same session, which is how [position] becomes reachable as a tiebreak.
+     */
+    data class PrCandidate(
+        val label: String,
+        val weight: Double?,
+        val reps: Int,
+        val position: Int,
+        val finishedAt: Long,
+    )
+
+    /**
+     * [candidates] are listed in canonical comparison order — `finishedAt` ascending, then
+     * `position` ascending. Sites that cannot see a timestamp (`PrComparator`) resolve ties
+     * by list order, so the list order has to be the order the rule would impose.
+     */
+    data class PrScenario(
+        val name: String,
+        val isWeightless: Boolean,
+        val candidates: List<PrCandidate>,
+        /** Label of the set that must hold the record, or null when nothing is eligible. */
+        val expectedHolder: String?,
+        val why: String,
+    )
+
+    val WEIGHTLESS_WITH_RESIDUAL_WEIGHTS = PrScenario(
+        name = "weightless exercise carrying residual set weights",
+        isWeightless = true,
+        candidates = listOf(
+            PrCandidate("residual-weight-8-reps", weight = 50.0, reps = 8, position = 0, finishedAt = 3_000L),
+            PrCandidate("no-weight-12-reps", weight = null, reps = 12, position = 0, finishedAt = 4_000L),
+        ),
+        expectedHolder = "no-weight-12-reps",
+        why = "A weightless exercise is ranked on reps alone. A stray weight on the row is " +
+            "not a reason to promote it above a set with more reps.",
+    )
+
+    val WEIGHT_TIE_BROKEN_BY_REPS = PrScenario(
+        name = "equal weight, more reps wins",
+        isWeightless = false,
+        candidates = listOf(
+            PrCandidate("100kg-5-reps", weight = 100.0, reps = 5, position = 0, finishedAt = 1_000L),
+            PrCandidate("null-weight-20-reps", weight = null, reps = 20, position = 1, finishedAt = 1_000L),
+            PrCandidate("100kg-6-reps", weight = 100.0, reps = 6, position = 0, finishedAt = 2_000L),
+        ),
+        expectedHolder = "100kg-6-reps",
+        why = "Weight ties, so reps decide. The weight-null row is ineligible for a weighted " +
+            "exercise however many reps it logged.",
+    )
+
+    val TIE_BROKEN_BY_EARLIEST_FINISH = PrScenario(
+        name = "equal weight and reps, earliest session keeps it",
+        isWeightless = false,
+        candidates = listOf(
+            PrCandidate("first-session", weight = 80.0, reps = 5, position = 0, finishedAt = 5_000L),
+            PrCandidate("second-session", weight = 80.0, reps = 5, position = 0, finishedAt = 6_000L),
+        ),
+        expectedHolder = "first-session",
+        why = "The badge belongs to the first occurrence — repeating a record does not move it.",
+    )
+
+    val TIE_BROKEN_BY_POSITION = PrScenario(
+        name = "identical sets in one session, lowest position keeps it",
+        isWeightless = false,
+        candidates = listOf(
+            PrCandidate("position-0", weight = 90.0, reps = 5, position = 0, finishedAt = 7_000L),
+            PrCandidate("position-1", weight = 90.0, reps = 5, position = 1, finishedAt = 7_000L),
+        ),
+        expectedHolder = "position-0",
+        why = "Same session, so finished_at cannot separate them; position is the last criterion.",
+    )
+
+    val ZERO_REP_SET_IS_NOT_A_RECORD = PrScenario(
+        name = "a zero-rep set holds nothing however heavy",
+        isWeightless = false,
+        candidates = listOf(
+            PrCandidate("200kg-0-reps", weight = 200.0, reps = 0, position = 0, finishedAt = 8_000L),
+            PrCandidate("100kg-5-reps", weight = 100.0, reps = 5, position = 1, finishedAt = 8_000L),
+        ),
+        expectedHolder = "100kg-5-reps",
+        why = "A loaded bar that was never lifted is not a record. reps > 0 is eligibility, " +
+            "not a tiebreak.",
+    )
+
+    val WEIGHTED_WITH_NO_WEIGHTS_HAS_NO_RECORD = PrScenario(
+        name = "weighted exercise whose sets all lack a weight",
+        isWeightless = false,
+        candidates = listOf(
+            PrCandidate("null-weight-10-reps", weight = null, reps = 10, position = 0, finishedAt = 9_000L),
+        ),
+        expectedHolder = null,
+        why = "Nothing is eligible, so there is no holder — not a holder with a zero weight.",
+    )
+
+    val WEIGHTLESS_WITH_NO_REPS_HAS_NO_RECORD = PrScenario(
+        name = "weightless exercise whose only set logged zero reps",
+        isWeightless = true,
+        candidates = listOf(
+            PrCandidate("zero-reps", weight = null, reps = 0, position = 0, finishedAt = 10_000L),
+        ),
+        expectedHolder = null,
+        why = "Same eligibility floor applies without a weight to fall back on.",
+    )
+
+    val SCENARIOS: List<PrScenario> = listOf(
+        WEIGHTLESS_WITH_RESIDUAL_WEIGHTS,
+        WEIGHT_TIE_BROKEN_BY_REPS,
+        TIE_BROKEN_BY_EARLIEST_FINISH,
+        TIE_BROKEN_BY_POSITION,
+        ZERO_REP_SET_IS_NOT_A_RECORD,
+        WEIGHTED_WITH_NO_WEIGHTS_HAS_NO_RECORD,
+        WEIGHTLESS_WITH_NO_REPS_HAS_NO_RECORD,
+    )
+}

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepository.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepository.kt
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.core.data.exercise.personal_record
 
-import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -10,53 +9,34 @@ import kotlinx.coroutines.flow.Flow
  * the participating tables change. No manual cache; for one-shot freezes (Live workout
  * pre-session snapshot) collect with [kotlinx.coroutines.flow.firstOrNull] or call
  * [getPersonalRecord].
+ *
+ * None of these take an exercise type. Which sets are eligible and which one wins is decided
+ * once, in SQL, from `exercise_table.type` — see `SessionDao`'s `PR_ELIGIBILITY` /
+ * `PR_ORDER`. A caller-supplied type would be a second copy of that rule, free to go stale.
  */
 interface PersonalRecordRepository {
 
     /**
-     * Returns the heaviest set logged for [exerciseUuid] across finished sessions, or null
-     * when no finished session has logged the exercise yet. The aggregate respects [type]:
-     * weighted exercises sort by weight DESC then reps DESC; weightless exercises sort by
-     * reps DESC. Tiebreak: earliest `finished_at` wins.
+     * The record-holding set for [exerciseUuid], or null when no finished session has logged
+     * an eligible set yet.
      */
-    suspend fun getPersonalRecord(
-        exerciseUuid: String,
-        type: ExerciseTypeDataModel,
-    ): PersonalRecordDataModel?
+    suspend fun getPersonalRecord(exerciseUuid: String): PersonalRecordDataModel?
 
     /**
      * Reactive PR for a single exercise. Re-emits when finished-session sets for this
      * exercise change (Room handles invalidation). Subscribe in screens that should
      * stay live-updated; for one-shot freezes (e.g. Live workout pre-session snapshot)
-     * use [observePersonalRecords] + `firstOrNull()` or stick to [getPersonalRecord].
+     * use [observePersonalRecordsBatch] + `firstOrNull()` or stick to [getPersonalRecord].
      */
-    fun observePersonalRecord(
-        exerciseUuid: String,
-        type: ExerciseTypeDataModel,
-    ): Flow<PersonalRecordDataModel?>
+    fun observePersonalRecord(exerciseUuid: String): Flow<PersonalRecordDataModel?>
 
     /**
-     * Reactive PR map for a batch of exercises. Implemented via [kotlinx.coroutines.flow.combine]
-     * over per-exercise flows; downstream gets a fresh map each time any contributor emits.
-     * The map's keyset matches [uuidsByType] exactly; values are nullable when the exercise
-     * has no PR yet.
-     *
-     * Suitable only for **one-shot** uses (e.g. `firstOrNull()` to freeze a snapshot at session
-     * load); long-lived subscribers should use [observePersonalRecordsBatch] / [observePrSetUuids]
-     * to avoid the combine-of-N amplification that fires N per-entity Flows on every relevant
-     * table change.
-     */
-    fun observePersonalRecords(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
-    ): Flow<Map<String, PersonalRecordDataModel?>>
-
-    /**
-     * Long-lived batch variant of [observePersonalRecords]. Backed by a single Room query with
-     * `IN (:uuids)`; one subscription, one query plan, one cursor. Re-emits when any participating
-     * table changes. Values are non-null — exercises with no PR yet are simply absent from the map.
+     * Batch PR map. Backed by a single Room query with `IN (:uuids)`; one subscription, one
+     * query plan, one cursor. Re-emits when any participating table changes. Values are
+     * non-null — exercises with no PR yet are simply absent from the map.
      */
     fun observePersonalRecordsBatch(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
+        exerciseUuids: Set<String>,
     ): Flow<Map<String, PersonalRecordDataModel>>
 
     /**
@@ -64,7 +44,5 @@ interface PersonalRecordRepository {
      * consumers (e.g. Past session) that need set-uuid equality for badge rendering and never
      * read other PR fields, so the heavier model never crosses the boundary.
      */
-    fun observePrSetUuids(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
-    ): Flow<Set<String>>
+    fun observePrSetUuids(exerciseUuids: Set<String>): Flow<Set<String>>
 }

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepositoryImpl.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepositoryImpl.kt
@@ -8,11 +8,9 @@ import io.github.stslex.workeeper.core.core.di.AppScope
 import io.github.stslex.workeeper.core.core.di.IODispatcher
 import io.github.stslex.workeeper.core.data.database.session.PersonalRecordRow
 import io.github.stslex.workeeper.core.data.database.session.SessionDao
-import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.SetsDataType.Companion.toData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -28,56 +26,35 @@ class PersonalRecordRepositoryImpl @Inject internal constructor(
 
     override suspend fun getPersonalRecord(
         exerciseUuid: String,
-        type: ExerciseTypeDataModel,
     ): PersonalRecordDataModel? = withContext(ioDispatcher) {
-        sessionDao
-            .getPersonalRecord(
-                exerciseUuid = Uuid.parse(exerciseUuid),
-                isWeightless = type == ExerciseTypeDataModel.WEIGHTLESS,
-            )
-            ?.toData()
+        sessionDao.getPersonalRecord(Uuid.parse(exerciseUuid))?.toData()
     }
 
     override fun observePersonalRecord(
         exerciseUuid: String,
-        type: ExerciseTypeDataModel,
     ): Flow<PersonalRecordDataModel?> = sessionDao
-        .observePersonalRecord(
-            exerciseUuid = Uuid.parse(exerciseUuid),
-            isWeightless = type == ExerciseTypeDataModel.WEIGHTLESS,
-        )
+        .observePersonalRecord(Uuid.parse(exerciseUuid))
         .map { it?.toData() }
         .flowOn(ioDispatcher)
 
-    override fun observePersonalRecords(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
-    ): Flow<Map<String, PersonalRecordDataModel?>> {
-        if (uuidsByType.isEmpty()) return flowOf(emptyMap())
-        val perExerciseFlows: List<Flow<Pair<String, PersonalRecordDataModel?>>> =
-            uuidsByType.map { (uuid, type) ->
-                observePersonalRecord(uuid, type).map { uuid to it }
-            }
-        return combine(perExerciseFlows) { pairs -> pairs.toMap() }
-    }
-
     override fun observePersonalRecordsBatch(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
+        exerciseUuids: Set<String>,
     ): Flow<Map<String, PersonalRecordDataModel>> {
-        if (uuidsByType.isEmpty()) return flowOf(emptyMap())
+        if (exerciseUuids.isEmpty()) return flowOf(emptyMap())
         return sessionDao
-            .observePersonalRecordsBatch(uuidsByType.keys.map(Uuid::parse))
-            .map { rows -> rows.toBestPerExercise(uuidsByType) }
+            .observePersonalRecordsBatch(exerciseUuids.map(Uuid::parse))
+            .map { rows -> rows.toBestPerExercise() }
             .flowOn(ioDispatcher)
     }
 
     override fun observePrSetUuids(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
+        exerciseUuids: Set<String>,
     ): Flow<Set<String>> {
-        if (uuidsByType.isEmpty()) return flowOf(emptySet())
+        if (exerciseUuids.isEmpty()) return flowOf(emptySet())
         return sessionDao
-            .observePersonalRecordsBatch(uuidsByType.keys.map(Uuid::parse))
+            .observePersonalRecordsBatch(exerciseUuids.map(Uuid::parse))
             .map { rows ->
-                rows.toBestPerExercise(uuidsByType)
+                rows.toBestPerExercise()
                     .values
                     .map { it.setUuid }
                     .toSet()
@@ -86,20 +63,14 @@ class PersonalRecordRepositoryImpl @Inject internal constructor(
     }
 
     /**
-     * The DAO returns all candidate sets ordered with the heaviest-first within each exercise
-     * group. The `IN (:uuids)` query cannot encode the per-exercise `(:isWeightless = 1 OR
-     * weight IS NOT NULL)` predicate, so we filter weighted exercises' weight-null rows here
-     * — a weighted exercise's PR cannot be a weightless set.
+     * The DAO already returns only eligible candidates, best-first within each exercise group,
+     * so picking the holder is `.first()` per group and nothing else. Do not reintroduce a
+     * filter here: eligibility lives in SQL, and a second copy of half the rule in this module
+     * is exactly how the batch path came to disagree with the single-exercise path.
      */
-    private fun List<PersonalRecordRow>.toBestPerExercise(
-        uuidsByType: Map<String, ExerciseTypeDataModel>,
-    ): Map<String, PersonalRecordDataModel> = asSequence()
-        .filter { row ->
-            val type = uuidsByType[row.exerciseUuid.toString()] ?: return@filter false
-            type == ExerciseTypeDataModel.WEIGHTLESS || row.weight != null
-        }
-        .groupBy { it.exerciseUuid.toString() }
-        .mapValues { (_, group) -> group.first().toData() }
+    private fun List<PersonalRecordRow>.toBestPerExercise(): Map<String, PersonalRecordDataModel> =
+        groupBy { it.exerciseUuid.toString() }
+            .mapValues { (_, group) -> group.first().toData() }
 
     private fun PersonalRecordRow.toData(): PersonalRecordDataModel = PersonalRecordDataModel(
         sessionUuid = sessionUuid.toString(),

--- a/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/sets/PrComparator.kt
+++ b/core/data/exercise/src/main/kotlin/io/github/stslex/workeeper/core/data/exercise/sets/PrComparator.kt
@@ -6,17 +6,37 @@ import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseType
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordDataModel
 
 /**
- * Pure-function PR comparator. Mirrors the SQL `ORDER BY` in
- * `SessionDao.observePersonalRecord`; used at session finish where the comparison happens
- * against an in-memory snapshot rather than re-running the DAO query.
+ * The in-memory arm of the PR rule, used at session finish and for the live per-set badge —
+ * both compare against a snapshot rather than re-running the DAO query, because the sets in
+ * question belong to a session that has not finished yet and so are invisible to SQL.
  *
- * Parity with the SQL path is asserted by `PrComparatorTest` against a Room in-memory DB.
+ * The rule it implements is the one in `SessionDao`'s `PR_ELIGIBILITY` / `PR_ORDER`:
+ *
+ *  - eligible iff `reps > 0`, and the exercise is WEIGHTLESS or the set carries a weight;
+ *  - ordered by weight DESC (WEIGHTED only), then reps DESC, then `finished_at` ASC, then
+ *    `position` ASC.
+ *
+ * Two criteria collapse here rather than being dropped:
+ *
+ *  - **`finished_at` ASC.** Every candidate this object sees belongs to the same unfinished
+ *    session, so they share a `finished_at` and the criterion cannot separate them *within*
+ *    [bestOf]. Across the snapshot boundary it is what makes [beats] strict: the live session
+ *    finishes after every session already recorded, so its `finished_at` is the largest, and
+ *    ties therefore go to the incumbent. `>` is not a second rule — it is criterion (3)
+ *    applied to a set whose timestamp is guaranteed to lose.
+ *  - **`position` ASC.** [bestOf] returns the first maximal element, so a tie is resolved in
+ *    favour of the earlier list entry. That is criterion (4) **only if the caller's list is
+ *    ordered by position** — see the precondition on [bestOf].
+ *
+ * Agreement with the SQL path is asserted by `PrRuleParityTest` in `core/data/exercise`,
+ * which runs one fixture through every PR site — this object, both single-exercise queries,
+ * the batch query, and the repository — and requires them to name the same set.
  */
 object PrComparator {
 
     /**
-     * True if [candidate] strictly beats [baseline] for an exercise of [type].
-     * `null` baseline means no PR exists yet — any non-zero candidate beats it.
+     * True if [candidate] would take the record from [baseline] for an exercise of [type].
+     * A null [baseline] means no PR exists yet — any *eligible* candidate takes it.
      */
     fun beats(
         candidate: PlanSetDataModel,
@@ -33,9 +53,10 @@ object PrComparator {
     /**
      * Primitive-baseline overload used by surfaces that store the snapshot as plain values
      * rather than a [PersonalRecordDataModel] (e.g. `LiveWorkoutStore.State.PrSnapshotItem`).
-     * [hasBaseline] distinguishes "no PR yet" from "PR with null weight" — important for
-     * weighted exercises where a null baseline weight (no PR) and a real-but-null-weighted
-     * PR are different states.
+     * [hasBaseline] carries the one bit the nullable values cannot: whether a PR exists at
+     * all. For a WEIGHTED exercise a real PR always has a weight — eligibility excludes
+     * weight-null rows — so `hasBaseline = true` with a null [baselineWeight] is a state no
+     * caller can produce; it is coerced to 0.0 only to keep the function total.
      */
     fun beats(
         candidate: PlanSetDataModel,
@@ -43,35 +64,47 @@ object PrComparator {
         baselineReps: Int?,
         type: ExerciseTypeDataModel,
         hasBaseline: Boolean,
-    ): Boolean = when (type) {
-        ExerciseTypeDataModel.WEIGHTED -> beatsWeighted(candidate, baselineWeight, baselineReps, hasBaseline)
-        ExerciseTypeDataModel.WEIGHTLESS -> beatsWeightless(candidate, baselineReps, hasBaseline)
+    ): Boolean {
+        if (!candidate.isEligible(type)) return false
+        if (!hasBaseline) return true
+        return when (type) {
+            ExerciseTypeDataModel.WEIGHTED -> beatsWeighted(candidate, baselineWeight, baselineReps)
+            ExerciseTypeDataModel.WEIGHTLESS -> candidate.reps > (baselineReps ?: 0)
+        }
     }
 
     /**
-     * Picks the best set in [sets] for an exercise of [type]. Returns null if [sets] is empty
-     * or none of the candidates qualify (e.g. weighted exercise with all weight-null sets).
-     * "Best" follows the same ordering as the SQL PR query.
+     * Picks the record-holding set among [sets] for an exercise of [type], or null when none
+     * is eligible (all weight-null for a WEIGHTED exercise, all zero-rep, or empty).
+     *
+     * **Precondition: [sets] is ordered by set position, ascending.** Ties are broken in
+     * favour of the earlier entry, which is criterion (4) of the rule only under that
+     * ordering. The sole caller satisfies it: the list originates from
+     * `SetDao.getByPerformedExercises` (`ORDER BY performed_exercise_uuid, position ASC`) and
+     * every state transition that rewrites it preserves position order — replacement in
+     * place, append-then-`sortBy(position)`, `filterNot`, or `map`.
      */
     fun bestOf(
         sets: List<PlanSetDataModel>,
         type: ExerciseTypeDataModel,
-    ): PlanSetDataModel? = when (type) {
-        ExerciseTypeDataModel.WEIGHTED ->
-            sets
-                .filter { it.weight != null }
-                .maxWithOrNull(WEIGHTED_COMPARATOR)
-        ExerciseTypeDataModel.WEIGHTLESS -> sets.maxByOrNull { it.reps }
-    }
+    ): PlanSetDataModel? = sets
+        .filter { it.isEligible(type) }
+        .maxWithOrNull(comparatorFor(type))
+
+    /**
+     * Shared eligibility: the in-memory half of `SessionDao.PR_ELIGIBILITY`. The session-state
+     * clauses have no counterpart here — these sets are in an unfinished session by
+     * construction.
+     */
+    private fun PlanSetDataModel.isEligible(type: ExerciseTypeDataModel): Boolean =
+        reps > 0 && (type == ExerciseTypeDataModel.WEIGHTLESS || weight != null)
 
     private fun beatsWeighted(
         candidate: PlanSetDataModel,
         baselineWeight: Double?,
         baselineReps: Int?,
-        hasBaseline: Boolean,
     ): Boolean {
         val candidateWeight = candidate.weight ?: return false
-        if (!hasBaseline) return candidateWeight > 0.0 || candidate.reps > 0
         val resolvedBaselineWeight = baselineWeight ?: 0.0
         return when {
             candidateWeight > resolvedBaselineWeight -> true
@@ -80,17 +113,21 @@ object PrComparator {
         }
     }
 
-    private fun beatsWeightless(
-        candidate: PlanSetDataModel,
-        baselineReps: Int?,
-        hasBaseline: Boolean,
-    ): Boolean {
-        if (!hasBaseline) return candidate.reps > 0
-        return candidate.reps > (baselineReps ?: 0)
+    private fun comparatorFor(
+        type: ExerciseTypeDataModel,
+    ): Comparator<PlanSetDataModel> = when (type) {
+        ExerciseTypeDataModel.WEIGHTED -> WEIGHTED_COMPARATOR
+        ExerciseTypeDataModel.WEIGHTLESS -> WEIGHTLESS_COMPARATOR
     }
 
     private val WEIGHTED_COMPARATOR: Comparator<PlanSetDataModel> = compareBy(
+        // Eligibility already dropped the weight-null rows; the elvis is unreachable and
+        // exists only because the model types weight as nullable for both exercise kinds.
         { it.weight ?: 0.0 },
         { it.reps },
     )
+
+    /** Weight drops out entirely, mirroring the `CASE WHEN e.type = 'WEIGHTED'` in SQL. */
+    private val WEIGHTLESS_COMPARATOR: Comparator<PlanSetDataModel> =
+        compareBy { it.reps }
 }

--- a/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepositoryImplDbTest.kt
+++ b/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PersonalRecordRepositoryImplDbTest.kt
@@ -10,7 +10,6 @@ import io.github.stslex.workeeper.core.data.database.session.model.SetEntity
 import io.github.stslex.workeeper.core.data.database.session.model.SetTypeEntity
 import io.github.stslex.workeeper.core.data.database.testfixtures.RepositoryTestEnv
 import io.github.stslex.workeeper.core.data.database.training.TrainingEntity
-import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -53,10 +52,7 @@ internal class PersonalRecordRepositoryImplDbTest {
         seedFinishedSet(trainingUuid, exerciseUuid, weight = 100.0, reps = 5, finishedAt = 2_000L)
         seedFinishedSet(trainingUuid, exerciseUuid, weight = 100.0, reps = 4, finishedAt = 3_000L)
 
-        val pr = repository.getPersonalRecord(
-            exerciseUuid = exerciseUuid.toString(),
-            type = ExerciseTypeDataModel.WEIGHTED,
-        )
+        val pr = repository.getPersonalRecord(exerciseUuid.toString())
 
         assertEquals(100.0, pr?.weight)
         // Reps DESC tiebreaker: 5 reps wins over 4 reps when weight is equal.
@@ -71,10 +67,7 @@ internal class PersonalRecordRepositoryImplDbTest {
         seedFinishedSet(trainingUuid, exerciseUuid, weight = null, reps = 8, finishedAt = 1_000L)
         seedFinishedSet(trainingUuid, exerciseUuid, weight = null, reps = 12, finishedAt = 2_000L)
 
-        val pr = repository.getPersonalRecord(
-            exerciseUuid = exerciseUuid.toString(),
-            type = ExerciseTypeDataModel.WEIGHTLESS,
-        )
+        val pr = repository.getPersonalRecord(exerciseUuid.toString())
 
         assertEquals(12, pr?.reps)
         assertNull(pr?.weight)
@@ -85,10 +78,7 @@ internal class PersonalRecordRepositoryImplDbTest {
         runTest {
             val (_, exerciseUuid) = seedTrainingAndExercise()
 
-            val pr = repository.getPersonalRecord(
-                exerciseUuid = exerciseUuid.toString(),
-                type = ExerciseTypeDataModel.WEIGHTED,
-            )
+            val pr = repository.getPersonalRecord(exerciseUuid.toString())
 
             assertNull(pr)
         }
@@ -98,23 +88,20 @@ internal class PersonalRecordRepositoryImplDbTest {
         val (trainingUuid, exerciseUuid) = seedTrainingAndExercise()
         seedFinishedSet(trainingUuid, exerciseUuid, weight = 100.0, reps = 5, finishedAt = 1_000L)
 
-        val pr = repository.observePersonalRecord(
-            exerciseUuid = exerciseUuid.toString(),
-            type = ExerciseTypeDataModel.WEIGHTED,
-        ).first()
+        val pr = repository.observePersonalRecord(exerciseUuid.toString()).first()
 
         assertEquals(100.0, pr?.weight)
     }
 
     @Test
-    fun `observePersonalRecords with empty input emits an empty map`() = runTest {
-        val map = repository.observePersonalRecords(emptyMap()).first()
+    fun `observePersonalRecordsBatch with empty input emits an empty map`() = runTest {
+        val map = repository.observePersonalRecordsBatch(emptySet()).first()
 
         assertTrue(map.isEmpty())
     }
 
     @Test
-    fun `observePersonalRecords returns one PR per requested exercise`() = runTest {
+    fun `observePersonalRecordsBatch returns one PR per requested exercise`() = runTest {
         val (trainingUuid, weightedUuid) = seedTrainingAndExercise()
         val weightlessUuid = Uuid.random()
         env.exerciseDao.insert(
@@ -139,11 +126,8 @@ internal class PersonalRecordRepositoryImplDbTest {
             finishedAt = 2_000L,
         )
 
-        val records = repository.observePersonalRecords(
-            uuidsByType = mapOf(
-                weightedUuid.toString() to ExerciseTypeDataModel.WEIGHTED,
-                weightlessUuid.toString() to ExerciseTypeDataModel.WEIGHTLESS,
-            ),
+        val records = repository.observePersonalRecordsBatch(
+            setOf(weightedUuid.toString(), weightlessUuid.toString()),
         ).first()
 
         assertEquals(2, records.size)
@@ -179,10 +163,7 @@ internal class PersonalRecordRepositoryImplDbTest {
         )
 
         val records = repository.observePersonalRecordsBatch(
-            uuidsByType = mapOf(
-                weightedUuid.toString() to ExerciseTypeDataModel.WEIGHTED,
-                secondExerciseUuid.toString() to ExerciseTypeDataModel.WEIGHTED,
-            ),
+            setOf(weightedUuid.toString(), secondExerciseUuid.toString()),
         ).first()
 
         assertEquals(100.0, records[weightedUuid.toString()]?.weight)
@@ -210,9 +191,7 @@ internal class PersonalRecordRepositoryImplDbTest {
             setUuid = prSetUuid,
         )
 
-        val ids = repository.observePrSetUuids(
-            uuidsByType = mapOf(exerciseUuid.toString() to ExerciseTypeDataModel.WEIGHTED),
-        ).first()
+        val ids = repository.observePrSetUuids(setOf(exerciseUuid.toString())).first()
 
         assertEquals(setOf(prSetUuid.toString()), ids)
     }

--- a/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PrRuleParityTest.kt
+++ b/core/data/exercise/src/test/kotlin/io/github/stslex/workeeper/core/data/exercise/personal_record/PrRuleParityTest.kt
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.data.exercise.personal_record
+
+import io.github.stslex.workeeper.core.data.database.session.SessionStateEntity
+import io.github.stslex.workeeper.core.data.database.sets.PlanSetDataModel
+import io.github.stslex.workeeper.core.data.database.sets.SetTypeDataModel
+import io.github.stslex.workeeper.core.data.database.testfixtures.PrRuleDbSeeder
+import io.github.stslex.workeeper.core.data.database.testfixtures.PrRuleFixture
+import io.github.stslex.workeeper.core.data.database.testfixtures.RepositoryTestEnv
+import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
+import io.github.stslex.workeeper.core.data.exercise.sets.PrComparator
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import kotlin.uuid.Uuid
+
+/**
+ * One fixture, every PR site, one answer.
+ *
+ * `PrComparator`'s KDoc used to claim a test like this existed. It did not, and that is the
+ * direct reason the batch query and the single-exercise query were allowed to disagree about
+ * weightless exercises for as long as they did. This is the guard that was being claimed.
+ *
+ * Each scenario in [PrRuleFixture] is run through:
+ *
+ *  - **S1** `SessionDao.getPersonalRecord` — one-shot single-exercise query
+ *  - **S2** `SessionDao.observePersonalRecord` — reactive single-exercise query
+ *  - **S3** `SessionDao.observePersonalRecordsBatch`, through
+ *    `PersonalRecordRepositoryImpl.observePersonalRecordsBatch` and `observePrSetUuids` —
+ *    the repository is what turns candidate rows into a holder, so it is part of the site
+ *  - **S4** `PrComparator.bestOf` — the in-memory arm
+ *
+ * `ChartFolder`'s day-winner is the fifth site. It lives in `feature/exercise-chart`, which
+ * has no database on its test classpath, so it is held to the same [PrRuleFixture] scenarios
+ * by `ChartFolderPrRuleParityTest` over there.
+ *
+ * S4 is asserted in two phases, because the SQL sites cannot see an unfinished session — which
+ * is the whole reason `PrComparator` exists. Sessions are seeded IN_PROGRESS; the SQL sites
+ * must return nothing while `PrComparator` already names the holder; then the sessions are
+ * finished and every SQL site must arrive at that same set.
+ */
+@ExtendWith(RobolectricExtension::class)
+@Config(application = RepositoryTestEnv.TestApplication::class, sdk = [33])
+internal class PrRuleParityTest {
+
+    private lateinit var env: RepositoryTestEnv
+    private lateinit var seeder: PrRuleDbSeeder
+    private lateinit var repository: PersonalRecordRepositoryImpl
+
+    @BeforeEach
+    fun setup() {
+        env = RepositoryTestEnv()
+        seeder = PrRuleDbSeeder(env)
+        repository = PersonalRecordRepositoryImpl(
+            sessionDao = env.sessionDao,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        env.close()
+    }
+
+    @Test
+    fun `every PR site names the same set`() = runTest {
+        PrRuleFixture.SCENARIOS.forEach { scenario -> assertAllSitesAgree(scenario) }
+    }
+
+    private suspend fun assertAllSitesAgree(scenario: PrRuleFixture.PrScenario) {
+        val where = "[${scenario.name}] ${scenario.why}"
+        val seeded = seeder.seed(scenario, state = SessionStateEntity.IN_PROGRESS)
+        val exerciseUuid = seeded.exerciseUuid
+        val type = if (scenario.isWeightless) {
+            ExerciseTypeDataModel.WEIGHTLESS
+        } else {
+            ExerciseTypeDataModel.WEIGHTED
+        }
+
+        // Phase 1 — the session is still running, so SQL is blind to it by design.
+        assertNull(
+            env.sessionDao.getPersonalRecord(exerciseUuid),
+            "$where — S1 must not award a record from an unfinished session",
+        )
+        assertNull(
+            env.sessionDao.observePersonalRecord(exerciseUuid).first(),
+            "$where — S2 must not award a record from an unfinished session",
+        )
+        assertTrue(
+            env.sessionDao.observePersonalRecordsBatch(listOf(exerciseUuid)).first().isEmpty(),
+            "$where — S3 must not award a record from an unfinished session",
+        )
+
+        // S4 answers now, from in-memory candidates, and its answer is the one the SQL sites
+        // have to reach once the session lands.
+        val planSets = scenario.candidates.map { it.toPlanSet() }
+        val best = PrComparator.bestOf(planSets, type)
+        // Identity, not equality: the tie scenarios contain candidates that are equal on
+        // (weight, reps), so comparing values would pass whichever one was returned.
+        val bestLabel = planSets
+            .indexOfFirst { it === best }
+            .takeIf { it >= 0 }
+            ?.let { scenario.candidates[it].label }
+        assertEquals(scenario.expectedHolder, bestLabel, "$where — S4 PrComparator.bestOf")
+
+        // Phase 2 — the session finishes; every SQL site must now name that same set.
+        seeder.finishAllSessions(seeded)
+        val expected = seeded.expectedHolderSetUuid
+
+        assertEquals(
+            expected,
+            env.sessionDao.getPersonalRecord(exerciseUuid)?.setUuid,
+            "$where — S1 SessionDao.getPersonalRecord",
+        )
+        assertEquals(
+            expected,
+            env.sessionDao.observePersonalRecord(exerciseUuid).first()?.setUuid,
+            "$where — S2 SessionDao.observePersonalRecord",
+        )
+        assertEquals(
+            expected,
+            repository.observePersonalRecordsBatch(setOf(exerciseUuid.toString()))
+                .first()[exerciseUuid.toString()]
+                ?.setUuid
+                ?.let(Uuid::parse),
+            "$where — S3 observePersonalRecordsBatch via the repository",
+        )
+        assertEquals(
+            setOfNotNull(expected?.toString()),
+            repository.observePrSetUuids(setOf(exerciseUuid.toString())).first(),
+            "$where — S3 observePrSetUuids via the repository",
+        )
+    }
+
+    @Test
+    fun `a residual weight on a weightless row does not promote it in the batch query`() = runTest {
+        // The regression this change exists for: the batch query used to sort weight-null rows
+        // last and then order by weight DESC, so a weightless exercise's badge landed on
+        // whichever set happened to carry a stray weight rather than on the rep record.
+        val scenario = PrRuleFixture.WEIGHTLESS_WITH_RESIDUAL_WEIGHTS
+        val seeded = seeder.seed(scenario, state = SessionStateEntity.FINISHED)
+
+        val rows = env.sessionDao.observePersonalRecordsBatch(listOf(seeded.exerciseUuid)).first()
+
+        assertEquals(
+            listOf("no-weight-12-reps", "residual-weight-8-reps"),
+            rows.map { seeded.labelOf(it.setUuid) },
+            "batch candidates must come back rep-ordered, best first — the stray 50kg row loses",
+        )
+    }
+
+    @Test
+    fun `beats hands ties to the incumbent because a live session finishes last`() {
+        val equal = PlanSetDataModel(weight = 100.0, reps = 5, type = SetTypeDataModel.WORK)
+        val better = PlanSetDataModel(weight = 100.0, reps = 6, type = SetTypeDataModel.WORK)
+        val zeroRep = PlanSetDataModel(weight = 500.0, reps = 0, type = SetTypeDataModel.WORK)
+
+        assertFalse(
+            PrComparator.beats(
+                candidate = equal,
+                baselineWeight = 100.0,
+                baselineReps = 5,
+                type = ExerciseTypeDataModel.WEIGHTED,
+                hasBaseline = true,
+            ),
+            "equalling the record does not take it — the live session's finished_at is the largest",
+        )
+        assertTrue(
+            PrComparator.beats(
+                candidate = better,
+                baselineWeight = 100.0,
+                baselineReps = 5,
+                type = ExerciseTypeDataModel.WEIGHTED,
+                hasBaseline = true,
+            ),
+        )
+        assertFalse(
+            PrComparator.beats(
+                candidate = zeroRep,
+                baselineWeight = null,
+                baselineReps = null,
+                type = ExerciseTypeDataModel.WEIGHTED,
+                hasBaseline = false,
+            ),
+            "a zero-rep set is ineligible, so it cannot open an empty record either",
+        )
+    }
+
+    private fun PrRuleFixture.PrCandidate.toPlanSet(): PlanSetDataModel = PlanSetDataModel(
+        weight = weight,
+        reps = reps,
+        type = SetTypeDataModel.WORK,
+    )
+}

--- a/feature/exercise-chart/build.gradle.kts
+++ b/feature/exercise-chart/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(project(":core:data:exercise"))
 
     testImplementation(kotlin("test"))
+    // For PrRuleFixture only — the shared, DB-free description of which set holds a record.
+    // ChartFolder's day-winner is one of the five sites held to it; see
+    // ChartFolderPrRuleParityTest and core/data/exercise's PrRuleParityTest.
+    testImplementation(testFixtures(project(":core:data:database")))
 
     androidTestImplementation(libs.bundles.android.test)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)

--- a/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
+++ b/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
@@ -57,19 +57,29 @@ internal fun bucketAndFold(
         }
         .toList()
 
-    if (flat.isEmpty()) return ChartFoldDomain(
+    // Same eligibility as the PR rule (`SessionDao.PR_ELIGIBILITY`): a zero-rep set is not a
+    // data point, and for a WEIGHTED exercise a weight-null set is excluded rather than
+    // coerced to 0.0 — coercion invents a point at the bottom of the axis.
+    val eligible = flat.filter { it.isEligible(exerciseType) }
+
+    if (eligible.isEmpty()) return ChartFoldDomain(
         points = emptyList(),
         footer = null,
         windowStartDay = null,
         windowEndDay = null,
     )
 
-    // The earliest finishedAt wins on tie, matching the v2.1 PR semantics.
+    // Which set represents the day, ordered as `SessionDao.PR_ORDER`: the metric first (that
+    // is what the axis plots), then reps DESC, then earliest finishedAt. Position ASC is the
+    // last criterion and comes for free — `sortedWith` is stable and each session's sets
+    // arrive in position order from `SessionDao.getHistoryByExercise`.
     val foldComparator = compareByDescending<FlatSet> { f ->
         metricValue(f, metric, exerciseType)
-    }.thenBy(FlatSet::finishedAt)
+    }
+        .thenByDescending(FlatSet::reps)
+        .thenBy(FlatSet::finishedAt)
 
-    val pointsByDay = flat
+    val pointsByDay = eligible
         .groupBy(FlatSet::day)
         .map { (_, dailySets) ->
             val winner = dailySets.sortedWith(foldComparator).first()
@@ -127,14 +137,38 @@ private fun computeWindow(
     }
 }
 
+/**
+ * A set is plottable under the same rule that makes it PR-eligible, minus the session-state
+ * clauses the history query has already applied.
+ */
+private fun FlatSet.isEligible(type: ExerciseTypeDomain): Boolean =
+    reps > 0 && (type == ExerciseTypeDomain.WEIGHTLESS || weight != null)
+
+/**
+ * Branches on the metric first, then on what that metric can mean for the exercise type — the
+ * other way round reads as if the type silences the metric.
+ *
+ * For a WEIGHTLESS exercise both metrics genuinely collapse to reps: there is no weight to be
+ * heaviest, and per-set volume with an unknown constant bodyweight is reps up to that
+ * constant. Nothing is lost by the collapse, and the metric toggle is not offered for those
+ * exercises anyway (`ExerciseChartStore.State.showMetricToggle`).
+ *
+ * `weight` is non-null here: [isEligible] dropped weight-null rows for WEIGHTED exercises
+ * before this is ever called.
+ */
 private fun metricValue(
     set: FlatSet,
     metric: ChartMetricDomain,
     type: ExerciseTypeDomain,
-): Double = when {
-    type == ExerciseTypeDomain.WEIGHTLESS -> set.reps.toDouble()
-    metric == ChartMetricDomain.HEAVIEST_WEIGHT -> set.weight ?: 0.0
-    else -> (set.weight ?: 0.0) * set.reps
+): Double = when (metric) {
+    ChartMetricDomain.HEAVIEST_WEIGHT -> when (type) {
+        ExerciseTypeDomain.WEIGHTLESS -> set.reps.toDouble()
+        ExerciseTypeDomain.WEIGHTED -> set.weight ?: 0.0
+    }
+    ChartMetricDomain.VOLUME_PER_SET -> when (type) {
+        ExerciseTypeDomain.WEIGHTLESS -> set.reps.toDouble()
+        ExerciseTypeDomain.WEIGHTED -> (set.weight ?: 0.0) * set.reps
+    }
 }
 
 private fun List<ChartPointDomain>.toFooter(): ChartFooterStatsDomain? {

--- a/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
+++ b/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.feature.exercise_chart.domain
+
+import io.github.stslex.workeeper.core.data.database.testfixtures.PrRuleFixture
+import io.github.stslex.workeeper.feature.exercise_chart.domain.model.ChartMetricDomain
+import io.github.stslex.workeeper.feature.exercise_chart.domain.model.ChartPresetDomain
+import io.github.stslex.workeeper.feature.exercise_chart.domain.model.ExerciseTypeDomain
+import io.github.stslex.workeeper.feature.exercise_chart.domain.model.HistoryEntryDomain
+import io.github.stslex.workeeper.feature.exercise_chart.domain.model.HistorySetDomain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+
+/**
+ * The fifth PR site. `ChartFolder` picks one set to represent a day, and that choice is the
+ * same question the four data-layer sites answer — so it is held to the same scenarios, from
+ * the same [PrRuleFixture], as `PrRuleParityTest` in `core/data/exercise`. This module has no
+ * database on its test classpath, hence a separate test rather than a fifth arm over there;
+ * the fixture is shared, which is the part that matters.
+ *
+ * Every fixture timestamp falls on the same day, so each scenario folds to exactly one point
+ * and "the day's set" is "the record-holding set" — which is the parity claim.
+ *
+ * The metric is [ChartMetricDomain.HEAVIEST_WEIGHT] throughout, because that is the metric
+ * under which the chart's primary sort key *is* the PR rule's primary key. Under
+ * [ChartMetricDomain.VOLUME_PER_SET] the chart deliberately ranks by `weight × reps` instead;
+ * eligibility and the lower tiebreaks still apply, but the winner is not claimed to match.
+ */
+internal class ChartFolderPrRuleParityTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+
+    @Test
+    fun `the day's set is the record-holding set`() {
+        PrRuleFixture.SCENARIOS.forEach { scenario ->
+            val where = "[${scenario.name}] ${scenario.why}"
+            val fold = bucketAndFold(
+                history = scenario.toHistory(),
+                preset = ChartPresetDomain.ALL,
+                metric = ChartMetricDomain.HEAVIEST_WEIGHT,
+                exerciseType = if (scenario.isWeightless) {
+                    ExerciseTypeDomain.WEIGHTLESS
+                } else {
+                    ExerciseTypeDomain.WEIGHTED
+                },
+                now = NOW,
+                zoneId = zone,
+            )
+
+            val expected = scenario.expectedHolder
+            if (expected == null) {
+                assertTrue(
+                    fold.points.isEmpty(),
+                    "$where — nothing is eligible, so the day must not plot a point at all",
+                )
+                return@forEach
+            }
+
+            val holder = scenario.candidates.first { it.label == expected }
+            assertEquals(1, fold.points.size, "$where — one day, one point")
+            val point = fold.points.single()
+            assertEquals(sessionUuidFor(holder.finishedAt), point.sessionUuid, "$where — session")
+            assertEquals(holder.weight, point.weight, "$where — weight")
+            assertEquals(holder.reps, point.reps, "$where — reps")
+        }
+    }
+
+    @Test
+    fun `an ineligible set never becomes the day's point`() {
+        // Before the fix, a weight-null set on a WEIGHTED exercise was coerced to 0.0 rather
+        // than excluded, so an exercise whose sets all lack a weight plotted a flat run of
+        // zeroes instead of plotting nothing.
+        val scenario = PrRuleFixture.WEIGHTED_WITH_NO_WEIGHTS_HAS_NO_RECORD
+
+        val fold = bucketAndFold(
+            history = scenario.toHistory(),
+            preset = ChartPresetDomain.ALL,
+            metric = ChartMetricDomain.HEAVIEST_WEIGHT,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = NOW,
+            zoneId = zone,
+        )
+
+        assertTrue(fold.points.isEmpty())
+        assertNull(fold.footer)
+    }
+
+    @Test
+    fun `volume metric keeps the shared eligibility even though it ranks differently`() {
+        // The 200kg zero-rep set has volume 0 and heaviest-weight 200; under either metric it
+        // is ineligible, and the day belongs to the set that was actually performed.
+        val scenario = PrRuleFixture.ZERO_REP_SET_IS_NOT_A_RECORD
+
+        val fold = bucketAndFold(
+            history = scenario.toHistory(),
+            preset = ChartPresetDomain.ALL,
+            metric = ChartMetricDomain.VOLUME_PER_SET,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = NOW,
+            zoneId = zone,
+        )
+
+        val point = fold.points.single()
+        assertEquals(100.0, point.weight)
+        assertEquals(5, point.reps)
+    }
+
+    /**
+     * Candidates sharing a `finishedAt` share a session, matching how `PrRuleDbSeeder` lays
+     * them out in SQL, and are listed in position order — the order
+     * `SessionDao.getHistoryByExercise` delivers them in.
+     */
+    private fun PrRuleFixture.PrScenario.toHistory(): List<HistoryEntryDomain> = candidates
+        .groupBy { it.finishedAt }
+        .map { (finishedAt, group) ->
+            HistoryEntryDomain(
+                sessionUuid = sessionUuidFor(finishedAt),
+                finishedAt = finishedAt,
+                sets = group.map { HistorySetDomain(weight = it.weight, reps = it.reps) },
+            )
+        }
+
+    private fun sessionUuidFor(finishedAt: Long): String = "session-$finishedAt"
+
+    private companion object {
+        /** Comfortably after every fixture timestamp, all of which sit on the epoch day. */
+        const val NOW = 100_000L
+    }
+}

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractor.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractor.kt
@@ -6,7 +6,6 @@ import io.github.stslex.workeeper.core.core.images.model.ImageSaveResult
 import io.github.stslex.workeeper.feature.exercise.domain.model.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseChangeDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseDomain
-import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.HistoryEntryDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.PersonalRecordDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.PlanSetDomain
@@ -34,10 +33,7 @@ interface ExerciseInteractor {
      * change (Room invalidation). Drives the read-mode PR card; collected only when the
      * screen is bound to an existing exercise (create mode has no uuid yet).
      */
-    fun observePersonalRecord(
-        exerciseUuid: String,
-        type: ExerciseTypeDomain,
-    ): Flow<PersonalRecordDomain?>
+    fun observePersonalRecord(exerciseUuid: String): Flow<PersonalRecordDomain?>
 
     suspend fun saveExercise(snapshot: ExerciseChangeDomain): SaveResult
 

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImpl.kt
@@ -16,7 +16,6 @@ import io.github.stslex.workeeper.feature.exercise.domain.mapper.ExerciseDomainM
 import io.github.stslex.workeeper.feature.exercise.domain.model.ArchiveResult
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseChangeDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseDomain
-import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.HistoryEntryDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.PersonalRecordDomain
 import io.github.stslex.workeeper.feature.exercise.domain.model.PlanSetDomain
@@ -74,9 +73,8 @@ class ExerciseInteractorImpl internal constructor(
 
     override fun observePersonalRecord(
         exerciseUuid: String,
-        type: ExerciseTypeDomain,
     ): Flow<PersonalRecordDomain?> = personalRecordRepository
-        .observePersonalRecord(exerciseUuid, type.toData())
+        .observePersonalRecord(exerciseUuid)
         .map { record -> record?.toDomain() }
 
     override suspend fun saveExercise(

--- a/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandler.kt
+++ b/feature/exercise/src/main/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandler.kt
@@ -153,9 +153,11 @@ internal class CommonHandler @Inject constructor(
     }
 
     /**
-     * Restarts the PR collection whenever the user's selected type changes — switching
-     * WEIGHTED ↔ WEIGHTLESS in edit mode would otherwise leave the original subscription
-     * running with the stale `isWeightless` flag and re-emit a wrong PR after save.
+     * The query no longer takes a type — it reads `exercise_table.type` itself — so the
+     * subscription cannot go stale on the *query* side. The restart is still needed on the
+     * *rendering* side: the PR card formats weight-bearing and rep-only records differently,
+     * so switching WEIGHTED ↔ WEIGHTLESS in edit mode must re-map the latest record through
+     * the new type rather than leave the old label on screen.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observePersonalRecord(uuid: String) {
@@ -163,7 +165,7 @@ internal class CommonHandler @Inject constructor(
             .map { it.type.toDomain() }
             .distinctUntilChanged()
             .flatMapLatest { type ->
-                interactor.observePersonalRecord(uuid, type)
+                interactor.observePersonalRecord(uuid)
                     .map { record -> record?.toUi(resourceWrapper, type.toUi()) }
             }
             .launch { pr ->

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/domain/ExerciseInteractorImplTest.kt
@@ -4,7 +4,6 @@ package io.github.stslex.workeeper.feature.exercise.domain
 import io.github.stslex.workeeper.core.core.images.ImageStorage
 import io.github.stslex.workeeper.core.data.exercise.exercise.ExerciseRepository
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseChangeDataModel
-import io.github.stslex.workeeper.core.data.exercise.exercise.model.ExerciseTypeDataModel
 import io.github.stslex.workeeper.core.data.exercise.exercise.model.SetsDataType
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordDataModel
 import io.github.stslex.workeeper.core.data.exercise.personal_record.PersonalRecordRepository
@@ -166,11 +165,11 @@ internal class ExerciseInteractorImplTest {
             finishedAt = 1_000L,
         )
         every {
-            personalRecordRepository.observePersonalRecord("uuid-1", ExerciseTypeDataModel.WEIGHTED)
+            personalRecordRepository.observePersonalRecord("uuid-1")
         } returns flowOf(payload)
 
         val result = interactor
-            .observePersonalRecord("uuid-1", ExerciseTypeDomain.WEIGHTED)
+            .observePersonalRecord("uuid-1")
             .first()
 
         assertNotNull(result)

--- a/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandlerTest.kt
+++ b/feature/exercise/src/test/kotlin/io/github/stslex/workeeper/feature/exercise/ui/mvi/handler/CommonHandlerTest.kt
@@ -9,7 +9,6 @@ import io.github.stslex.workeeper.core.ui.plan_editor.model.PlanSetUiModel
 import io.github.stslex.workeeper.core.ui.plan_editor.model.SetTypeUiModel
 import io.github.stslex.workeeper.feature.exercise.di.ExerciseHandlerStore
 import io.github.stslex.workeeper.feature.exercise.domain.ExerciseInteractor
-import io.github.stslex.workeeper.feature.exercise.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.PendingImage
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.model.TagUiModel
 import io.github.stslex.workeeper.feature.exercise.ui.mvi.store.DialogState
@@ -32,7 +31,7 @@ internal class CommonHandlerTest {
 
     private val interactor = mockk<ExerciseInteractor>(relaxed = true).apply {
         every { observeAvailableTags() } returns flowOf(emptyList())
-        every { observePersonalRecord(any(), any<ExerciseTypeDomain>()) } returns emptyFlow()
+        every { observePersonalRecord(any()) } returns emptyFlow()
     }
     private val resourceWrapper = mockk<ResourceWrapper>(relaxed = true)
 

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractor.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractor.kt
@@ -4,7 +4,6 @@ package io.github.stslex.workeeper.feature.live_workout.domain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.AddExerciseResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.AdhocSessionResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.ExercisePickerEntry
-import io.github.stslex.workeeper.feature.live_workout.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.FinishResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.InlineAdhocResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.PersonalRecordDomain
@@ -77,15 +76,13 @@ interface LiveWorkoutInteractor {
 
     /**
      * Single-exercise lazy PR fetch used by the mid-session add-exercise handler. Returns
-     * the heaviest finished-session set for [exerciseUuid] under the [type]-aware ordering,
-     * or `null` for an exercise with no history (typical for newly inline-created entries).
-     * The handler merges the result into `State.preSessionPrSnapshot` via map-plus
-     * semantics so parallel fetches are race-safe.
+     * the record-holding finished-session set for [exerciseUuid], or `null` for an exercise
+     * with no history (typical for newly inline-created entries). The exercise type is read
+     * from the DB by the query itself, so the handler cannot hand it a stale one. The handler
+     * merges the result into `State.preSessionPrSnapshot` via map-plus semantics so parallel
+     * fetches are race-safe.
      */
-    suspend fun fetchPrSnapshotForExercise(
-        exerciseUuid: String,
-        type: ExerciseTypeDomain,
-    ): PersonalRecordDomain?
+    suspend fun fetchPrSnapshotForExercise(exerciseUuid: String): PersonalRecordDomain?
 
     suspend fun loadSession(sessionUuid: String): SessionSnapshotDomain?
 

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImpl.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImpl.kt
@@ -19,7 +19,6 @@ import io.github.stslex.workeeper.feature.live_workout.domain.mapper.LiveWorkout
 import io.github.stslex.workeeper.feature.live_workout.domain.model.AddExerciseResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.AdhocSessionResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.ExercisePickerEntry
-import io.github.stslex.workeeper.feature.live_workout.domain.model.ExerciseTypeDomain
 import io.github.stslex.workeeper.feature.live_workout.domain.model.FinishResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.InlineAdhocResult
 import io.github.stslex.workeeper.feature.live_workout.domain.model.LiveExerciseDomain
@@ -134,11 +133,10 @@ class LiveWorkoutInteractorImpl internal constructor(
         // then drop the underlying flow; the snapshot lives in State for the session's
         // lifetime, immune to mid-session emissions from other places (Exercise detail edit,
         // a finished session on another screen).
-        val uuidsByType = exerciseSnapshots.associate { snap ->
-            snap.performed.exerciseUuid to snap.exerciseType.toData()
-        }
+        val exerciseUuids = exerciseSnapshots
+            .mapTo(mutableSetOf()) { snap -> snap.performed.exerciseUuid }
         val preSessionPrs = personalRecordRepository
-            .observePersonalRecordsBatch(uuidsByType)
+            .observePersonalRecordsBatch(exerciseUuids)
             .firstOrNull()
             .orEmpty()
             .mapValues { (_, pr) -> pr.toDomain() }
@@ -339,12 +337,11 @@ class LiveWorkoutInteractorImpl internal constructor(
 
     override suspend fun fetchPrSnapshotForExercise(
         exerciseUuid: String,
-        type: ExerciseTypeDomain,
     ): PersonalRecordDomain? = withContext(defaultDispatcher) {
         // C1 lock — single-exercise lazy fetch. PersonalRecordRepository.getPersonalRecord is
         // a suspend hit on the same DAO query observePersonalRecord wraps, so we get the
         // freshest baseline without holding a Flow open mid-session.
-        personalRecordRepository.getPersonalRecord(exerciseUuid, type.toData())?.toDomain()
+        personalRecordRepository.getPersonalRecord(exerciseUuid)?.toDomain()
     }
 
     override suspend fun setPlanForExercise(

--- a/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandler.kt
+++ b/feature/live-workout/src/main/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandler.kt
@@ -15,7 +15,6 @@ import io.github.stslex.workeeper.feature.live_workout.di.LiveWorkoutScope
 import io.github.stslex.workeeper.feature.live_workout.domain.LiveWorkoutInteractor
 import io.github.stslex.workeeper.feature.live_workout.domain.model.ExercisePickerEntry
 import io.github.stslex.workeeper.feature.live_workout.domain.model.PersonalRecordDomain
-import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMapper.toDomain
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.LiveWorkoutMapper.toUi
 import io.github.stslex.workeeper.feature.live_workout.mvi.mapper.StateStatusMapper
 import io.github.stslex.workeeper.feature.live_workout.mvi.model.ErrorType
@@ -192,10 +191,7 @@ internal class ExercisePickerHandler @Inject constructor(
             // map-plus update is skipped, which keeps the in-moment PR badge suppressed.
             val pr: PersonalRecordDomain? = if (picked.fetchPr) {
                 runCatching {
-                    interactor.fetchPrSnapshotForExercise(
-                        exerciseUuid = picked.exerciseUuid,
-                        type = picked.type.toDomain(),
-                    )
+                    interactor.fetchPrSnapshotForExercise(exerciseUuid = picked.exerciseUuid)
                 }.getOrNull()
             } else {
                 null

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImplTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/domain/LiveWorkoutInteractorImplTest.kt
@@ -50,7 +50,6 @@ internal class LiveWorkoutInteractorImplTest {
     private val trainingRepository = mockk<TrainingRepository>(relaxed = true)
     private val trainingExerciseRepository = mockk<TrainingExerciseRepository>(relaxed = true)
     private val personalRecordRepository = mockk<PersonalRecordRepository>(relaxed = true).apply {
-        every { observePersonalRecords(any()) } returns flowOf(emptyMap())
         every { observePersonalRecordsBatch(any()) } returns flowOf(emptyMap())
     }
 
@@ -442,14 +441,12 @@ internal class LiveWorkoutInteractorImplTest {
 
         interactor.loadSession(sessionUuid)
 
-        // Refactor switched the PR pre-snapshot from `observePersonalRecords` (combine-of-N)
-        // to `observePersonalRecordsBatch` (single Room query). Verify the right one is
-        // used and the legacy combine path stays untouched.
+        // Perf guard: the PR pre-snapshot must stay on `observePersonalRecordsBatch`
+        // (single Room query) rather than a combine-of-N over per-exercise flows. The
+        // combine-of-N variant `observePersonalRecords` has since been deleted outright,
+        // so this positive assertion is now the whole guard.
         verify(exactly = 1) {
             personalRecordRepository.observePersonalRecordsBatch(any())
-        }
-        verify(exactly = 0) {
-            personalRecordRepository.observePersonalRecords(any())
         }
     }
 

--- a/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandlerTest.kt
+++ b/feature/live-workout/src/test/kotlin/io/github/stslex/workeeper/feature/live_workout/mvi/handler/ExercisePickerHandlerTest.kt
@@ -147,7 +147,7 @@ internal class ExercisePickerHandlerTest {
         )
         // reusedExisting = false → no history → PR baseline fetch is skipped.
         coVerify(exactly = 0) {
-            interactor.fetchPrSnapshotForExercise(any(), any())
+            interactor.fetchPrSnapshotForExercise(any())
         }
     }
 
@@ -182,10 +182,7 @@ internal class ExercisePickerHandlerTest {
 
         // reusedExisting = true → existing row may have history → PR baseline is fetched.
         coVerify(exactly = 1) {
-            interactor.fetchPrSnapshotForExercise(
-                exerciseUuid = "ex-library-1",
-                type = ExerciseTypeDomain.WEIGHTED,
-            )
+            interactor.fetchPrSnapshotForExercise(exerciseUuid = "ex-library-1")
         }
     }
 

--- a/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImpl.kt
+++ b/feature/past-session/src/main/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImpl.kt
@@ -43,10 +43,10 @@ class PastSessionInteractorImpl internal constructor(
             emit(null)
             return@flow
         }
-        val uuidsByType = initial.exercises.associate { it.exerciseUuid to it.exerciseType }
+        val exerciseUuids = initial.exercises.mapTo(mutableSetOf()) { it.exerciseUuid }
         emitAll(
             personalRecordRepository
-                .observePrSetUuids(uuidsByType)
+                .observePrSetUuids(exerciseUuids)
                 .map { prSetUuids ->
                     val fresh = sessionRepository.getSessionDetail(sessionUuid) ?: initial
                     DetailWithPrs(detail = fresh.toDomain(), prSetUuids = prSetUuids)

--- a/feature/past-session/src/test/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImplTest.kt
+++ b/feature/past-session/src/test/kotlin/io/github/stslex/workeeper/feature/past_session/domain/PastSessionInteractorImplTest.kt
@@ -68,9 +68,7 @@ internal class PastSessionInteractorImplTest {
         )
         coEvery { sessionRepository.getSessionDetail("session-1") } returns detail
         every {
-            personalRecordRepository.observePrSetUuids(
-                mapOf("exercise-1" to ExerciseTypeDataModel.WEIGHTED),
-            )
+            personalRecordRepository.observePrSetUuids(setOf("exercise-1"))
         } returns flowOf(setOf("set-prev"))
 
         val result = interactor.observeDetailWithPrs("session-1").first()


### PR DESCRIPTION
Phase 2 of the PR-ordering unification. Phase 1's rule is implemented verbatim; no visual changes.

## 1. Preflight outcomes

### F1 — `@Query(CONST)` under Room 3 + KSP: **it works. Hoisted.**

A throwaway `@Query(PROBE_CONST_SQL)` DAO function compiled, and Room resolved the constant — including **string-template composition of `const val`s**, which is what the hoist actually needs. Verified by firing, not by a green build: changing `PROBE_WHERE` from `IN_PROGRESS` to `FINISHED AND finished_at IS NOT NULL` propagated into `SessionDao_Impl.kt`:

```kotlin
public override suspend fun probeConstQuery(): SessionEntity? {
  val _sql: String = """
      |        SELECT * FROM session_table WHERE state = 'FINISHED' AND finished_at IS NOT NULL LIMIT 1
      """.trimMargin()
```

No error to report. All three sites now reference shared `PR_ROW_SELECT` / `PR_ELIGIBILITY` / `PR_ORDER` constants, so the rule is single-sourced structurally rather than by comment.

### F2 — `bestOf` and criterion (4): **provable. Documented as a precondition. Proceeded.**

`bestOf` has exactly **one** call site:

`PrComparator.bestOf` ← `LiveWorkoutDomainMapper.bestOfDomain` ← `LiveWorkoutMapper.toNewPrEntry` (`LiveWorkoutMapper.kt:251`), fed by `performedSets.filter { it.isDone }.map { it.toPlanSetDomain() }`.

The list is position-ordered, proven from source:

| Step | Source | Preserves position order? |
|---|---|---|
| DB read | `SetDao.getByPerformedExercises` — `ORDER BY performed_exercise_uuid, position ASC` | establishes it |
| grouping | `SetRepositoryImpl.getByPerformedExercises` — `groupBy` | yes (stable, encounter order) |
| domain map | `LiveWorkoutInteractorImpl:129` — `.map` | yes |
| UI map | `LiveWorkoutMapper.toLiveSets` — `.map` | yes |
| mark done | `LiveSetMutator.applySetMarked:103-108` — replace in place, else append + `sortBy { position }` | yes |
| uncheck | `applySetUnchecked:125` — `filterNot` | yes |
| type change | `applySetTypeChange:150` — `.map` | yes |
| reset / skip | `applyResetSets`, `applySkip` — `persistentListOf()` | trivially |
| filter at call site | `.filter { it.isDone }` | yes |

`PlanSetDataModel` was **not** extended. `bestOf` returns the first maximal element, which is criterion (4) under that ordering; the precondition and its proof are now in the KDoc.

## 2. Measured before/after

Not reasoned. The same `PrRuleFixture` scenarios were run against a `dev` worktree (old code) and against this branch (new code); both tables are captured test output.

`S1` = `getPersonalRecord`, `S2` = `observePersonalRecord`, `S3` = batch query + repository, `S4` = `PrComparator.bestOf`, `S5` = `ChartFolder` day-winner.

### Before (measured on `dev`)

| Scenario | Correct answer | S1 | S2 | S3 | S4 | S5 |
|---|---|---|---|---|---|---|
| weightless carrying residual set weights | `no-weight-12-reps` | ✅ | ✅ | ❌ `residual-weight-8-reps` | ✅ | ✅ |
| equal weight, more reps wins | `100kg-6-reps` | ✅ | ✅ | ✅ | ✅ | ❌ `100kg-5-reps` |
| equal weight+reps, earliest session | `first-session` | ✅ | ✅ | ✅ | ✅ | ✅ |
| identical sets, lowest position | `position-0` | ✅ | ✅ | ✅ | ✅ | ✅ |
| zero-rep set however heavy | `100kg-5-reps` | ❌ `200kg-0-reps` | ❌ | ❌ | ❌ | ❌ `200kg-0-reps` |
| weighted, all sets weight-null | *no record* | ✅ | ✅ | ✅ | ✅ | ❌ plots a point, `value=0.0` |
| weightless, only set zero reps | *no record* | ❌ `zero-reps` | ❌ | ❌ | ❌ | ❌ `zero-reps`, `value=0.0` |

### After (measured on this branch)

All 5 sites × all 7 scenarios return the correct answer. `PrRuleParityTest` + `ChartFolderPrRuleParityTest` are green.

## 3. User-visible changes

**For your release-notes call.** Nothing here changes layout, colour, or copy.

### PR badges that stop appearing

1. **Zero-rep sets lose their badge.** A set logged with a weight but `reps = 0` was the record holder on every path (it sorted first on weight DESC). It is now ineligible everywhere. If a user has such a row, the badge moves to the heaviest set that was actually performed — or disappears if there is no such set.
2. **A weightless exercise whose only logged set has `reps = 0` now has no PR at all** (previously it held one at 0 reps).
   > **This one is not behaviour-neutral**, contrary to the Phase 1 note that `reps > 0` was neutral today. It is measured, both rows above. It is still the right rule; flagging it because it is the only place the accepted decision and the measurement disagree.
3. **Weighted exercises logged entirely without weights**: unchanged on the PR paths (already no record), but the **chart** stops drawing them as a flat line of zeroes and now draws nothing.

### PR badges that move to a different set

4. **Weightless exercises carrying residual `set_table.weight` values.** On the *Past session* screen and the *Live workout* pre-session snapshot (both batch-query consumers), the badge sat on whichever set happened to carry a stray weight instead of on the rep record. It now sits on the rep record — matching what the Exercise-detail screen already showed for that same exercise. **This was a visible self-contradiction between two screens; it is gone.** No migration; the residual weights stay in the DB as decided.

### Chart

5. **Day-winner ties on weight are now broken by reps.** A day with `100kg × 5` and `100kg × 6` used to plot whichever came first; it now plots the 6-rep set. Same y-value, different tooltip/detail.

### WEIGHTED behaviour — confirmed unchanged

Confirmed by measurement, not inference: for weighted exercises with well-formed data (non-null weight, `reps > 0`) every site returns the same set before and after — rows 2, 3, 4 of the before-table, unchanged after. The weight-DESC → reps-DESC → earliest-finish → lowest-position order is identical. The only weighted-exercise changes are the two eligibility exclusions above, both of which concern malformed rows.

## 4. Tests

**Nothing broke.** Full `testDebugUnitTest`, `detekt`, and `lintDebug` are green, and every one of the 4 commits is independently green (`testDebugUnitTest` + `detekt` checked out one at a time).

`LiveWorkoutInteractorImplTest:434` — **still green.** S3 was fixed in place via the type-join, not retired; `observePersonalRecordsBatch` is still the route and the guard still asserts `exactly = 1`. Its *negative* half (`verify(exactly = 0) { observePersonalRecords(any()) }`) was removed because `observePersonalRecords` — the combine-of-N variant — is deleted outright per work item 6, so the type system now enforces what that line asserted. The perf claim the test exists to protect is untouched.

Signature updates only (no assertion changes): `SessionDao*PersonalRecordTest`, `PersonalRecordRepositoryImplDbTest`, `ExerciseInteractorImplTest`, `CommonHandlerTest`, `ExercisePickerHandlerTest`, `PastSessionInteractorImplTest`.

### The parity test was verified to fail before being trusted

A green detector proves nothing. Each arm was checked by reverting the code it guards:

| Mutation | Result |
|---|---|
| A — restore old batch ordering (`CASE WHEN weight IS NULL…, weight DESC`) | 🔴 |
| B — drop `AND s.reps > 0` from eligibility | 🔴 |
| C — resurrect the repository's weight filter | 🔴 |
| D — `bestOf` without the eligibility filter | 🔴 |
| E — old `ChartFolder` comparator (no reps key, no exclusion) | 🔴 |

All five restored to green.

## 5. Verified by me vs. needs a device

**Verified here (JVM / Robolectric + real in-memory Room):**
- every SQL claim — the queries ran against a real `AppDatabase`, not a mock
- five-site parity, all 7 scenarios, plus the two-phase in-progress → finished contract
- the before/after tables (executed on a `dev` worktree and on this branch)
- full unit suite, detekt, `lintDebug`, per-commit bisect
- generated `SessionDao_Impl.kt` inspected to confirm the composed SQL is what I intended

**Needs a device / your eyes:**
- **Badge rendering on real data.** I proved which set the rule names; I did not run the app. Whether a badge visibly moves on your device depends on whether your DB actually contains weightless rows with residual weights or zero-rep sets. Worth checking the Past-session screen for a weightless exercise.
- **Chart appearance** for an exercise logged without weights — should now render empty-state rather than a zero line. Not visually confirmed.
- `connectedDebugAndroidTest` was not run (no device). `compileDebugAndroidTestKotlin` passes.
- Migration testing: **N/A**, no schema change.

## 6. One correction to the brief

Work item 5(b) described the `metricValue` type-before-metric short-circuit as making "the metric toggle a silent no-op" for weightless exercises. The toggle is **not reachable** for them — `ExerciseChartStore.State.showMetricToggle` is `selectedExercise?.type == WEIGHTED`, and `ExerciseChartScreen.kt:239` gates rendering on it. So there is no user-facing no-op.

The branch order is still wrong to read, and it is fixed (metric first, then type), but **this part is a readability change with no behaviour change** — I did not invent a distinct volume semantic for bodyweight exercises, since per-set volume with an unknown constant bodyweight *is* reps up to that constant. That collapse is now documented instead of being implied by branch order. The genuinely defective half of 5(b) — `weight ?: 0.0` — is fixed by the eligibility exclusion in 5(a).

## 7. Scope note

Work item 2 says "update all callers". I took that through the repository boundary: `PersonalRecordRepository` no longer accepts an exercise type at all (`Map<String, ExerciseTypeDataModel>` → `Set<String>`), and the two feature interactors that only forwarded it lost the parameter too. A parameter that no longer influences the result is the same trap the item exists to remove. It is confined to commit 1 and is pure deletion — revert that hunk if you would rather keep the API shape.

## Verification-harness accounting

No multi-agent harness was used, so there is no agents-started/agents-completed count to report. Every check above was run directly and its output is quoted or tabulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En41Lzk2AG4riaw6FrnPAQ
