### PR TITLE
fix(exercise-chart): answer both post-merge review comments on the day-winner fold

### DIFF
--- a/documentation/feature-specs/v2.2-exercise-charts.md
+++ b/documentation/feature-specs/v2.2-exercise-charts.md
@@ -36,7 +36,16 @@ X axis = days. Y axis = a single Y-value per day, computed client-side from raw 
    - **Heaviest weight (default)**: `max(weight)` over the day's rows. Tooltip lists all reps for the heaviest set. Weightless exercises: `max(reps)`.
    - **Volume per set**: `max(weight × reps)` over the day's rows. Weightless exercises: same as Heaviest weight (volume meaningless without weight); toggle is hidden for weightless.
 
-If two rows tie on the metric, the earlier `finishedAt` wins (consistent with the PR `finished_at ASC` tiebreak). Tooltip then says `"N подходов в этот день"`.
+Only rows the chart can actually plot are candidates for the day's value: a set at zero reps, and a weight-null set on a weighted exercise, are excluded rather than coerced to `0.0` (coercion invents a point at the bottom of the axis). This is the same eligibility the PR rule applies — `SessionDao.PR_ELIGIBILITY`.
+
+Tiebreaks below the metric are **metric-dependent**, because the chart answers the PR question under only one of the two metrics:
+
+- **Heaviest weight** — a tie on the metric *is* a tie on weight, so the remaining keys are `SessionDao.PR_ORDER` exactly: `reps DESC`, then earliest `finishedAt`. The day's set is the record-holding set, which is what `ChartFolderPrRuleParityTest` pins against the shared `PrRuleFixture`.
+- **Volume per set** — a tie is instead a trade of weight against reps (`100×2 == 50×4`), where `reps DESC` would read as "prefer the lighter set" and would move the tooltip's navigation target to the later session. Volume is not a PR metric, so the key is not applied: earliest `finishedAt` wins.
+
+Position ASC is the last key under both, and comes for free — the sort is stable and each session's sets arrive in position order from `SessionDao.getHistoryByExercise`.
+
+Tooltip then says `"N подходов в этот день"`, where **N counts every set logged that day**, including sets that were not eligible to be plotted. Eligibility chooses which set represents the day; it never changes how many the user logged.
 
 ### Edge interpolation
 
@@ -91,7 +100,7 @@ If `state.personalRecord == null`, no card is shown, so no chart entry from Exer
 - **Q3.** Y metric: toggle between **Heaviest weight** (Y = `weight`, reps in tooltip) and **Volume per set** (Y = `weight × reps`). Default is **Heaviest weight** to match PR semantics. Toggle hidden for weightless (Y = `reps`).
 - **Q4.** Default `exerciseUuid = null` resolution: last-trained exercise (`MAX(sn.finished_at)` over finished sessions joined to performed_exercise).
 - **Q5.** Standalone entry: `Icons.Outlined.QueryStats` icon left of Settings in Home top bar.
-- **Tooltip on point tap.** Exercise name + date + weight × reps (or just reps for weightless) + `"N подходов в этот день"` if `N > 1`. Tap on the tooltip itself navigates to `Screen.PastSession(sessionUuid)` for the session containing the max-of-day set (unambiguous: tied maxes break by earliest `finishedAt`, and that row's `sessionUuid` is the navigation target).
+- **Tooltip on point tap.** Exercise name + date + weight × reps (or just reps for weightless) + `"N подходов в этот день"` if `N > 1`. Tap on the tooltip itself navigates to `Screen.PastSession(sessionUuid)` for the session containing the max-of-day set. The target is unambiguous, but the tiebreak that makes it so is metric-dependent (see [Bucketing semantics](#bucketing-semantics)): under **Volume per set** a tied max resolves to the earliest `finishedAt`; under **Heaviest weight** `reps DESC` is applied first, so a tie on weight resolves to the higher-rep set — the record holder — and only then to the earliest `finishedAt`.
 - **Edge interpolation.** Flat fill-forward both edges; linear between points; single-point case = flat across window.
 - **Empty state.** Three distinct branches keyed off `State.emptyReason`:
   - `NO_FINISHED_SESSIONS` — no recents at all. CTA "Начать тренировку" → Home. Picker
@@ -620,13 +629,24 @@ internal object ExerciseChartUiMapper {
                 }
             }
 
-        if (flat.isEmpty()) return FoldResult(persistentListOf(), null)
+        // 2. Only plottable sets can represent a day — same rule as `SessionDao.PR_ELIGIBILITY`.
+        //    A weight-null set on a WEIGHTED exercise is excluded, never coerced to 0.0.
+        val eligible = flat.filter { it.reps > 0 && (exerciseType == WEIGHTLESS || it.weight != null) }
+        if (eligible.isEmpty()) return FoldResult(persistentListOf(), null)
 
-        // 2. Group by day, fold per metric
-        val pointsByDay = flat.groupBy { it.day }.map { (day, dailySets) ->
-            val foldComparator = compareByDescending<FlatSet> { f ->
-                metricValue(f, metric, exerciseType)
-            }.thenBy { it.finishedAt }                  // earliest wins on tie
+        // 3. "N sets this day" counts every set logged, plottable or not — so it is derived
+        //    from the unfiltered `flat`, not from the eligible group.
+        val setsPerDay = flat.groupingBy { it.day }.eachCount()
+
+        // 4. Group by day, fold per metric. The keys below the metric are metric-dependent:
+        //    reps DESC applies only where a metric tie is a weight tie (see Bucketing semantics).
+        val byMetric = compareByDescending<FlatSet> { f -> metricValue(f, metric, exerciseType) }
+        val foldComparator = when (metric) {
+            HEAVIEST_WEIGHT -> byMetric.thenByDescending { it.reps }.thenBy { it.finishedAt }
+            VOLUME_PER_SET -> byMetric.thenBy { it.finishedAt }
+        }
+
+        val pointsByDay = eligible.groupBy { it.day }.map { (day, dailySets) ->
             val winner = dailySets.sortedWith(foldComparator).first()
             ChartPointUiModel(
                 day = day,
@@ -634,7 +654,7 @@ internal object ExerciseChartUiMapper {
                 sessionUuid = winner.sessionUuid,
                 weight = winner.weight,
                 reps = winner.reps,
-                setCount = dailySets.size,
+                setCount = setsPerDay.getValue(day),
             )
         }.sortedBy { it.day }
 
@@ -823,12 +843,21 @@ feature_home_charts                                 # contentDescription for ico
 
 ### Mapper tests
 
-`ExerciseChartUiMapperTest` (pure unit):
+The fold itself lives in `ChartFolder.bucketAndFold` (domain), so these are `ChartFolderTest`;
+`ExerciseChartUiMapperTest` covers only the domain → UI formatting on top of it.
+
+`ChartFolderTest` (pure unit):
 - empty history → empty points + null footer.
 - single set → single point, footer min == max == last.
 - multiple days, single metric — points sorted ASC by day, values match max-of-day.
 - two sessions same day, different weights — collapsed to higher; `setCount = N` (N includes all sets of the day, not just sessions).
 - tie on metric value — earlier `finishedAt` wins; tooltip's `sessionUuid` is the earlier one.
+- `setCount` counts sets the chart cannot plot — a day holding an unplottable set still reports every set logged, so the `setCount > 1` tooltip line is not silently dropped.
+- volume tie across sessions — under `VOLUME_PER_SET` the earlier session wins, since the reps key is not applied there.
+- volume tie inside one session — resolves to the earlier position, via the stable sort.
+
+`ChartFolderPrRuleParityTest` (pure unit, shared `PrRuleFixture`) — the fifth PR site: under
+`HEAVIEST_WEIGHT` the day's set is the record-holding set for every fixture scenario.
 - weightless exercise — Y = reps regardless of metric.
 - preset window filtering — sets outside `[now - delta, now]` excluded.
 - `All` preset — no filtering.

--- a/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
+++ b/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
@@ -69,19 +69,29 @@ internal fun bucketAndFold(
         windowEndDay = null,
     )
 
-    // Which set represents the day, ordered as `SessionDao.PR_ORDER`: the metric first (that
-    // is what the axis plots), then reps DESC, then earliest finishedAt. Position ASC is the
-    // last criterion and comes for free — `sortedWith` is stable and each session's sets
-    // arrive in position order from `SessionDao.getHistoryByExercise`.
-    val foldComparator = compareByDescending<FlatSet> { f ->
-        metricValue(f, metric, exerciseType)
+    // Eligibility decides which set *represents* a day; it does not decide how many sets the
+    // user logged that day. A set recorded without a weight was still performed — it just
+    // cannot be plotted — so the tooltip's "N sets this day" keeps counting every set.
+    val setsPerDay = flat.groupingBy(FlatSet::day).eachCount()
+
+    // Which set represents the day. The metric comes first — that is what the axis plots.
+    // Under HEAVIEST_WEIGHT the keys below it are `SessionDao.PR_ORDER`: a tie on the metric
+    // *is* a tie on weight, so reps DESC ranks equal-weight sets exactly as the PR rule does,
+    // and the earliest finishedAt settles the rest. Under VOLUME_PER_SET a tie instead means
+    // the two sets traded weight against reps (100×2 == 50×4), where reps DESC would quietly
+    // read as "prefer the lighter set" — volume is not a PR metric, so nothing licenses that
+    // key and the chart's own rule stands: earliest finishedAt wins. Position ASC is the last
+    // criterion either way and comes for free — `sortedWith` is stable and each session's
+    // sets arrive in position order from `SessionDao.getHistoryByExercise`.
+    val byMetric = compareByDescending<FlatSet> { f -> metricValue(f, metric, exerciseType) }
+    val foldComparator = when (metric) {
+        ChartMetricDomain.HEAVIEST_WEIGHT -> byMetric.thenByDescending(FlatSet::reps).thenBy(FlatSet::finishedAt)
+        ChartMetricDomain.VOLUME_PER_SET -> byMetric.thenBy(FlatSet::finishedAt)
     }
-        .thenByDescending(FlatSet::reps)
-        .thenBy(FlatSet::finishedAt)
 
     val pointsByDay = eligible
         .groupBy(FlatSet::day)
-        .map { (_, dailySets) ->
+        .map { (day, dailySets) ->
             val winner = dailySets.sortedWith(foldComparator).first()
             ChartPointDomain(
                 day = winner.day,
@@ -90,7 +100,7 @@ internal fun bucketAndFold(
                 sessionUuid = winner.sessionUuid,
                 weight = winner.weight,
                 reps = winner.reps,
-                setCount = dailySets.size,
+                setCount = setsPerDay.getValue(day),
             )
         }
         .sortedBy(ChartPointDomain::day)

--- a/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
+++ b/feature/exercise-chart/src/main/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolder.kt
@@ -70,8 +70,11 @@ internal fun bucketAndFold(
     )
 
     // Eligibility decides which set *represents* a day; it does not decide how many sets the
-    // user logged that day. A set recorded without a weight was still performed — it just
-    // cannot be plotted — so the tooltip's "N sets this day" keeps counting every set.
+    // user logged that day. Both grounds `isEligible` drops on — a weighted set saved without
+    // a weight, and a set left at zero reps — were still logged against that day, so the
+    // tooltip's "N sets this day" counts over the unfiltered window. That is the spec's
+    // definition, and it agrees with the app's other set counter: `SessionDao`'s
+    // `set_count` is a bare `COUNT(*)` over `set_table` with no reps or weight predicate.
     val setsPerDay = flat.groupingBy(FlatSet::day).eachCount()
 
     // Which set represents the day. The metric comes first — that is what the axis plots.

--- a/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
+++ b/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
@@ -25,8 +25,10 @@ import java.time.ZoneId
  *
  * The metric is [ChartMetricDomain.HEAVIEST_WEIGHT] throughout, because that is the metric
  * under which the chart's primary sort key *is* the PR rule's primary key. Under
- * [ChartMetricDomain.VOLUME_PER_SET] the chart deliberately ranks by `weight × reps` instead;
- * eligibility and the lower tiebreaks still apply, but the winner is not claimed to match.
+ * [ChartMetricDomain.VOLUME_PER_SET] the chart deliberately ranks by `weight × reps` instead:
+ * eligibility is still shared, but the reps tiebreak is not. A volume tie is a trade of weight
+ * against reps, so ranking by reps there would amount to ranking by *ascending* weight — only
+ * the earliest-`finishedAt` tiebreak carries over, and the winner is not claimed to match.
  */
 internal class ChartFolderPrRuleParityTest {
 

--- a/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
+++ b/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderPrRuleParityTest.kt
@@ -23,12 +23,14 @@ import java.time.ZoneId
  * Every fixture timestamp falls on the same day, so each scenario folds to exactly one point
  * and "the day's set" is "the record-holding set" — which is the parity claim.
  *
- * The metric is [ChartMetricDomain.HEAVIEST_WEIGHT] throughout, because that is the metric
- * under which the chart's primary sort key *is* the PR rule's primary key. Under
+ * The parity claim is asserted under [ChartMetricDomain.HEAVIEST_WEIGHT], because that is the
+ * metric under which the chart's primary sort key *is* the PR rule's primary key. Under
  * [ChartMetricDomain.VOLUME_PER_SET] the chart deliberately ranks by `weight × reps` instead:
- * eligibility is still shared, but the reps tiebreak is not. A volume tie is a trade of weight
- * against reps, so ranking by reps there would amount to ranking by *ascending* weight — only
- * the earliest-`finishedAt` tiebreak carries over, and the winner is not claimed to match.
+ * eligibility and the lower `finishedAt` / position tiebreaks are still shared, but the reps
+ * key is not. A volume tie is a trade of weight against reps, so ranking by reps there would
+ * amount to ranking by *ascending* weight. The one test below that does pass
+ * [ChartMetricDomain.VOLUME_PER_SET] therefore claims only the shared eligibility, not the
+ * winner.
  */
 internal class ChartFolderPrRuleParityTest {
 

--- a/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderTest.kt
+++ b/feature/exercise-chart/src/test/kotlin/io/github/stslex/workeeper/feature/exercise_chart/domain/ChartFolderTest.kt
@@ -140,6 +140,62 @@ internal class ChartFolderTest {
     }
 
     @Test
+    fun `setCount counts sets the chart cannot plot`() {
+        // Eligibility picks the day's winner; it must not shrink "N sets this day". A weighted
+        // set logged without a weight is unplottable but was still performed.
+        val result = bucketAndFold(
+            history = listOf(
+                entry(
+                    finishedAt = utcMillis(2026, 4, 28),
+                    sessionUuid = "s1",
+                    sets = listOf(
+                        set(weight = 100.0, reps = 5),
+                        set(weight = 110.0, reps = 3),
+                        set(weight = null, reps = 8),
+                    ),
+                ),
+            ),
+            preset = ChartPresetDomain.MONTHS_3,
+            metric = ChartMetricDomain.HEAVIEST_WEIGHT,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = utcMillis(2026, 5, 1),
+            zoneId = zone,
+        )
+
+        val point = result.points.single()
+        assertEquals(110.0, point.value)
+        assertEquals(3, point.reps)
+        assertEquals(3, point.setCount)
+    }
+
+    @Test
+    fun `setCount keeps the tooltip label when only one set of the day is plottable`() {
+        // `setCount == 1` is not just an off-by-one: the UI mapper gates the tooltip's
+        // "N sets this day" line on `setCount > 1`, so undercounting here erases the line.
+        val result = bucketAndFold(
+            history = listOf(
+                entry(
+                    finishedAt = utcMillis(2026, 4, 28),
+                    sessionUuid = "s1",
+                    sets = listOf(
+                        set(weight = 100.0, reps = 5),
+                        set(weight = null, reps = 8),
+                    ),
+                ),
+            ),
+            preset = ChartPresetDomain.MONTHS_3,
+            metric = ChartMetricDomain.HEAVIEST_WEIGHT,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = utcMillis(2026, 5, 1),
+            zoneId = zone,
+        )
+
+        val point = result.points.single()
+        assertEquals(100.0, point.value)
+        assertEquals(2, point.setCount)
+    }
+
+    @Test
     fun `tie on metric value selects earlier finishedAt session`() {
         val result = bucketAndFold(
             history = listOf(
@@ -319,6 +375,66 @@ internal class ChartFolderTest {
         )
 
         assertEquals(800.0, result.points.single().value)
+    }
+
+    @Test
+    fun `volume tie across sessions keeps the earlier session`() {
+        // Under VOLUME_PER_SET a tie is a trade of weight against reps, so a reps tiebreak
+        // would mean "prefer the lighter set" — and would move the tooltip's navigation
+        // target to the later session. Volume is not a PR metric; earliest finishedAt wins.
+        val result = bucketAndFold(
+            history = listOf(
+                entry(
+                    finishedAt = utcMillis(2026, 4, 28, hour = 9),
+                    sessionUuid = "morning",
+                    sets = listOf(set(weight = 100.0, reps = 2)), // weight×reps = 200
+                ),
+                entry(
+                    finishedAt = utcMillis(2026, 4, 28, hour = 18),
+                    sessionUuid = "evening",
+                    sets = listOf(set(weight = 50.0, reps = 4)), // weight×reps = 200
+                ),
+            ),
+            preset = ChartPresetDomain.MONTHS_3,
+            metric = ChartMetricDomain.VOLUME_PER_SET,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = utcMillis(2026, 5, 1),
+            zoneId = zone,
+        )
+
+        val point = result.points.single()
+        assertEquals(200.0, point.value)
+        assertEquals("morning", point.sessionUuid)
+        assertEquals(100.0, point.weight)
+        assertEquals(2, point.reps)
+    }
+
+    @Test
+    fun `volume tie inside one session keeps the earlier position`() {
+        // A drop set ties with itself: every set of a session shares one finishedAt, so the
+        // position order the history query delivers is what decides, via a stable sort.
+        val result = bucketAndFold(
+            history = listOf(
+                entry(
+                    finishedAt = utcMillis(2026, 4, 28),
+                    sessionUuid = "s1",
+                    sets = listOf(
+                        set(weight = 100.0, reps = 2), // weight×reps = 200
+                        set(weight = 50.0, reps = 4), // weight×reps = 200
+                    ),
+                ),
+            ),
+            preset = ChartPresetDomain.MONTHS_3,
+            metric = ChartMetricDomain.VOLUME_PER_SET,
+            exerciseType = ExerciseTypeDomain.WEIGHTED,
+            now = utcMillis(2026, 5, 1),
+            zoneId = zone,
+        )
+
+        val point = result.points.single()
+        assertEquals(200.0, point.value)
+        assertEquals(100.0, point.weight)
+        assertEquals(2, point.reps)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #178, which was merged into `dev` before its two P2 review comments were addressed. This branch carries those fixes; both review threads on #178 are answered and resolved.

### 1. Preserve all daily sets in the tooltip count ([thread](https://github.com/stslex/Workeeper/pull/178#discussion_r3652970182))

Grouping `eligible` made `dailySets.size` count only plottable sets, so a day holding a weighted set logged without a weight understated `"N подходов в этот день"`.

Not merely an off-by-one: `ExerciseChartUiMapper.kt:63` gates that line on `setCount > 1`, so a 2-set day with one unplottable set lost the line **entirely**. `setCount` now counts over the unfiltered `flat` list — which is what the spec defines, and what the app's only other set counter does (`SessionDao.set_count` is a bare `COUNT(*)` with no reps/weight predicate).

### 2. Keep the earliest session for tied volume values ([thread](https://github.com/stslex/Workeeper/pull/178#discussion_r3652970183))

Took the reviewer's first suggested option — apply the reps tiebreak only where the heaviest-weight metric requires it:

- **`HEAVIEST_WEIGHT`** — a tie on the metric *is* a tie on weight, so `reps DESC` ranks equal-weight sets exactly as `SessionDao.PR_ORDER` does. Key kept; this is the PR-rule parity #178 exists to establish.
- **`VOLUME_PER_SET`** — a tie is instead a trade of weight against reps (`100×2 == 50×4`), where the same key quietly reads as "prefer the lighter set" and moves the tooltip's navigation target to the later session. Volume is not a PR metric, so the key is dropped: earliest `finishedAt` wins.

### 3. Spec reconciliation

The reviewer cited the spec as its authority, and on `setCount` the spec was right. But its tiebreak statement had been stale since #178 (which touched no docs), and its reference fold stale since b98efe33. Left alone, code and spec contradict each other and the next reviewer re-raises the same comment. So:

- Lines 39 / 94 / 831 now state the tie rule **per metric** instead of asserting one universal `finishedAt` rule.
- `setCount` is stated as counting every set *logged*, not every set *plotted*.
- The reference fold gets its eligibility filter back — as written it coerced weight-null sets to `0.0` and reproduced the phantom points b98efe33 removed.
- Test inventory corrected: the fold tests live in `ChartFolderTest`, not `ExerciseChartUiMapperTest`.

### Tests

Four new cases in `ChartFolderTest`. They are proven detectors, not just green — reverting the `setCount` fix fails both `setCount` tests (`22 tests completed, 2 failed`).

### Checks

- `./gradlew detekt` — green. The fix as originally written had **2 real `Wrapping` violations** (`ChartFolder.kt:88`, `:91`); fixed here, so this would otherwise have been a red check.
- `./gradlew testDebugUnitTest` — full suite green.
- No Paparazzi golden covers the chart screen (goldens are `core/ui/kit` primitives only), so no visual-gate impact.

### Noted, not fixed — genuinely separate

`getHistoryByExercise` selects `s.type AS set_type` (`SessionDao.kt:388`) but `ExerciseChartDomainMapper.kt:29` drops it. Warmup sets therefore count toward "N sets this day" and can win a day outright. Pre-existing and independent of this diff, but it is the other half of "is the tooltip's count honest".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADmwfE8FaM6jco6jRoUcz1