### PR TITLE
docs(design-system): AppNumberInput section matches the shipped component (B9)

### DIFF
--- a/documentation/design-system.md
+++ b/documentation/design-system.md
@@ -444,21 +444,34 @@ Visual: AppShapes.medium, border-only (no fill), surface tier 0 fill
 
 ### 4. AppNumberInput
 
-Specialized for weight / reps in Live workout. Large tap target,
-large numbers, optimized keyboard.
+The mockup's `.field` — a value and its unit on a recessed panel
+(extraction §1.6). Specialized for weight / reps in Live workout and
+the past-session read-back. Large tap target, large numbers, optimized
+keyboard.
 
 ```
 package: io.github.stslex.workeeper.core.ui.kit.components.input
 
-API: AppNumberInput(value, onValueChange, decimals = 0, suffix = null,
-                    modifier, enabled = true)
+API: AppNumberInput(value, onValueChange, modifier, decimals = 0,
+                    suffix = null, enabled = true, isError = false,
+                    isRecord = false, isDone = false, isLogged = false)
 
 Visual:
   height: AppDimension.heightMd (48.dp)
-  text: titleLarge, tabularNumbers
-  background: surface tier 2
-  shape: AppShapes.small
-  suffix display ("kg", "reps") — tertiary text trailing inside the field
+  text: AppTypography.dataValue (26sp Archivo wdth 115 / wght 700);
+        values longer than 3 glyphs step down to numeric.section
+        (19sp bold) instead of clipping
+  value color: textTertiary resting → textPrimary when isDone or
+        isLogged → record.textPrimary when isRecord (record wins)
+  background: surface tier 3 (field); the isDone `donefill` and
+        isRecord `record.background` washes REPLACE the tier
+        (isLogged keeps the plain tier — colour without the wash)
+  shape: RoundedCornerShape(AppDimension.Radius.small) (8.dp)
+  border: none by default (recessed by tier alone); hairline
+        status.error outline when isError
+  suffix display ("kg", "reps") — mono.caption trailing inside the
+        field; textDim resting, promotes to textSecondary over the
+        isDone / isRecord washes
 
 KeyboardOptions:
   decimals = 0 → KeyboardType.Number

--- a/documentation/design-system.md
+++ b/documentation/design-system.md
@@ -458,7 +458,7 @@ API: AppNumberInput(value, onValueChange, modifier, decimals = 0,
 
 Visual:
   height: AppDimension.heightMd (48.dp)
-  text: AppTypography.dataValue (26sp Archivo wdth 115 / wght 700);
+  text: AppTypography.dataValue (26sp Archivo wdth 116 / wght 700);
         values longer than 3 glyphs step down to numeric.section
         (19sp bold) instead of clipping
   value color: textTertiary resting → textPrimary when isDone or


### PR DESCRIPTION
## What

Docs-only. Rewrites design-system.md §Components/4 (AppNumberInput) from the component source as it is on `dev` — no code touched. **Mergeable on sight.**

## Why

The section was falsified twice over:

- **background: surface tier 2** — falsified by #184 C3; the field is **tier 3**, and the `isDone`/`isRecord` washes *replace* the tier rather than stack on it.
- **API line listed 6 parameters** — the component has 10: `isError`, `isRecord`, `isDone` (#184–#186) and `isLogged` (#187) were missing.
- Typography was stale too: `titleLarge, tabularNumbers` → `AppTypography.dataValue` (26sp Archivo wdth 116/wght 700) with the 3-glyph downstep to `numeric.section`; the unit is `mono.caption` with wash-promotion to `textSecondary`.
- `shape: AppShapes.small` → `RoundedCornerShape(AppDimension.Radius.small)` (8.dp), no default border, hairline `status.error` outline on error.

Closes the live instance of registry item **B9** (design-system.md drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSq5JQESEhYZCZeJdXfi2P

## Phase-1 independent review (2026-07-29, three lenses)

Three independent reviewers (spec-conformance, API reconstruction, claims re-derivation) verified every claim in the rewritten section against the dev source. One number was falsified and is fixed in `713bc978`: the section said **wdth 115** where the shipped cut — spec §4, resolved B3, the ledger, `archivo_bold_wdth116`, and this file's own typography table at L184 — is **wdth 116**; 115 is the mockup's `.data-l` CSS declaration. (This body originally repeated the same 115; corrected above.)

**Notes, recorded not fixed** (whole-file drift is B9's still-open remit, this PR's section is now internally true):
- L126/L104/L290: untouched palette/elevation annotations still file the input-fill role under **tier 2** and call tier 3 "active" — the exact drift axis this PR corrects inside §Components/4. "Closes the live instance of B9" is true of the section, not the file.
- L269: the Shape section still lists "small inputs" under `AppShapes.small = 6.dp`, while the number input correctly documents `Radius.small` = 8dp.
- L448: the usage sentence names two consumers; the plan editor (`PlanEditorBody.kt:126,138`) is a third.
- PR-body provenance nit: `isError` predates the v3 stack (2026-05-08), it is not from #184–#186.