### PR TITLE
the shared list row: one skeleton, four payloads, and no behaviour flags (stacked on #203)

### DIFF
--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/list/AppListRow.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/list/AppListRow.kt
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package io.github.stslex.workeeper.core.ui.kit.components.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
+import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
+
+/**
+ * The `#s-list` `.row` skeleton — **one drawing, four payloads.**
+ *
+ * §26 "List row" and `#s-list`'s own hint say it outright: *«Скелет строки один — 88px, линейка
+ * снизу, имя и мета-строка, шеврон. Начинки разные: поля у четырёх экранов не совпадают.»* The four
+ * are `all-trainings`, `all-exercises`, `archive` and `home`, and this is the skeleton they share:
+ * a full-bleed ruled row of at least [AppDimension.rowHeight], a two-line clamped name over a
+ * single-line meta, and a trailing region.
+ *
+ * ## What is shared, and what deliberately is not
+ *
+ * Everything here is identical in all four instances, byte for byte, before this extraction: the
+ * `Column`/`Row` nesting, `heightIn`, the [AppDimension.screenEdge] gutter, the `Space.md` gap, the
+ * text column's `weight(1f)` and `Space.xs`, both text styles and colours, both clamps, and the
+ * divider. There is **no behaviour flag on this signature** — no `lifted`, no `selecting`, no
+ * `clickable` — and that is the finding the extraction rests on rather than a simplification:
+ * every difference between the four is a *modifier* or the *content of the trailing region*, so
+ * they belong in [rowModifier] and [content], which is what those seams are for.
+ *
+ * ## Two modifier seams, because the drawn row has two boxes
+ *
+ * [modifier] reaches the outer `Column` — the row **plus** its rule, which is what a caller animates
+ * (`Modifier.animateItem`). [rowModifier] reaches the inner `Row` — the ruled area **without** the
+ * rule, which is what a caller lifts, clicks and tags. The distinction is not stylistic: a
+ * `liftedSurface` on the outer box paints behind the divider, and a `combinedClickable` there makes
+ * the hairline part of the touch target. [rowModifier] lands **before** `heightIn` and the gutter,
+ * where every caller's chain sat before the extraction, so the painted region and the touch region
+ * are unchanged.
+ *
+ * ## The meta line arrives formatted, and composing it stays with the screen
+ *
+ * [meta] is a `String`. Its four producers compose it in three different places — two inside a
+ * composable (`pluralStringResource`, `stringResource` per exercise type), one as a pure extension
+ * on the ui model (`home`), one in the **mapper** (`archive`, which is the only form assertable
+ * without a composition). They differ in token *order* too, by decision: §26 fixes "information
+ * first, tags last" and leaves each screen's tokens to that screen. Pulling any of that in here
+ * would put display strings and per-feature resources in the kit, which is the boundary
+ * `CLAUDE.md` draws for the mapper layer. So the row takes the formatted line and asserts nothing
+ * about it; `RecentMetaLineTest` and its siblings stay where they are.
+ *
+ * ## The rule is drawn with a token the app does not have
+ *
+ * `#s-list` rules the row with `--hair-s`, and the slot that would take it (`borderSubtle`) is
+ * `--hair` — a different value. The row rules with `borderSubtle` until the palette decision lands:
+ * a known approximation, recorded as D3 and owed its own PR, not a transcription error. All four
+ * instances shipped it; it is one line now instead of four.
+ *
+ * ## The trailing region is a slot, and archive is why it is not a fixed-width one
+ *
+ * Three of the four hold the drawn 20px slot ([AppListRowSlot]). `archive` holds two live verbs —
+ * a restore button and an overflow — which is `archive-delta.md` §2.1, unresolved and explicitly
+ * a §0.1 decision for the owner. Had this component owned the slot width, extraction would have
+ * answered that question in a refactor. It owns the *gap* and the alignment; the caller owns what
+ * sits in the region.
+ *
+ * @param name the row's title. Clamped to two lines, ellipsised.
+ * @param meta the composed meta line. One line, ellipsised; see the note above on where it is built.
+ * @param nameTestTag tag for the name text — per screen, per item.
+ * @param metaTestTag tag for the meta text — per screen, per item.
+ * @param showDivider the drawn rule. `#s-list` drops it on the last row
+ *  (`.frame .row:last-of-type`), so the list does not end on a hairline into empty space.
+ * @param modifier the outer box — row **and** rule.
+ * @param rowModifier the inner box — lift, click, tag. Applied before the height floor and gutter.
+ * @param content the **trailing region**. Named `content` because it is this component's only
+ *  composable slot and `ComposableLambdaParameterNaming` requires that of a sole slot; the row's
+ *  name and meta are parameters, not slots. Wrap it in [AppListRowSlot] for the drawn 20px slot.
+ */
+@Composable
+fun AppListRow(
+    name: String,
+    meta: String,
+    nameTestTag: String,
+    metaTestTag: String,
+    showDivider: Boolean,
+    modifier: Modifier = Modifier,
+    rowModifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(rowModifier)
+                .heightIn(min = AppDimension.rowHeight)
+                .padding(horizontal = AppDimension.screenEdge),
+            horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
+            ) {
+                Text(
+                    modifier = Modifier.testTag(nameTestTag),
+                    text = name,
+                    style = AppUi.typography.titleMedium,
+                    color = AppUi.colors.textPrimary,
+                    maxLines = NAME_MAX_LINES,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    modifier = Modifier.testTag(metaTestTag),
+                    text = meta,
+                    style = AppUi.typography.mono.meta,
+                    color = AppUi.colors.textTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            content()
+        }
+        if (showDivider) {
+            HorizontalDivider(
+                thickness = AppDimension.borderHairline,
+                color = AppUi.colors.borderSubtle,
+            )
+        }
+    }
+}
+
+/**
+ * The drawn 20px trailing slot, centred and **fixed width**.
+ *
+ * §26 "Selection mode", as amended: an unselected row in selection mode loses the chevron, not the
+ * slot. As first drawn the slot followed its contents and the text column moved with it — measured
+ * 338 / 336 / 370px for chevron, check and nothing — which reflowed every row on entering the mode
+ * and one row on every toggle, against a two-line clamped name. Holding the width is the fix, so
+ * a caller that puts its content straight into [AppListRow]'s trailing region without this box is
+ * opting out of it.
+ */
+@Composable
+fun AppListRowSlot(content: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier.width(AppDimension.iconSm),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+/** Two lines, then ellipsis — the drawn `.row .name` clamp. */
+private const val NAME_MAX_LINES = 2

--- a/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/list/AppListRow.kt
+++ b/core/ui/kit/src/main/kotlin/io/github/stslex/workeeper/core/ui/kit/components/list/AppListRow.kt
@@ -142,12 +142,10 @@ fun AppListRow(
 /**
  * The drawn 20px trailing slot, centred and **fixed width**.
  *
- * §26 "Selection mode", as amended: an unselected row in selection mode loses the chevron, not the
- * slot. As first drawn the slot followed its contents and the text column moved with it — measured
- * 338 / 336 / 370px for chevron, check and nothing — which reflowed every row on entering the mode
- * and one row on every toggle, against a two-line clamped name. Holding the width is the fix, so
- * a caller that puts its content straight into [AppListRow]'s trailing region without this box is
- * opting out of it.
+ * §26 "Selection mode", as amended: an unselected row in selection mode loses the chevron, **not
+ * the slot**. The width is held whatever is in it, so the text column beside it never reflows on a
+ * selection toggle — a caller that puts content straight into [AppListRow]'s trailing region
+ * instead of this box is opting out of that guarantee.
  */
 @Composable
 fun AppListRowSlot(content: @Composable () -> Unit) {

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
@@ -39,11 +39,8 @@ import kotlinx.collections.immutable.persistentListOf
  * `#s-list`'s hint states it outright: "Скелет строки один — 88px, линейка снизу, имя и мета-строка,
  * шеврон. Начинки разные". The skeleton is now [AppListRow] and is documented there.
  *
- * **This paragraph used to say the opposite** — that extraction waited for a third consumer to say
- * what the shape was — and the wait was the right call: with two payloads the choice between a
- * pre-joined string and a union of nullable fields was a guess. With four it was measured. The
- * answer turned out to be the pre-joined string, and no union at all: every difference between the
- * four is a modifier or the trailing region's content.
+ * What this row keeps is its own: the payload, the meta line's composition and the trailing slot's
+ * three states.
  *
  * ## What this payload does differently, and it is one thing
  *

--- a/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
+++ b/feature/all-exercises/src/main/kotlin/io/github/stslex/workeeper/feature/all_exercises/ui/components/ExerciseRow.kt
@@ -6,18 +6,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -26,8 +17,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRow
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRowSlot
 import io.github.stslex.workeeper.core.ui.kit.components.surface.liftedSurface
 import io.github.stslex.workeeper.core.ui.kit.icons.AppIcons
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
@@ -45,13 +37,13 @@ import kotlinx.collections.immutable.persistentListOf
  * ## One skeleton, four payloads — this is the second of them
  *
  * `#s-list`'s hint states it outright: "Скелет строки один — 88px, линейка снизу, имя и мета-строка,
- * шеврон. Начинки разные". The skeleton — the 88dp ruled full-bleed row, the two-line clamp, the
- * single non-wrapping meta line and the fixed trailing slot — is `TrainingRow`'s, extracted there
- * and documented there. **It is deliberately not shared code yet**: the two payloads do not line up
- * on a single field (this one carries a type and two counts, that one an `isActive` flag and one), so a
- * shared component would take either a pre-joined string or a union of nullable fields. The
- * all-exercises delta mapping records the field-by-field comparison; extraction waits for a third
- * consumer to say what the shape actually is.
+ * шеврон. Начинки разные". The skeleton is now [AppListRow] and is documented there.
+ *
+ * **This paragraph used to say the opposite** — that extraction waited for a third consumer to say
+ * what the shape was — and the wait was the right call: with two payloads the choice between a
+ * pre-joined string and a union of nullable fields was a guess. With four it was measured. The
+ * answer turned out to be the pre-joined string, and no union at all: every difference between the
+ * four is a modifier or the trailing region's content.
  *
  * ## What this payload does differently, and it is one thing
  *
@@ -86,56 +78,29 @@ internal fun ExerciseRow(
     onLongPress: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                // Called unconditionally and driven by the flag, per its own KDoc: branching at the
-                // call site would rebuild the modifier graph on the flip and kill the tween. The
-                // drawn resting row has no fill of its own — it sits on `--base` — so the resting
-                // colour is transparent rather than the default `surfaceTier1`.
-                .liftedSurface(
-                    shape = RectangleShape,
-                    lifted = isSelected,
-                    restingColor = Color.Transparent,
-                )
-                .combinedClickable(onClick = onClick, onLongClick = onLongPress)
-                .heightIn(min = AppDimension.rowHeight)
-                .padding(horizontal = AppDimension.screenEdge)
-                .testTag("AllExercisesItem_${item.uuid}"),
-            horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
-            ) {
-                Text(
-                    modifier = Modifier.testTag("AllExercisesItemName_${item.uuid}"),
-                    text = item.name,
-                    style = AppUi.typography.titleMedium,
-                    color = AppUi.colors.textPrimary,
-                    maxLines = NAME_MAX_LINES,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    modifier = Modifier.testTag("AllExercisesItemMeta_${item.uuid}"),
-                    text = item.metaLine(),
-                    style = AppUi.typography.mono.meta,
-                    color = AppUi.colors.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            TrailingSlot(item = item, isSelected = isSelected, isSelecting = isSelecting)
-        }
-        if (showDivider) {
-            HorizontalDivider(
-                thickness = AppDimension.borderHairline,
-                color = AppUi.colors.borderSubtle,
+    AppListRow(
+        modifier = modifier,
+        // Called unconditionally and driven by the flag, per its own KDoc: branching at the call
+        // site would rebuild the modifier graph on the flip and kill the tween. The drawn resting
+        // row has no fill of its own — it sits on `--base` — so the resting colour is transparent
+        // rather than the default `surfaceTier1`.
+        rowModifier = Modifier
+            .liftedSurface(
+                shape = RectangleShape,
+                lifted = isSelected,
+                restingColor = Color.Transparent,
             )
-        }
-    }
+            .combinedClickable(onClick = onClick, onLongClick = onLongPress)
+            .testTag("AllExercisesItem_${item.uuid}"),
+        name = item.name,
+        nameTestTag = "AllExercisesItemName_${item.uuid}",
+        meta = item.metaLine(),
+        metaTestTag = "AllExercisesItemMeta_${item.uuid}",
+        showDivider = showDivider,
+        content = {
+            TrailingSlot(item = item, isSelected = isSelected, isSelecting = isSelecting)
+        },
+    )
 }
 
 /**
@@ -170,10 +135,7 @@ private fun TrailingSlot(
     isSelecting: Boolean,
 ) {
     val spec = continuityAlphaSpec<Float>()
-    Box(
-        modifier = Modifier.width(SLOT),
-        contentAlignment = Alignment.Center,
-    ) {
+    AppListRowSlot {
         AnimatedContent(
             targetState = trailingSlotKind(isSelected = isSelected, isSelecting = isSelecting),
             transitionSpec = { fadeIn(spec) togetherWith fadeOut(spec) using null },
@@ -224,9 +186,7 @@ private fun ExerciseUiModel.metaLine(): String {
     return (listOf(head, footerLabel).filter { it.isNotEmpty() } + tags).joinToString(separator)
 }
 
-private const val NAME_MAX_LINES = 2
-
-/** The drawn 20px slot, on the icon ladder. Holds the check; the chevron centres in it. */
+/** The drawn 20px glyph, on the icon ladder — the slot's own width is `AppListRowSlot`'s. */
 private val SLOT = AppDimension.iconSm
 
 @Preview(name = "Light", showBackground = true)

--- a/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/ui/components/TrainingRow.kt
+++ b/feature/all-trainings/src/main/kotlin/io/github/stslex/workeeper/feature/all_trainings/ui/components/TrainingRow.kt
@@ -6,18 +6,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -26,8 +17,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRow
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRowSlot
 import io.github.stslex.workeeper.core.ui.kit.components.surface.liftedSurface
 import io.github.stslex.workeeper.core.ui.kit.icons.AppIcons
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
@@ -41,25 +33,9 @@ import kotlinx.collections.immutable.persistentListOf
 /**
  * One row of the trainings list — `pass2d.html` `#s-list` `.row`.
  *
- * ## One skeleton, four payloads
- *
- * §26 "List row": an 88dp ruled row, name clamped to two lines with ellipsis, a single meta line,
- * and a chevron. `min-height` holds every row to one size — neither a long name nor extra tags
- * moves it, which is what lets four different payloads share one skeleton.
- *
- * The row is **full-bleed and ruled**, not an inset card: the drawn `.row` carries
- * `padding:0 var(--gutter)` with no vertical padding and a `border-bottom`, and the list around it
- * has no horizontal padding of its own. The 20px gutter rounds to [AppDimension.screenEdge] on
- * §0.2's own worked example (mockup 20 → 16dp).
- *
- * ## The trailing slot is fixed width, and that is an amendment
- *
- * §26 "Selection mode": unselected rows lose the chevron, **not the slot**. As first drawn the slot
- * followed its contents and the text column moved with it — measured 338 / 336 / 370px for chevron,
- * check and nothing, which reflowed every row on entering selection mode and one row on every
- * toggle, against a two-line clamped name. The slot now holds [SLOT] whatever is in it. The drawn
- * 20px rounds to [AppDimension.iconSm]; the check keeps its heavier 2.2 stroke
- * ([AppIcons.RowCheck]), so the drawn weight difference survives the rounding.
+ * The skeleton is [AppListRow] — 88dp, ruled, two-line name over one meta line, trailing region —
+ * and its derivations live there: the gutter, the fixed-width slot's measured reflow, and the
+ * `--hair-s` rule. What follows is this payload's own.
  *
  * ## No leading media, and no chips
  *
@@ -68,11 +44,6 @@ import kotlinx.collections.immutable.persistentListOf
  * in an 88dp row, and the full set lives in the filter band above the list, so the row **confirms**
  * tags rather than enumerating them. Both shipped here before the extraction; both are gone.
  *
- * ## The divider
- *
- * `--hair-s` has no app token by design, and the slot that would take it (`borderSubtle`) is
- * `--hair`, a different value — recorded as D3 and owed its own palette PR. The row rules with
- * `borderSubtle` until then: a known approximation, not a transcription error.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -91,55 +62,28 @@ internal fun TrainingRow(
     // that is both is still legible as running. The accent ring this row used to keep under
     // selection was solving a problem the meta line already solves.
     val lifted = isSelected || item.isActive
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                // Called unconditionally and driven by the flag, per its own KDoc: branching at
-                // the call site would rebuild the modifier graph on the flip and kill the tween.
-                // The drawn resting row has no fill of its own — it sits on `--base` — so the
-                // resting colour is transparent rather than the default `surfaceTier1`.
-                .liftedSurface(
-                    shape = RectangleShape,
-                    lifted = lifted,
-                    restingColor = Color.Transparent,
-                )
-                .combinedClickable(onClick = onClick, onLongClick = onLongPress)
-                .heightIn(min = AppDimension.rowHeight)
-                .padding(horizontal = AppDimension.screenEdge),
-            horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
-            ) {
-                Text(
-                    modifier = Modifier.testTag("AllTrainingsItemName_${item.uuid}"),
-                    text = item.name,
-                    style = AppUi.typography.titleMedium,
-                    color = AppUi.colors.textPrimary,
-                    maxLines = NAME_MAX_LINES,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    modifier = Modifier.testTag("AllTrainingsItemMeta_${item.uuid}"),
-                    text = item.metaLine(),
-                    style = AppUi.typography.mono.meta,
-                    color = AppUi.colors.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            TrailingSlot(item = item, isSelected = isSelected, isSelecting = isSelecting)
-        }
-        if (showDivider) {
-            HorizontalDivider(
-                thickness = AppDimension.borderHairline,
-                color = AppUi.colors.borderSubtle,
+    AppListRow(
+        modifier = modifier,
+        // Called unconditionally and driven by the flag, per its own KDoc: branching at the call
+        // site would rebuild the modifier graph on the flip and kill the tween. The drawn resting
+        // row has no fill of its own — it sits on `--base` — so the resting colour is transparent
+        // rather than the default `surfaceTier1`.
+        rowModifier = Modifier
+            .liftedSurface(
+                shape = RectangleShape,
+                lifted = lifted,
+                restingColor = Color.Transparent,
             )
-        }
-    }
+            .combinedClickable(onClick = onClick, onLongClick = onLongPress),
+        name = item.name,
+        nameTestTag = "AllTrainingsItemName_${item.uuid}",
+        meta = item.metaLine(),
+        metaTestTag = "AllTrainingsItemMeta_${item.uuid}",
+        showDivider = showDivider,
+        content = {
+            TrailingSlot(item = item, isSelected = isSelected, isSelecting = isSelecting)
+        },
+    )
 }
 
 /**
@@ -173,10 +117,7 @@ private fun TrailingSlot(
     isSelecting: Boolean,
 ) {
     val spec = continuityAlphaSpec<Float>()
-    Box(
-        modifier = Modifier.width(SLOT),
-        contentAlignment = Alignment.Center,
-    ) {
+    AppListRowSlot {
         AnimatedContent(
             targetState = trailingSlotKind(isSelected = isSelected, isSelecting = isSelecting),
             transitionSpec = { fadeIn(spec) togetherWith fadeOut(spec) using null },
@@ -225,9 +166,7 @@ private fun TrainingListItemUi.metaLine(): String {
 /** The interpunct the drawing joins meta tokens with. */
 private const val META_SEPARATOR = " · "
 
-private const val NAME_MAX_LINES = 2
-
-/** The drawn 20px slot, on the icon ladder. Holds the check; the chevron centres in it. */
+/** The drawn 20px glyph, on the icon ladder — the slot's own width is `AppListRowSlot`'s. */
 private val SLOT = AppDimension.iconSm
 
 @Preview(name = "Light", showBackground = true)

--- a/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
+++ b/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
@@ -47,22 +47,21 @@ import io.github.stslex.workeeper.feature.archive.domain.model.ExerciseTypeDomai
  * ```
  *
  *
- * ## What this row does NOT resolve
+ * ## This row does not yet conform, and that is now scheduled rather than open
  *
- * **The trailing slot is deliberately untouched, and it is the screen's open question.** `#s-list`
- * gives a row one 20px slot holding a chevron, a check, or nothing; this row carries *two* live
- * verbs — a `Restore` button and an overflow whose single item is permanent delete — and both were
- * verified reachable before the question was framed, so it does not collapse to one (unlike B23's
- * dialog on the sibling, which had no producer at all). The drawn archive row carries a **chevron**,
- * i.e. it navigates, and says nothing about either verb.
+ * §2.1 asked whether the drawn one-slot skeleton or this screen's two live verbs win. **It is RULED
+ * (Ilya, §24.2 group A):** an archived item **opens** — read-only detail — so the drawn chevron is
+ * true, this row takes the drawn 20dp slot like its three siblings, and restore and
+ * permanent-delete come off it. Where they go is the one part still open, and it belongs to the
+ * drawing.
  *
- * That is a §0.1 decision for the owner, not a delta to apply, so the two affordances are left
- * exactly as they were. Everything around them is rebuilt. See `archive-delta.md` §2.1 for the three
- * readings and the argument against each.
- *
- * One consequence worth stating rather than discovering: while the affordances stay, this row is
- * **taller than 88dp in practice** and its trailing region is not the drawn slot. The `heightIn`
- * minimum is the drawn one; the row is not yet the drawn row, and it cannot be until §2.1 is ruled.
+ * **What ships here is the pre-ruling row, deliberately.** Applying the ruling moves pixels — a
+ * chevron appears, two affordances leave, and the row drops to the drawn 88dp, which it currently
+ * exceeds because its trailing region is not the slot. The extraction this file is part of asserts
+ * the opposite (every golden byte-identical), so conformance cannot land in the same change without
+ * destroying the only claim that change makes. **It lands in the archive rebuild, after group A is
+ * drawn**, and until then this row is the one consumer of [AppListRow] that does not use
+ * `AppListRowSlot` — by schedule, not by exception.
  */
 @Composable
 internal fun ArchivedItemRow(

--- a/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
+++ b/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
@@ -79,11 +79,12 @@ internal fun ArchivedItemRow(
         meta = metaLine,
         metaTestTag = "ArchivedItemMeta_${item.uuid}",
         showDivider = showDivider,
-        // UNRESOLVED — archive-delta §2.1. Two verbs against a one-slot skeleton; left as-is on
-        // purpose rather than picked, which is also why this is NOT wrapped in `AppListRowSlot`:
-        // the drawn 20dp slot cannot hold them, and the shared row deliberately does not impose
-        // it. Do not "tidy" either without that ruling — collapsing it silently answers a §0.1
-        // question in a refactor.
+        // SCHEDULED, not open — §2.1 is ruled (§24.2 group A): the row will take the drawn 20dp
+        // slot with a chevron and these two verbs leave it. Not applied here because this change
+        // asserts every golden stays byte-identical and applying it moves pixels; it lands with
+        // the archive rebuild. Until then this stays un-slotted BY SCHEDULE — so do not wrap it in
+        // `AppListRowSlot` piecemeal either: the slot arrives with the click and the destination
+        // or not at all.
         content = {
             TrailingAffordances(
                 item = item,

--- a/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
+++ b/feature/archive/src/main/kotlin/io/github/stslex/workeeper/feature/archive/ui/components/ArchivedItemRow.kt
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package io.github.stslex.workeeper.feature.archive.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -26,10 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButton
 import io.github.stslex.workeeper.core.ui.kit.components.button.AppButtonSize
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRow
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
 import io.github.stslex.workeeper.core.ui.kit.theme.AppUi
@@ -78,52 +73,26 @@ internal fun ArchivedItemRow(
     onPermanentDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = AppDimension.rowHeight)
-                .padding(horizontal = AppDimension.screenEdge),
-            horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
-            ) {
-                Text(
-                    modifier = Modifier.testTag("ArchivedItemName_${item.uuid}"),
-                    text = item.name,
-                    style = AppUi.typography.titleMedium,
-                    color = AppUi.colors.textPrimary,
-                    maxLines = NAME_MAX_LINES,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    modifier = Modifier.testTag("ArchivedItemMeta_${item.uuid}"),
-                    text = metaLine,
-                    style = AppUi.typography.mono.meta,
-                    color = AppUi.colors.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            // UNRESOLVED — archive-delta §2.1. Two verbs against a one-slot skeleton; left as-is
-            // on purpose rather than picked. Do not "tidy" this into the drawn 20dp slot without
-            // that ruling: collapsing it silently answers a §0.1 question in a refactor.
+    AppListRow(
+        modifier = modifier,
+        name = item.name,
+        nameTestTag = "ArchivedItemName_${item.uuid}",
+        meta = metaLine,
+        metaTestTag = "ArchivedItemMeta_${item.uuid}",
+        showDivider = showDivider,
+        // UNRESOLVED — archive-delta §2.1. Two verbs against a one-slot skeleton; left as-is on
+        // purpose rather than picked, which is also why this is NOT wrapped in `AppListRowSlot`:
+        // the drawn 20dp slot cannot hold them, and the shared row deliberately does not impose
+        // it. Do not "tidy" either without that ruling — collapsing it silently answers a §0.1
+        // question in a refactor.
+        content = {
             TrailingAffordances(
                 item = item,
                 onRestore = onRestore,
                 onPermanentDelete = onPermanentDelete,
             )
-        }
-        if (showDivider) {
-            HorizontalDivider(
-                thickness = AppDimension.borderHairline,
-                color = AppUi.colors.borderSubtle,
-            )
-        }
-    }
+        },
+    )
 }
 
 /** The two contested verbs, unchanged. See [ArchivedItemRow]'s KDoc and `archive-delta.md` §2.1. */
@@ -177,8 +146,6 @@ private fun TrailingAffordances(
         }
     }
 }
-
-private const val NAME_MAX_LINES = 2
 
 @Preview(name = "Light", showBackground = true)
 @Preview(

--- a/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/RecentSessionRow.kt
+++ b/feature/home/src/main/kotlin/io/github/stslex/workeeper/feature/home/ui/components/RecentSessionRow.kt
@@ -2,24 +2,15 @@
 package io.github.stslex.workeeper.feature.home.ui.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRow
+import io.github.stslex.workeeper.core.ui.kit.components.list.AppListRowSlot
 import io.github.stslex.workeeper.core.ui.kit.icons.AppIcons
 import io.github.stslex.workeeper.core.ui.kit.theme.AppDimension
 import io.github.stslex.workeeper.core.ui.kit.theme.AppTheme
@@ -39,11 +30,9 @@ import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
  *
  * ## What it is
  *
- * The drawn skeleton, identical to `TrainingRow` and `ExerciseRow` in structure: an 88dp ruled
- * full-bleed row, name clamped to two lines with ellipsis, a single-line meta, a fixed-width
- * trailing slot with a chevron. `min-height` holds every row to one size, which is what lets four
- * payloads share one skeleton — measured on this module's own goldens at **88.0 / 88.0 / 88.0 /
- * 88.0 dp**, the fourth of which is the two-line clamp.
+ * The drawn skeleton — [AppListRow], where the 88dp floor, the clamp, the gutter and the rule are
+ * documented. Measured on this module's own goldens at **88.0 / 88.0 / 88.0 / 88.0 dp**, the fourth
+ * of which is the two-line clamp.
  *
  * ## The meta line's order, which is a decision and not a transcription
  *
@@ -68,12 +57,6 @@ import io.github.stslex.workeeper.feature.home.mvi.model.RecentSessionItem
  * `TrainingRow`'s `lifted` flag is likewise absent: nothing on this list is running, by
  * construction — the query filters `state = 'FINISHED'`, and a running session is Home's banner.
  *
- * ## The divider
- *
- * `--hair-s` has no app token by design and the slot that would take it (`borderSubtle`) is
- * `--hair`, a different value — D3, owed its own palette PR. The row rules with `borderSubtle`
- * until then: a known approximation, not a transcription error, and the same one both siblings
- * ship.
  */
 @Composable
 internal fun RecentSessionRow(
@@ -82,42 +65,20 @@ internal fun RecentSessionRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onClick)
-                .heightIn(min = AppDimension.rowHeight)
-                .padding(horizontal = AppDimension.screenEdge)
-                .testTag("HomeRecentRow_${item.sessionUuid}"),
-            horizontalArrangement = Arrangement.spacedBy(AppDimension.Space.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(AppDimension.Space.xs),
-            ) {
-                Text(
-                    modifier = Modifier.testTag("HomeRecentName_${item.sessionUuid}"),
-                    text = item.trainingName,
-                    style = AppUi.typography.titleMedium,
-                    color = AppUi.colors.textPrimary,
-                    maxLines = NAME_MAX_LINES,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    modifier = Modifier.testTag("HomeRecentMeta_${item.sessionUuid}"),
-                    text = item.metaLine(),
-                    style = AppUi.typography.mono.meta,
-                    color = AppUi.colors.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            Box(
-                modifier = Modifier.width(SLOT),
-                contentAlignment = Alignment.Center,
-            ) {
+    AppListRow(
+        modifier = modifier,
+        rowModifier = Modifier
+            .clickable(onClick = onClick)
+            .testTag("HomeRecentRow_${item.sessionUuid}"),
+        name = item.trainingName,
+        nameTestTag = "HomeRecentName_${item.sessionUuid}",
+        meta = item.metaLine(),
+        metaTestTag = "HomeRecentMeta_${item.sessionUuid}",
+        showDivider = showDivider,
+        // Always a chevron: Home has no selection mode, so the crossfading slot and its selector
+        // are absent here rather than copied with two unreachable branches.
+        content = {
+            AppListRowSlot {
                 Icon(
                     modifier = Modifier.size(SLOT),
                     imageVector = AppIcons.ChevronRight,
@@ -125,14 +86,8 @@ internal fun RecentSessionRow(
                     tint = AppUi.colors.textTertiary,
                 )
             }
-        }
-        if (showDivider) {
-            HorizontalDivider(
-                thickness = AppDimension.borderHairline,
-                color = AppUi.colors.borderSubtle,
-            )
-        }
-    }
+        },
+    )
 }
 
 /**
@@ -151,9 +106,7 @@ internal fun RecentSessionItem.metaLine(): String =
 /** The interpunct the drawing joins meta tokens with. */
 private const val META_SEPARATOR = " · "
 
-private const val NAME_MAX_LINES = 2
-
-/** The drawn 20px slot, on the icon ladder. Holds the chevron, centred. */
+/** The drawn 20px glyph, on the icon ladder — the slot's own width is `AppListRowSlot`'s. */
 private val SLOT = AppDimension.iconSm
 
 @Preview(name = "Light", showBackground = true)


### PR DESCRIPTION
**Stacked on #203** (`fix/paging-flash-and-name`), which is under review, and **#207 stands on this
one** (`docs/mockup-pass-groups`, docs only). This PR's base is #203's branch, not `dev` — so its diff, and the mockup gate's merge-base, are both taken against it. **If
review moves #203, this rebases and every gate here re-runs against the new base before any green on
it counts**; a squash there rewrites the SHA, so this arrives conflicting until it does. #203 must
not be deleted while this points at it.

The whole assertion is one line: **352 goldens stay byte-identical.** A pixel that moves is a delta
the extraction introduced, not a tolerance.

---

## What was measured before anything was written

The earlier mapping compared `TrainingRow` against `ExerciseRow` and found four substantive lines.
That was two instances. Here are four, field by field:

| axis | all-trainings | all-exercises | home | archive |
|---|---|---|---|---|
| lift | `isSelected \|\| isActive` | `isSelected` | none | none |
| click | `combinedClickable` | `combinedClickable` | `clickable` | **none** |
| row testTag | none | item tag | row tag | none |
| meta composed | in a `@Composable` | in a `@Composable` | pure extension | **in the mapper** |
| trailing | slot, 3 states, crossfading | slot, 3 states, crossfading | slot, chevron only | 2 verbs (§2.1) |
| height in practice | 88dp | 88dp | 88dp | **taller** |

**Identical in all four, byte for byte:** the `Column`/`Row` nesting, `heightIn(rowHeight)`, the
`screenEdge` gutter, the `Space.md` gap, the text column's `weight(1f)` and `Space.xs`, both text
styles and both colours, both clamps, and the divider. Roughly 45 lines per instance.

## The finding the signature rests on

**Every one of those differences is a modifier or the content of the trailing region.** So the
component carries **no behaviour flag at all** — no `lifted`, no `isSelecting`, no `onClick`, no
nullable callbacks:

```kotlin
AppListRow(
    name: String, meta: String,
    nameTestTag: String, metaTestTag: String,
    showDivider: Boolean,
    modifier: Modifier = Modifier,        // outer box: row AND rule — what a caller animates
    rowModifier: Modifier = Modifier,     // inner box: lift, click, tag
    content: @Composable () -> Unit,      // the trailing region
)
```

The test this extraction was conditioned on — *more than a couple of optional parameters is evidence
against it* — is passed with **zero**. Had the four differed on payload fields instead, the same
measurement would have produced a union of nullables and the answer would have been "don't".

**Two modifier seams, because the drawn row has two boxes.** `liftedSurface` on the outer box paints
behind the divider; `combinedClickable` there makes the hairline part of the touch target.
`rowModifier` lands exactly where every caller's chain already sat — before `heightIn` and the
gutter — so the painted region and the touch region are unchanged.

## Where it lives, and what stays behind

`core/ui/kit/components/list/`. After the extraction the row is a widget: `name` and `meta` are
`String`s, no domain type, no feature resource, no logic.

**The meta line stays per screen and the row takes it formatted.** Its four producers compose it in
three different places — two inside a composable (`pluralStringResource`; a per-type
`stringResource`), one as a pure extension on the ui model (home), one in the **mapper** (archive,
the only form assertable without a composition) — and they differ in token *order* by decision
(§26 fixes "information first, tags last" and leaves each screen its tokens). Pulling any of it into
the kit would put display strings and per-feature resources there, which is the boundary
`CLAUDE.md` draws for the mapper layer. `RecentMetaLineTest` and its siblings do not move.

**Archive is why the row does not own the slot width.** Three of four wrap the drawn 20px slot
(`AppListRowSlot`); archive holds a restore button and an overflow, which is `archive-delta.md`
§2.1 — unresolved, and a §0.1 decision for the owner. A component that imposed the slot would have
answered that question inside a refactor. The row owns the gap and the alignment; the caller owns
what sits in the region.

## Gates

Re-run at `1f667b75` **after rebasing onto #203's round-2 fixes** — a green measured against the
old base would not be evidence. `--rerun-tasks --no-build-cache`, no `from cache` or `up-to-date` in
the summary.

| gate | result |
|---|---|
| `assembleDebug detekt lintDebug testDebugUnitTest verifyPaparazziDebug` | **BUILD SUCCESSFUL**, `1847 actionable tasks: 1847 executed` |
| unit suites | **2037 tests, 0 failures, 0 skipped** |
| goldens | **352 byte-identical**, ten suites, **zero PNGs in the diff** |
| `shell_gate.py --base $(git merge-base origin/fix/paging-flash-and-name HEAD)` | **11 passed, 0 failed** — base is the branch below, not `dev` |
| `personal_data_gate.py` | **PASS** |

**Mutation, with the consumer named** (§27's red-mutation twin, filed in #203): the value here is
the skeleton, and what reads it in production is the four screens — so the mutations run against
*their* goldens, not the kit's.

| mutation | verdict |
|---|---|
| gutter `screenEdge` → `Space.sm` | **RED** in all four modules |
| `heightIn` `rowHeight` → `heightLg` | **RED** (trainings, home) |
| `NAME_MAX_LINES` 2 → 1 | **RED** (exercises, archive) |

## Two notes on what this touched

- **`content`, not `trailing`.** A sole composable lambda must be named that
  (`ComposableLambdaParameterNaming` is an error, not a warning). The KDoc says why the name reads
  oddly for a trailing region.
- **A stale claim removed rather than narrated.** `ExerciseRow`'s KDoc said extraction was
  "deliberately not shared code yet" and waited on a third consumer to say what the shape was. That
  sentence is now false, and review was right that the *correction* does not belong in the file
  either — the KDoc keeps the present contract, and what the wait bought (with two payloads the
  choice between a pre-joined string and a union of nullable fields was a guess; with four it was
  measured, and the answer was the string with no union) is in the commit body.

## Not in this PR

- **No kit golden for `AppListRow`.** Its four consumers already photograph the skeleton 142 times,
  and the mutations above show those pictures are what gates it. A fifth photograph of the same
  drawing would add goldens without adding a detector.
- **Archive's conformance — and it is now scheduled, not open.** §2.1 has since been **ruled**
  (§24.2 group A, Ilya): an archived item **opens**, read-only, so the drawn chevron is true, the
  row takes the drawn 20dp slot like its three siblings, and restore + permanent-delete come off it.
  **That does not land here**, and the reason is this PR's own assertion: applying it moves pixels —
  a chevron appears, two affordances leave, and the row drops to the drawn 88dp it currently exceeds
  — while the only claim this change makes is that every golden stays byte-identical. It lands in
  **the archive rebuild, after group A is drawn.** `ArchivedItemRow`'s KDoc says so at the point of
  use (`70164c25`), so the exception is not discovered later by whoever reads the file: until then
  archive is the one `AppListRow` consumer not using `AppListRowSlot`, by schedule rather than by
  exception. Retrospectively this is why the row deliberately does not own the slot width — the
  fourth consumer is about to need it.
- The follow-ups filed off #203's audit — #204 (detekt source scope), #205 (golden-gate auto-apply).
