### PR TITLE
v3 group B: surveyed read-only — one of the two banner forms has no referent (stacked on #208)

### DIFF
--- a/documentation/feature-specs/v3-redesign-spec.md
+++ b/documentation/feature-specs/v3-redesign-spec.md
@@ -696,7 +696,7 @@ Taken the way A's was, and it corrects one sentence of this section's own first 
 
 | part | drawn referent | ships | the decision |
 |---|---|---|---|
-| **active-session banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04». A **row**, carrying exactly what the banner carries: name plus running time | `ActiveSessionBanner` = `AppCard`, inset, `Space.md` padding | row or card. **A row form is fully referenced and a card form is not** — `.card` exists but is drawn only for a *session's exercises* (`#s-live`, `#s-past`), never for a standing summary |
+| **active-session banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04». A referent for the **treatment**, not for the whole payload — see the content row below | `ActiveSessionBanner` = `AppCard`, inset, `Space.md` padding, **three elements beyond the name** | row or card. **The row's treatment is referenced and the card's is not** — `.card` exists but is drawn only for a *session's exercises* (`#s-live`, `#s-past`), never for a standing summary |
 | **start card** | **none for a card.** The drawn CTA grammar is `#s-empty`'s `.btns` — `.btn` + `.btn.ghost` — which lives *inside an empty state*, not as a standing block | `HomeStartCard` = `AppCard` with title + subtitle, shown when `activeSession == null && !isLoading` | whether the offer is a **card**, a pair of **buttons** in the drawn grammar, or absent — and the answer is coupled to the banner's, since they occupy the same slot in alternation |
 | **empty copy** | `#s-empty`'s `.empty` + `.glyph` + optional `.btns`, drawn three times | `AppEmptyState`, glyph `AppIcons.Trainings`, headline + supporting, **`actionLabel = null, onAction = null`** | the copy, and whether this state carries a CTA at all |
 
@@ -705,6 +705,24 @@ plus an empty-state CTA is **the same offer twice**". **Not today:** Home passes
 and `onAction = null`, so the empty state draws copy only and the start card is the single offer. The
 duplication is a **hazard of the decision**, not a live defect — and it becomes live the moment the
 empty state is given a button, which is precisely one of the three things B rules.
+
+**CORRECTED after review — "carries exactly what the banner carries" was false, and the difference
+is the interesting part.** Measured against `ActiveSessionBanner`: the shipped banner renders a
+**leading `Icons.Filled.FitnessCenter`** at `iconLg`, the training name **and** an emphasised
+`•elapsed` timer at `titleLarge` on one line (width reserved off `MAX_TEXT_TIME`), and a **progress
+line** at `bodySmall` carrying done/total. `.row.live` carries a name, one meta line and a chevron.
+So the row is a referent for the *treatment* — `--slab` + `--slabtop`, the lift — and **not** for the
+payload, and the comparison's real question is whether the row can take that payload:
+
+- **the leading icon cannot survive the row form at all** — §26 "Leading media in list rows" is a
+  stated **absence**, so choosing the row means dropping the mark or overruling a recorded decision;
+- **the emphasised timer** has no row-grammar equivalent: the row's meta line is one line at
+  `mono.meta`, so `•12:04` at title size becomes a meta token;
+- **done/total** folds into that same meta line or goes.
+
+**A sub-finding worth its own line, since it is a shipped fact rather than a drawing question:** the
+banner's leading mark is a **filled Material import** (`Icons.Filled.FitnessCenter`), which is the
+class this arc has removed twice. Whatever grammar wins, that mark does not survive as it is.
 
 **What the survey adds that the grouping did not have.** The banner/card question is not a taste
 question between two available forms: **one of the two forms has a referent and the other does not.**

--- a/documentation/feature-specs/v3-redesign-spec.md
+++ b/documentation/feature-specs/v3-redesign-spec.md
@@ -696,7 +696,7 @@ Taken the way A's was, and it corrects one sentence of this section's own first 
 
 | part | drawn referent | ships | the decision |
 |---|---|---|---|
-| **active-session banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04». A referent for the **treatment**, not for the whole payload — see the content row below | `ActiveSessionBanner` = `AppCard`, inset, `Space.md` padding, **three elements beyond the name** | row or card. **The row's treatment is referenced and the card's is not** — `.card` exists but is drawn only for a *session's exercises* (`#s-live`, `#s-past`), never for a standing summary |
+| **active-session banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04». A referent for the **treatment**, not for the whole payload — see the content row below | `ActiveSessionBanner` = `AppCard`, inset, **24dp per edge** (`AppCard`'s own `cardPadding = Space.md` plus another `Space.md` on the nested `Row`), **three elements beyond the name** | row or card. **The row's treatment is referenced and the card's is not** — `.card` exists but is drawn only for a *session's exercises* (`#s-live`, `#s-past`), never for a standing summary |
 | **start card** | **none for a card.** The drawn CTA grammar is `#s-empty`'s `.btns` — `.btn` + `.btn.ghost` — which lives *inside an empty state*, not as a standing block | `HomeStartCard` = `AppCard` with title + subtitle, shown when `activeSession == null && !isLoading` | whether the offer is a **card**, a pair of **buttons** in the drawn grammar, or absent — and the answer is coupled to the banner's, since they occupy the same slot in alternation |
 | **empty copy** | `#s-empty`'s `.empty` + `.glyph` + optional `.btns`, drawn three times | `AppEmptyState`, glyph `AppIcons.Trainings`, headline + supporting, **`actionLabel = null, onAction = null`** | the copy, and whether this state carries a CTA at all |
 
@@ -720,9 +720,26 @@ payload, and the comparison's real question is whether the row can take that pay
   `mono.meta`, so `•12:04` at title size becomes a meta token;
 - **done/total** folds into that same meta line or goes.
 
-**A sub-finding worth its own line, since it is a shipped fact rather than a drawing question:** the
-banner's leading mark is a **filled Material import** (`Icons.Filled.FitnessCenter`), which is the
-class this arc has removed twice. Whatever grammar wins, that mark does not survive as it is.
+**Two shipped icons recorded as facts, with their treatment left to the ruling.** The banner's
+leading mark is `Icons.Filled.FitnessCenter` and `HomeStartCard`'s is `Icons.Filled.PlayArrow` —
+both **filled Material imports**, in a drawing whose every mark is a stroke at 1.6–2.7 with
+`fill:none`. **Nothing in the ledger bans a filled glyph on a card**, so declaring they cannot
+survive would be taking an appearance decision inside a survey that exists to stop for one; the
+earlier draft of this line did exactly that and is corrected here.
+
+**What the two rulings do to the banner's mark, which is a consequence of each and not a new
+decision:**
+
+- **as a ROW the mark is gone** — not by preference but by a recorded rule: §26 "Leading media in
+  list rows" is a stated absence, so the row form has nowhere to put it;
+- **as a CARD the mark stays, and what it should BE is open.** `#s-band` draws it as the stroke
+  training glyph the nav bar already carries, which is a **stand-in and is marked as one** —
+  a section mark doing duty as a state mark, since the nav glyph says *Trainings* and the banner
+  means *a session is running*, and no mark for that state is drawn anywhere. So the card form owes
+  either a mark it does not have, or the filled import it ships with, and that is the ruling's to
+  take.
+- **`HomeStartCard`'s `PlayArrow` rides on the same decision** and is recorded here so it is not
+  discovered separately later.
 
 **What the survey adds that the grouping did not have.** The banner/card question is not a taste
 question between two available forms: **one of the two forms has a referent and the other does not.**

--- a/documentation/feature-specs/v3-redesign-spec.md
+++ b/documentation/feature-specs/v3-redesign-spec.md
@@ -690,6 +690,35 @@ that are visible in a single screenful:
 Home is undrawn in full (`pass2d.html` has ten sections and none is Home), so B has no drawn
 referent to transcribe and every part of it is a §0.1 decision.
 
+##### SURVEYED, read-only — what each part has, ships, and decides
+
+Taken the way A's was, and it corrects one sentence of this section's own first draft.
+
+| part | drawn referent | ships | the decision |
+|---|---|---|---|
+| **active-session banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04». A **row**, carrying exactly what the banner carries: name plus running time | `ActiveSessionBanner` = `AppCard`, inset, `Space.md` padding | row or card. **A row form is fully referenced and a card form is not** — `.card` exists but is drawn only for a *session's exercises* (`#s-live`, `#s-past`), never for a standing summary |
+| **start card** | **none for a card.** The drawn CTA grammar is `#s-empty`'s `.btns` — `.btn` + `.btn.ghost` — which lives *inside an empty state*, not as a standing block | `HomeStartCard` = `AppCard` with title + subtitle, shown when `activeSession == null && !isLoading` | whether the offer is a **card**, a pair of **buttons** in the drawn grammar, or absent — and the answer is coupled to the banner's, since they occupy the same slot in alternation |
+| **empty copy** | `#s-empty`'s `.empty` + `.glyph` + optional `.btns`, drawn three times | `AppEmptyState`, glyph `AppIcons.Trainings`, headline + supporting, **`actionLabel = null, onAction = null`** | the copy, and whether this state carries a CTA at all |
+
+**CORRECTION to this section's own text, measured rather than remembered.** It said "a start card
+plus an empty-state CTA is **the same offer twice**". **Not today:** Home passes `actionLabel = null`
+and `onAction = null`, so the empty state draws copy only and the start card is the single offer. The
+duplication is a **hazard of the decision**, not a live defect — and it becomes live the moment the
+empty state is given a button, which is precisely one of the three things B rules.
+
+**What the survey adds that the grouping did not have.** The banner/card question is not a taste
+question between two available forms: **one of the two forms has a referent and the other does not.**
+Choosing the card means drawing a standing-summary card for the first time in this contract —
+new grammar, in §0.1's sense, exactly like Home's second trailing mark. Choosing the row means the
+band opens with the treatment the list below it already uses, and the "two grammars in eight
+vertical dp" problem disappears rather than being managed.
+
+**Half-answered by group A, and recorded so it is not re-opened:** the chart entry **stays in the
+bar**, so it is not competing for a slot in the band. B decides three blocks, not four.
+
+**Not drawn. Stops here for a ruling**, the way A did: the three parts are one grammar and drawing
+any of them takes the other two.
+
 #### Group C — STANDALONE (was items 6, 7, 8)
 
 Independent of A and B and of each other.


### PR DESCRIPTION
**Fifth in the stack: #203 → #206 → #207 → #208 → this.** Base is `docs/v3-group-a` (#208). Rebases and re-gates if anything below moves; nothing below may be `--delete-branch`ed while this points at it.

Group B surveyed the way A was — read-only, **nothing drawn** — and it stops here for a ruling.

| part | drawn referent | ships | the decision |
|---|---|---|---|
| **banner** | **`.row.live`** (`#s-list`) — `--slab` + `--slabtop`, meta «идёт сейчас · 12:04»; a **row**, carrying exactly what the banner carries | `AppCard`, inset | row or card |
| **start card** | **none for a card** — the drawn CTA grammar is `#s-empty`'s `.btns` (`.btn` + `.btn.ghost`), inside an empty state | `AppCard`, title + subtitle | card, drawn buttons, or absent |
| **empty copy** | `#s-empty`'s `.empty` + `.glyph` + optional `.btns` | `AppEmptyState`, **`actionLabel = null`** | the copy, and whether it carries a CTA at all |

**What the survey adds that the grouping did not have.** The banner question is not a choice between two available forms: **one has a referent and the other does not.** `.card` exists, but it is drawn only for a *session's exercises* (`#s-live`, `#s-past`) — never for a standing summary. Choosing the card means drawing a standing-summary card for the first time in this contract: **new grammar** in §0.1's sense, exactly like Home's second trailing mark. Choosing the row means the band opens with the treatment the list below it already uses.

**A correction to §24.2's own text, measured rather than remembered.** It said a start card plus an empty-state CTA is *the same offer twice*. **Not today** — Home passes `actionLabel = null, onAction = null`, so the empty state draws copy only and the start card is the single offer. The duplication is a **hazard of the decision**, not a live defect, and it becomes live the moment the empty state gets a button — which is one of the three things B rules.

**Half-answered by A:** the chart entry stays in the bar, so it is not competing for the band. B decides three blocks, not four.

Gates: shell gate green against the branch below, personal-data gate PASS, no code touched.